### PR TITLE
Support for Nova power type Keystone v3 Auth

### DIFF
--- a/src/provisioningserver/drivers/power/tests/test_nova.py
+++ b/src/provisioningserver/drivers/power/tests/test_nova.py
@@ -80,3 +80,63 @@ class TestNovaPowerDriver(MAASTestCase):
         self.expectThat(
             power_control_nova_mock, MockCalledOnceWith('query', **context))
         self.expectThat(expected_result, Equals('off'))
+
+    def make_parameters_v3(self):
+        system_id = factory.make_name('system_id')
+        machine = factory.make_name('nova_id')
+        tenant = factory.make_name('os_tenantname')
+        username = factory.make_name('os_username')
+        password = factory.make_name('os_password')
+        authurl = 'http://%s' % (factory.make_name('os_authurl'))
+        user_domain_name = factory.make_name('user_domain_name')
+        project_domain_name = factory.make_name('project_domain_name')
+        context = {
+            'system_id': system_id,
+            'nova_id': machine,
+            'os_tenantname': tenant,
+            'os_username': username,
+            'os_password': password,
+            'os_authurl': authurl,
+            'user_domain_name': user_domain_name,
+            'project_domain_name': project_domain_name,
+        }
+        return system_id, machine, tenant, username, password,
+               authurl, user_domain_name, project_domain_name, context
+
+    def test_power_on_calls_power_control_nova_v3(self):
+        system_id, machine, tenant, username, password, authurl,
+            user_domain_name, project_domain_name, context = (
+            self.make_parameters_v3())
+        nova_power_driver = NovaPowerDriver()
+        power_control_nova_mock = self.patch(
+            nova_power_driver, 'power_control_nova')
+        nova_power_driver.power_on(system_id, context)
+
+        self.assertThat(
+            power_control_nova_mock, MockCalledOnceWith('on', **context))
+
+    def test_power_off_calls_power_control_nova_v3(self):
+        system_id, machine, tenant, username, password, authurl,
+            user_domain_name, project_domain_name, context = (
+            self.make_parameters_v3())
+        nova_power_driver = NovaPowerDriver()
+        power_control_nova_mock = self.patch(
+            nova_power_driver, 'power_control_nova')
+        nova_power_driver.power_off(system_id, context)
+
+        self.assertThat(
+            power_control_nova_mock, MockCalledOnceWith('off', **context))
+
+    def test_power_query_calls_power_state_nova_v3(self):
+        system_id, machine, tenant, username, password, authurl,
+            user_domain_name, project_domain_name, context = (
+            self.make_parameters_v3())
+        nova_power_driver = NovaPowerDriver()
+        power_control_nova_mock = self.patch(
+            nova_power_driver, 'power_control_nova')
+        power_control_nova_mock.return_value = 'off'
+        expected_result = nova_power_driver.power_query(system_id, context)
+
+        self.expectThat(
+            power_control_nova_mock, MockCalledOnceWith('query', **context))
+        self.expectThat(expected_result, Equals('off'))


### PR DESCRIPTION
Since OpenStack Queens Keystone supports ONLY v3 auth
hence parameters below are required to work with that version
but old one are left as an option for backward compatibility
with prev OpenStack versions.

[0] https://docs.openstack.org/python-novaclient/latest/reference/api/index.html