### PR TITLE
Add openssh-client dependency

### DIFF
--- a/required-packages/base
+++ b/required-packages/base
@@ -13,6 +13,7 @@ libjs-jquery
 libpq-dev
 lshw
 nginx-core
+openssh-client
 postgresql
 pxelinux
 python3-all


### PR DESCRIPTION
While working in a minimal development container I ran into an issue where missing ssh-keygen broke SSH key import