### PR TITLE
modified extract_oauth_key_from_auth_header() function to parse Auth …

### DIFF
--- a/src/maasserver/api/utils.py
+++ b/src/maasserver/api/utils.py
@@ -193,12 +193,23 @@ def extract_oauth_key_from_auth_header(auth_data):
 
     :return: The oauth key from the header, or None.
     """
-    for entry in auth_data.split():
-        key_value = entry.split('=', 1)
-        if len(key_value) == 2:
-            key, value = key_value
-            if key == 'oauth_token':
-                return value.rstrip(',').strip('"')
+
+    ## values separted by comma only ##
+
+    if len(auth_data.split()) == 2:
+        for entry in auth_data.split()[1].split(","):
+            key_value = entry.split('=', 1)
+            if len(key_value) == 2:
+                key, value = key_value
+                if key == 'oauth_token':
+                    return value.strip('"')
+    else:
+        for entry in auth_data.split():
+            key_value = entry.split('=', 1)
+            if len(key_value) == 2:
+                key, value = key_value
+                if key == 'oauth_token':
+                    return value.rstrip(',').strip('"')
     return None
 
 


### PR DESCRIPTION
…headers where Oauth parameters are not separted by trailing whitespace