### PR TITLE
There's issue on VMWare VMs during disk erasing of a release phase.

### DIFF
--- a/src/metadataserver/user_data/templates/snippets/maas_wipe.py
+++ b/src/metadataserver/user_data/templates/snippets/maas_wipe.py
@@ -22,7 +22,7 @@ def list_disks():
     """Return list of disks to wipe."""
     disks = []
     output = subprocess.check_output(
-        ['lsblk', '-d', '-n', '-oKNAME,TYPE,RO'])
+        ['lsblk', '-d', '-n', '-e2', '-oKNAME,TYPE,RO'])
     for line in output.splitlines():
         kname, blk_type, readonly = line.split()
         if blk_type == b"disk" and readonly == b"0":


### PR DESCRIPTION
VM fails to erase disks because it also tries to erase fd0 which is not
there:

cloud-init[1332]: fd0, sda to be wiped.
kernel: [   79.037366] print_req_error: I/O error, dev fd0, sector 0
kernel: [   79.037432] floppy: error 10 while reading block 0
cloud-init[1332]: Traceback (most recent call last):
cloud-init[1332]:   File "/tmp/user_data.sh.b1jp9Q/bin/maas-wipe", line 266, in <module>
cloud-init[1332]:     main()
cloud-init[1332]:   File "/tmp/user_data.sh.b1jp9Q/bin/maas-wipe", line 260, in main
cloud-init[1332]:     zero_disk(kname)
cloud-init[1332]:   File "/tmp/user_data.sh.b1jp9Q/bin/maas-wipe", line 188, in zero_disk
cloud-init[1332]:     with open(DEV_PATH % kname, "rb") as fp:
cloud-init[1332]: OSError: [Errno 6] No such device or address: b'/dev/fd0'

This patch tries to exclude fd device by excluding its major number - 2
and thus parameter -e2 to lsblk.