### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/src/maasserver/api/doc.py
+++ b/src/maasserver/api/doc.py
@@ -111,7 +111,7 @@ def generate_power_types_doc():
                         "'%s' (%s)" % (choice[0], choice[1])
                         for choice in choices))
             default = field.get('default', '')
-            if default is not '':
+            if default != '':
                 field_description.append("  Default: '%s'." % default)
             line(''.join(field_description))
         line('')
@@ -153,7 +153,7 @@ def generate_pod_types_doc():
                         "'%s' (%s)" % (choice[0], choice[1])
                         for choice in choices))
             default = field.get('default', '')
-            if default is not '':
+            if default != '':
                 field_description.append("  Default: '%s'." % default)
             line(''.join(field_description))
         line('')

--- a/src/maasserver/forms/vlan.py
+++ b/src/maasserver/forms/vlan.py
@@ -161,7 +161,7 @@ class VLANForm(MAASModelForm):
         if (cleaned_data.get('secondary_rack') is None and
                 self.instance.secondary_rack is not None):
             self.instance.secondary_rack = None
-        if (cleaned_data.get('space') is "" and
+        if (cleaned_data.get('space') == "" and
                 self.instance.space is not None):
             self.instance.space = None
         return cleaned_data


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python.  These instances will raise SyntaxWarnings on Python >= 3.8 so it is best to fix them now.  https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

[flake8](http://flake8.pycqa.org) testing of https://github.com/maas/maas on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./src/maasserver/forms/vlan.py:164:13: F632 use ==/!= to compare str, bytes, and int literals
        if (cleaned_data.get('space') is "" and
            ^
./src/maasserver/api/doc.py:114:16: F632 use ==/!= to compare str, bytes, and int literals
            if default is not '':
               ^
./src/maasserver/api/doc.py:156:16: F632 use ==/!= to compare str, bytes, and int literals
            if default is not '':
               ^
3     F632 use ==/!= to compare str, bytes, and int literals
3
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree