### PR TITLE
Request to supports SSH Power driver

### DIFF
--- a/src/provisioningserver/drivers/power/registry.py
+++ b/src/provisioningserver/drivers/power/registry.py
@@ -28,6 +28,7 @@ from provisioningserver.drivers.power.ucsm import UCSMPowerDriver
 from provisioningserver.drivers.power.virsh import VirshPowerDriver
 from provisioningserver.drivers.power.vmware import VMwarePowerDriver
 from provisioningserver.drivers.power.wedge import WedgePowerDriver
+from provisioningserver.drivers.power.ssh import SSHPowerDriver
 from provisioningserver.utils.registry import Registry
 
 
@@ -69,6 +70,7 @@ power_drivers = [
     VirshPowerDriver(),
     VMwarePowerDriver(),
     WedgePowerDriver(),
+    SSHPowerDriver(),
 ]
 for driver in power_drivers:
     PowerDriverRegistry.register_item(driver.name, driver)

--- a/src/provisioningserver/drivers/power/ssh.py
+++ b/src/provisioningserver/drivers/power/ssh.py
@@ -1,0 +1,98 @@
+# Copyright 2015-2016 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+"""SSH Power Driver.
+
+Issue command to control power through SSH.
+"""
+
+__all__ = []
+
+from subprocess import (
+    PIPE,
+    Popen,
+)
+
+from provisioningserver.drivers import (
+    make_setting_field,
+)
+from provisioningserver.drivers.power import (
+    PowerActionError,
+    PowerDriver,
+)
+from provisioningserver.utils import shell
+from provisioningserver.utils.shell import get_env_with_locale
+
+from provisioningserver.logger import get_maas_logger
+from twisted.internet.defer import maybeDeferred
+
+maaslog = get_maas_logger("drivers.power.ssh")
+
+class SSHPowerDriver(PowerDriver):
+    """Power control through issuing SSH command."""
+
+    name = 'ssh'
+    chassis = True
+    description = "Issue Command through SSH"
+    settings = [
+        make_setting_field(
+            'username', "Username", required=True),
+        make_setting_field(
+            'device_address', "IP for Target Device", required=True),
+        make_setting_field(
+            'key_path', "Paired key on MaaS server", required=True),
+    ]
+    ip_extractor = None
+    queryable = False
+
+    def detect_missing_packages(self):
+        binary, package = ['ssh', 'openssh-client']
+        if not shell.has_command_available(binary):
+            return [package]
+        return []
+
+    @classmethod
+    def run_process(cls, command):
+        """Run SSH command in subprocess."""
+        proc = Popen(
+            command.split(), stdout=PIPE, stderr=PIPE,
+            env=get_env_with_locale())
+        stdout, stderr = proc.communicate()
+        stdout = stdout.decode("utf-8")
+        stderr = stderr.decode("utf-8")
+        if proc.returncode != 0:
+            raise PowerActionError(
+                "APC Power Driver external process error for command %s: %s: %s"
+                % (command, stdout, stderr))
+
+    def on(self, system_id, context):
+        """Override `on` as we do not need retry logic."""
+        return maybeDeferred(self.power_on, system_id, context)
+
+    def off(self, system_id, context):
+        """Override `off` as we do not need retry logic."""
+        return maybeDeferred(self.power_off, system_id, context)
+
+    def query(self, system_id, context):
+        """Override `query` as we do not need retry logic."""
+        return maybeDeferred(self.power_query, system_id, context)
+
+    def power_on(self, system_id, context):
+        """Power on machine through ssh."""
+        maaslog.info(
+            "You need to power on %s manually.", system_id)
+        self.run_process('ssh ' + '-o StrictHostKeyChecking=no ' + \
+            '-o UserKnownHostsFile=/dev/null ' + '-i ' + context['key_path'] + \
+            ' -t ' + context['username'] + '@' + context['device_address'] + \
+            ' (sleep 5; sudo reboot) &')
+
+    def power_off(self, system_id, context):
+        """Power off machine manually."""
+        maaslog.info(
+            "You need to power off %s manually.", system_id)
+
+    def power_query(self, system_id, context):
+        """Power query machine manually."""
+        maaslog.info(
+            "You need to check power state of %s manually.", system_id)
+        return 'unknown'


### PR DESCRIPTION
In our development environment, we need to daily deploy the daily built image to various platforms. (such as workstation, laptop, IoT board, etc...)
There's many platforms not support either:
1. Power on when AC detected (which means can not be wake up by PDU).
2. Wake on LAN.

and also these platforms won't be power-off after last deployment completed.

Here is the idea to power control device through ssh command.
Requirements:
1. Generate ssh keys on MaaS server (e.g. put ssh key in ```/var/lib/maas/id_rsa```).
2. Add the pair public key of above one to MaaS account.
3. Assign a static IP for target device.
4. Need to know a super user name on target device.

Then the device would be reboot after 5 secs (to prevent got ssh connection closed error) when deploying image if the device has been deployed by MaaS in previous stage.

I've already test it with ```version 2.5.0-7442-gdf68e30a5-0ubuntu1~18.04.1```.
![Screenshot from 2019-11-23 16-15-17](https://user-images.githubusercontent.com/20749662/69475858-6203c780-0e0d-11ea-87df-f9c2405fb3ed.png)

I'm new in MaaS world and would like to know more opinions.
Please let me know if anything I'm missing.