### PR TITLE
DNS: fix regression with non-maas RFC1918 reverse lookups

### DIFF
--- a/snap/local/tree/usr/share/maas/bind/named.conf
+++ b/snap/local/tree/usr/share/maas/bind/named.conf
@@ -11,6 +11,7 @@ options {
     session-keyfile "/var/snap/maas/current/bind/session.key";
     auth-nxdomain no;
     listen-on-v6 { any; };
+    empty-zones-enable no;
     include "/var/snap/maas/current/bind/named.conf.options.inside.maas";
 };
 


### PR DESCRIPTION
BIND 9.9 changed the default for empty-zones-enable to yes, to prevent
load on core DNS servers from reverse lookup queries for private network
addresses. There is some discussion at https://kb.isc.org/docs/aa-00800

Since MAAS does not explicitly set this to either value, the update to
BIND 9.9 changed the behavior of maas deployments: Reverse DNS lookups
done by maas hosts for addresses of non-maas hosts on private subnets
now fail.

(This has been going on for awhile; this patch is long overdue. We were
living with this by patching maas after every update, but now with snap
and automatic updates --- which are on the balance a good thing --- this
issue is causing lots of frustration for my deployment.)

While queries for private addresses should not be forwarded to public
nameservers, and resolvers at corporate boundaries should indeed have
"empty-zones-enable" set to "yes", for a maas controller, this is not
helpful. Maas is almost always going to be forwarding non-maas queries
to a local corporate name server, not the public root servers.

Bug: https://bugs.launchpad.net/maas/+bug/1908087