### PR TITLE
Add Hyper-V as a supported power provider

### DIFF
--- a/snap/local/requirements.txt
+++ b/snap/local/requirements.txt
@@ -1,2 +1,3 @@
 pyvmomi==6.0.0.2016.6
 git+https://github.com/Supervisor/supervisor@master#egg=supervisor
+pywinrm==0.4.1

--- a/src/provisioningserver/drivers/hardware/hyperv.py
+++ b/src/provisioningserver/drivers/hardware/hyperv.py
@@ -1,0 +1,151 @@
+import sys
+
+from winrm import protocol
+from provisioningserver.logger import get_maas_logger
+maaslog = get_maas_logger("drivers.power.hyperv")
+
+########## https://github.com/diyan/pywinrm/issues/269
+import logging
+class SuppressFilter(logging.Filter):
+    def filter(self, record):
+        return 'wsman' not in record.getMessage()
+
+try:
+    from urllib3.connectionpool import log
+    log.addFilter(SuppressFilter())
+except:
+    pass
+##########
+
+AUTH_BASIC = "basic"
+AUTH_KERBEROS = "kerberos"
+AUTH_CERTIFICATE = "certificate"
+AUTH_NTLM = "ntlm"
+
+DEFAULT_PORT_HTTP = 5985
+DEFAULT_PORT_HTTPS = 5986
+
+CODEPAGE_UTF8 = 65001
+
+AUTH_TRANSPORT_MAP = {
+    AUTH_BASIC: 'plaintext',
+    AUTH_KERBEROS: 'kerberos',
+    AUTH_CERTIFICATE: 'ssl',
+    AUTH_NTLM: 'ntlm',
+}
+
+VM_RUNNING = "Running"
+VM_PAUSED = "Paused"
+VM_STOPPED = "Off"
+VM_STARTING = "Starting"
+VM_STOPPING = "Stopping"
+
+VM_STATE_TO_POWER_STATE = {
+    VM_RUNNING: "on",
+    VM_STARTING: "on",
+    VM_STOPPING: "on",
+    VM_STOPPED: "off",
+    VM_PAUSED: "off",
+}
+
+
+class HypervCmdError(Exception):
+    """Failed to run command on remote Hyper-V node"""
+
+
+class WinRM(object):
+
+    def __init__(self, power_address, username, password, use_ssl=True):
+        self.hostname = power_address
+        self.use_ssl = use_ssl
+        maaslog.warning("HV init")
+
+        self.protocol = self._protocol(username, password)
+
+    def _protocol(self, username, password):
+        protocol.Protocol.DEFAULT_TIMEOUT = "PT3600S"
+        p = protocol.Protocol(endpoint=self._url,
+                              transport=AUTH_TRANSPORT_MAP[AUTH_NTLM],
+                              username=username,
+                              password=password,
+                              server_cert_validation='ignore')
+        return p
+
+    def _run_command(self, cmd):
+        if type(cmd) is not list:
+            raise ValueError("command must be a list")
+        
+        maaslog.info("HV run cmd: %s", cmd)
+        shell_id = None
+        try:
+            shell_id = self.protocol.open_shell()
+        except:
+            maaslog.warning("HV crapat: %s", sys.exc_info()[0])
+ 
+        command_id = self.protocol.run_command(shell_id, cmd[0], cmd[1:])
+        std_out, std_err, status_code = self.protocol.get_command_output(shell_id, command_id)
+        self.protocol.cleanup_command(shell_id, command_id)
+        self.protocol.close_shell(shell_id)
+
+        if status_code:  
+            raise HypervCmdError("Failed to run command: %s. Error message: %s" % (" ".join(cmd), std_err))
+        
+        return std_out
+
+    def run_command(self, command):
+        return self._run_command(command)
+
+    def run_powershell_command(self, command):
+        pscommand = ["powershell.exe", "-ExecutionPolicy", "RemoteSigned",
+                     "-NonInteractive", "-Command"] + command
+        return self._run_command(pscommand)
+
+    def get_vm_state(self, machine):
+        state = self.run_powershell_command(['(Get-VM %s -ErrorAction SilentlyContinue).State' % machine, ])
+        maaslog.warning(state.strip())
+
+        if not state:
+            raise HypervCmdError("Machine %s was not found on hypervisor %s" % (machine, self.hostname))
+        return state.strip().decode("utf-8")
+
+    @property
+    def _url(self):
+        proto = "http"
+        port = DEFAULT_PORT_HTTP
+        if self.use_ssl:
+            proto = "https"
+            port = DEFAULT_PORT_HTTPS
+        return "%s://%s:%s/wsman" % (proto, self.hostname, port)
+
+    def status(self, vm):
+        url = self._url
+
+
+def power_state_hyperv(poweraddr, machine, username, password, use_ssl=True):
+    """Return the power state for the VM using WinRM."""
+
+    conn = WinRM(poweraddr, username, password, use_ssl)
+    state = conn.get_vm_state(machine)
+    maaslog.warning("hv: %s", state)
+    maaslog.warning(VM_STATE_TO_POWER_STATE)
+    try:
+        return VM_STATE_TO_POWER_STATE[state]
+    except KeyError:
+        raise HypervCmdError('Unknown state: %s' % state)
+
+
+def power_control_hyperv(poweraddr, machine, power_change, username, password, use_ssl=True):
+    """Power controls a VM using WinRM."""
+
+    conn = WinRM(poweraddr, username, password, use_ssl)
+    state = conn.get_vm_state(machine)
+    maaslog.warning("HV status: %s", state)
+
+    if state == VM_STOPPED:
+        if power_change == 'on':
+            startCmd = '(Set-VMFirmware %s -BootOrder (Get-VMNetworkAdapter %s)); (Start-VM %s)' % (machine, machine, machine)
+            conn.run_powershell_command([startCmd, ])
+    elif state == VM_RUNNING:
+        if power_change == 'off':
+            conn.run_powershell_command(['Stop-VM %s -Force' % machine,])
+

--- a/src/provisioningserver/drivers/power/hyperv.py
+++ b/src/provisioningserver/drivers/power/hyperv.py
@@ -1,0 +1,105 @@
+"""Hyper-V Power Driver."""
+
+__all__ = []
+
+import importlib
+REQUIRED_PACKAGES = [["winrm", "pywinrm"], ]
+HYPERV_YES="y"
+HYPERV_NO="n"
+
+HYPERV_USE_SSL_CHOICES = [
+    [HYPERV_YES, "Yes"],
+    [HYPERV_NO, "No"]]
+
+from provisioningserver.drivers import (
+    IP_EXTRACTOR_PATTERNS,
+    make_ip_extractor,
+    make_setting_field,
+    SETTING_SCOPE,
+)
+
+from provisioningserver.drivers.power import PowerDriver
+from provisioningserver.drivers.hardware.hyperv import (
+    power_control_hyperv,
+    power_state_hyperv,
+)
+from provisioningserver.logger import get_maas_logger
+
+maaslog = get_maas_logger("drivers.power.hyperv")
+
+def extract_hyperv_parameters(context):
+    poweraddr = context.get("power_address")
+    machine = context.get("power_id")
+    username = context.get("power_user")
+    password = context.get("power_pass")
+    use_ssl = (context.get("use_ssl")==HYPERV_YES)
+
+    return poweraddr, machine, username, password, use_ssl
+
+class HypervPowerDriver(PowerDriver):
+
+    name = "hyperv"
+    chassis = False
+    description = "Hyper-V Power Driver."
+    settings = [
+        make_setting_field(
+            "power_id", 
+            "VM Name", 
+            required=True,
+            scope=SETTING_SCOPE.NODE,
+        ),
+        make_setting_field(
+            "power_address", 
+            "Hyper-V hostname", 
+            required=True,
+        ),
+        make_setting_field(
+            "power_user", 
+            "Hyper-V username", 
+            required=True,
+        ),
+        make_setting_field(
+            "power_pass", 
+            "Hyper-V password", 
+            field_type="password",
+            required=True,
+        ),
+        make_setting_field(
+            "power_use_ssl", 
+            "Use ssl", 
+            field_type='choice', 
+            required=True, 
+            choices=HYPERV_USE_SSL_CHOICES, 
+            default=HYPERV_NO,
+        ),
+    ]
+    ip_extractor = make_ip_extractor("power_address")
+
+    def detect_missing_packages(self):
+        missing_packages = set()
+        for module, package in REQUIRED_PACKAGES:
+            try:
+                importlib.import_module(module)
+            except ImportError:
+                missing_packages.add(package)
+        return list(missing_packages)
+
+    def power_on(self, system_id, context):
+        """Power on Hyper-V node."""
+        power_change = "on"
+        poweraddr, machine, username, password, use_ssl = extract_hyperv_parameters(context)
+        power_control_hyperv(poweraddr, machine, power_change, username, password, use_ssl)
+
+    def power_off(self, system_id, context):
+        """Power off Hyper-V node."""
+        power_change = "off"
+        poweraddr, machine, username, password, use_ssl = extract_hyperv_parameters(context)
+        power_control_hyperv(poweraddr, machine, power_change, username, password, use_ssl)
+
+    def power_query(self, system_id, context):
+        """Power query Hyper-V node."""
+        poweraddr, machine, username, password, use_ssl = extract_hyperv_parameters(context)
+        a = power_state_hyperv(poweraddr, machine, username, password, use_ssl)
+        maaslog.warning("state: %s", a)
+        return a
+

--- a/src/provisioningserver/drivers/power/hyperv.py
+++ b/src/provisioningserver/drivers/power/hyperv.py
@@ -40,7 +40,8 @@ class HypervPowerDriver(PowerDriver):
 
     name = "hyperv"
     chassis = False
-    description = "Hyper-V Power Driver."
+    can_probe = True
+    description = "Hyper-V Power Driver"
     settings = [
         make_setting_field(
             "power_id", 

--- a/src/provisioningserver/drivers/power/registry.py
+++ b/src/provisioningserver/drivers/power/registry.py
@@ -12,6 +12,7 @@ from provisioningserver.drivers.power.amt import AMTPowerDriver
 from provisioningserver.drivers.power.apc import APCPowerDriver
 from provisioningserver.drivers.power.dli import DLIPowerDriver
 from provisioningserver.drivers.power.eaton import EatonPowerDriver
+from provisioningserver.drivers.power.hyperv import HypervPowerDriver
 from provisioningserver.drivers.power.hmc import HMCPowerDriver
 from provisioningserver.drivers.power.ipmi import IPMIPowerDriver
 from provisioningserver.drivers.power.manual import ManualPowerDriver
@@ -53,6 +54,7 @@ power_drivers = [
     DLIPowerDriver(),
     EatonPowerDriver(),
     HMCPowerDriver(),
+    HypervPowerDriver(),
     IPMIPowerDriver(),
     ManualPowerDriver(),
     MoonshotIPMIPowerDriver(),


### PR DESCRIPTION
Note: Hyper-V VMs need to make use of legacy network adaptors in order to boot over network.