### PR TITLE
debian/control: add lsb-release dependency for postinst

### DIFF
--- a/debian/maas-rack-controller.postinst
+++ b/debian/maas-rack-controller.postinst
@@ -5,7 +5,8 @@ set -e
 . /usr/share/debconf/confmodule
 db_version 2.0
 
-RELEASE=`lsb_release -rs` || RELEASE=""
+. /etc/lsb-release
+RELEASE="${DISTRIB_RELEASE:-}"
 
 configure_logging() {
     # Give appropriate permissions

--- a/debian/maas-region-api.postinst
+++ b/debian/maas-region-api.postinst
@@ -5,7 +5,8 @@ set -e
 . /usr/share/debconf/confmodule
 db_version 2.0
 
-RELEASE=`lsb_release -rs` || RELEASE=""
+. /etc/lsb-release
+RELEASE="${DISTRIB_RELEASE:-}"
 
 configure_logging() {
     # Give appropriate permissions

--- a/debian/maas-region-controller.postinst
+++ b/debian/maas-region-controller.postinst
@@ -9,7 +9,8 @@ if [ -f /usr/share/dbconfig-common/dpkg/postinst.pgsql ]; then
     . /usr/share/dbconfig-common/dpkg/postinst.pgsql
 fi
 
-RELEASE=`lsb_release -rs` || RELEASE=""
+. /etc/lsb-release
+RELEASE="${DISTRIB_RELEASE:-}"
 
 maas_sync_migrate_db(){
     maas-region dbupgrade


### PR DESCRIPTION
Several packages calls to `lsb_release` but not depending on lsb-release, thus causes following errors in postint stage:

```
Setting up maas-region-api (1:2.9.2-9164-g.ac176b5c4-0ubuntu1~20.04.1) ...
/var/lib/dpkg/info/maas-region-api.postinst: 1: lsb_release: not found
Setting up maas-region-controller (1:2.9.2-9164-g.ac176b5c4-0ubuntu1~20.04.1) ...
/var/lib/dpkg/info/maas-region-controller.postinst: 1: lsb_release: not found
Setting up maas-rack-controller (1:2.9.2-9164-g.ac176b5c4-0ubuntu1~20.04.1) ...
/var/lib/dpkg/info/maas-rack-controller.postinst: 1: lsb_release: not found
```

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>