### PR TITLE
Pyre: domainname has type `str` but used as type `None`.

### DIFF
--- a/src/maasserver/api/dnsresources.py
+++ b/src/maasserver/api/dnsresources.py
@@ -71,9 +71,9 @@ class DNSResourcesQuerySet(QuerySet):
 
 def get_dnsresource_queryset(
     all_records: bool,
-    domainname: str = None,
-    name: str = None,
-    rrtype: str = None,
+    domainname: str,
+    name: str,
+    rrtype: str,
     user=None,
 ):
     # If the domain is a name, make it an id.


### PR DESCRIPTION
**"filename"**: "src/maasserver/api/dnsresources.py"
**"warning_type"**: "Incompatible variable type [9]"
**"warning_message"**: " domainname is declared to have type `str` but is used as type `None`."
**"warning_line"**: 74
**"fix"**: remove `None`