### PR TITLE
Support for Moonshot Chassis 2.0

### DIFF
--- a/src/provisioningserver/drivers/power/mscm.py
+++ b/src/provisioningserver/drivers/power/mscm.py
@@ -40,6 +40,7 @@ cartridge_mapping = {
     "ProLiant m700 Server Cartridge": "amd64/generic",
     "ProLiant m710 Server Cartridge": "amd64/generic",
     "ProLiant m720 Server Cartridge": "amd64/generic",
+    "ProLiant m750 Server Blade": "amd64/generic",
     "ProLiant m800 Server Cartridge": "armhf/keystone",
     "Default": "amd64/generic",
 }
@@ -47,7 +48,7 @@ cartridge_mapping = {
 
 class MSCMState:
     OFF = ("Off", "Unavailable")
-    ON = "On"
+    ON = ("On", "PoweringOn")
 
 
 class MSCMPowerDriver(PowerDriver):
@@ -154,7 +155,7 @@ class MSCMPowerDriver(PowerDriver):
                 "MSCM Power Driver unable to power query node %s: %s"
                 % (context["node_id"], e)
             )
-        match = re.search(r"Power State:\s*((O[\w]+|U[\w]+))", output)
+        match = re.search(r"Power State:\s*((O[\w]+|U[\w]+|P[\w]+))", output)
         if match is None:
             raise PowerFatalError(
                 "MSCM Power Driver unable to extract node power state from: %s"
@@ -164,12 +165,46 @@ class MSCMPowerDriver(PowerDriver):
             power_state = match.group(1)
             if power_state in MSCMState.OFF:
                 return "off"
-            elif power_state == MSCMState.ON:
+            elif power_state in MSCMState.ON:
                 return "on"
 
 
 @synchronous
 def probe_and_enlist_mscm(
+    user: str,
+    host: str,
+    username: Optional[str],
+    password: Optional[str],
+    accept_all: bool = False,
+    domain: str = None,
+):
+    """Extracts all of nodes from the MSCM, sets them to bootonce via PXE, and
+    then enlists them into MAAS. If accept_all is True, it will also commission
+    them.
+    If the chassis is a v1.0 chassis, it will also set all of them to boot via M.2
+    by, default. (Chassis 2.0 does not have such a command.)
+    """
+    mscm_driver = MSCMPowerDriver()
+    is_version_2: bool = False
+    
+    # Discover Moonshot Chassis firmware version (Only on Chassis 2.0 onwards).
+    #
+    # Example of output from running "show firmware":
+    # "show firmware\rFirmware Versions:\r\n        Chassis Manager:\r\n
+    #             HPE Moonshot Chassis Manager 2.0: 2.0-b176\r\n
+    #             HPE Moonshot Chassis Manager 2.0 Base Image: 1.3"
+    show_firmware = mscm_driver.run_mscm_command(
+        "show firmware",
+        power_address=host,
+        power_user=username,
+        power_pass=password,
+    )
+    if re.search(r"HPE Moonshot Chassis Manager 2.0", show_firmware):
+        probe_and_enlist_mscm_2(user, host, username, password, accept_all, domain)
+    else:
+        probe_and_enlist_mscm_1(user, host, username, password, accept_all, domain)
+
+def probe_and_enlist_mscm_1(
     user: str,
     host: str,
     username: Optional[str],
@@ -219,6 +254,104 @@ def probe_and_enlist_mscm(
             "show node info %s" % node_id, **params
         )
         match = re.search(r"Product Name:\s*([A-Za-z0-9 ]+)", node_info)
+        if match is None:
+            raise PowerFatalError(
+                "MSCM Power Driver unable to extract node architecture"
+                " from: %s" % node_info
+            )
+        else:
+            cartridge = match.group(1)
+        if cartridge in cartridge_mapping:
+            arch = cartridge_mapping[cartridge]
+        else:
+            arch = cartridge_mapping["Default"]
+        # Retrieve node MACs
+        #
+        # Example of output from running "show node macaddr <node_id>":
+        # "show node macaddr c1n1\r\r\nSlot ID    NIC 1 (Switch A)
+        # NIC 2 (Switch B)  NIC 3 (Switch A)  NIC 4 (Switch B)\r\n
+        # ---- ----- ----------------- ----------------- -----------------
+        # -----------------\r\n  1  c1n1  a0:1d:48:b5:04:34 a0:1d:48:b5:04:35
+        # a0:1d:48:b5:04:36 a0:1d:48:b5:04:37\r\n\r\n\r\n"
+        node_macaddr = mscm_driver.run_mscm_command(
+            "show node macaddr %s" % node_id, **params
+        )
+        macs = re.findall(r":".join(["[0-9a-f]{2}"] * 6), node_macaddr)
+        # Create node
+        system_id = create_node(macs, arch, "mscm", params, domain).wait(30)
+
+        if accept_all:
+            commission_node(system_id, user).wait(30)
+
+def probe_and_enlist_mscm_2(
+    user: str,
+    host: str,
+    username: Optional[str],
+    password: Optional[str],
+    accept_all: bool = False,
+    domain: str = None,
+):
+    """Extracts all of nodes from the MSCM, sets them to bootonce via PXE, and
+    then enlists them into MAAS.  If accept_all is True, it will also commission
+    them.
+    """
+    mscm_driver = MSCMPowerDriver()
+
+    # Discover all available nodes
+    #
+    # Example of output from running "show node mgmtaddr4 all":
+    # "show node mgmtaddr4 all\r\r\n
+    # Slot ID    Management Address\r\n
+    # ---- ----- ------------------\r\n
+    #   1  c1n1  192.168.4.125:736\r\n"
+    node_list = mscm_driver.run_mscm_command(
+        "show node mgmtaddr4 all",
+        power_address=host,
+        power_user=username,
+        power_pass=password,
+    )
+    nodes = re.findall(r"\d+\s+c\d+n\d", node_list)
+    for node in nodes:
+        blade_str, node_id = re.match(r"(\d+)\s+(c\d+n\d)", node).group(1, 2)
+        blade_id = int(blade_str)
+
+        params = {
+            "power_address": host,
+            "power_user": username,
+            "power_pass": password,
+            "node_id": node_id,
+        }
+        # Retrieve node architecture
+        #
+        # Example of output from running "show blades b<blade_id>":
+        # "show blades b1\r
+        # Blades:\r\n
+        #         b1:\r\n
+        #                 AssetTag:\r\n
+        #                 iLO HTTPS: https://192.168.1.1:123\r\n
+        #                 iLO SSH: 192.168.1.1:124\r\n
+        #                 iLO MAC: AA:AA:AA:AA:AA:AA\r\n
+        #                 Model: ProLiant m750 Server Blade\r\n
+        #                 UUID: 12345678-9012-3456-7890-123456789012\r\n
+        #                 SerialNumber: CN11111AAA\r\n
+        #                 Product ID: P17342-B21\r\n
+        #                 PartNumber: P17344-001\r\n
+        #                 Health: OK\r\n
+        #                 iLO Redfish Communication: OK\r\n
+        #                 iLO Health: OK\r\n
+        #                 UID: Off\r\n
+        #                 PowerState: Off\r\n
+        #                 NIC 1 MAC (Switch A): bb:bb:bb:bb:bb:bb\r\n
+        #                 NIC 2 MAC (Switch B): cc:cc:cc:cc:cc:cc\r\n
+        #                 FirmwareVersions:\r\n
+        #                         iLO: iLO 5 v2.30\r\n
+        #                         System ROM: H09 v1.34 (10/16/2020)\r\n
+        #                         System Programmable Logic Device: 0x05\r\n
+        #                         TPM: 73.64\r\n"
+        node_info = mscm_driver.run_mscm_command(
+            "show blades b%d" % blade_id, **params
+        )
+        match = re.search(r"Model:\s*([A-Za-z0-9 ]+)", node_info)
         if match is None:
             raise PowerFatalError(
                 "MSCM Power Driver unable to extract node architecture"


### PR DESCRIPTION
Patch to provide Moonshot Chassis 2.0 firmware support.

When adding a Moonshot chassis, the driver will correctly ascertain whether firmware is v1 or v2 and send appropriate discovery commands according to version.