### PR TITLE
fix: use clean authoritative flag before checking it

### DIFF
--- a/src/maasserver/forms/domain.py
+++ b/src/maasserver/forms/domain.py
@@ -40,13 +40,22 @@ class DomainForm(MAASModelForm):
         return self.instance
 
     def clean(self):
-        if self.data.get("authoritative") and len(
-            self.data.get("forward_dns_servers", "")
+        # Using "cleaned_data" here, inside a `clean` method
+        # that later calls super().clean() looks like things are out
+        # of order, but the way Django works is that this method is
+        # supposed to run _after_ field-level validation has run.
+        #
+        # You can see that the method that this overrides in the parent
+        # specifically says that it is a "hook for doing any extra
+        # form-wide cleaning after Field.clean() has
+        # been called on every field."
+        if self.cleaned_data.get("authoritative") and len(
+            self.cleaned_data.get("forward_dns_servers", "")
         ):
             raise ValidationError(
                 "a domain cannot be both authoritative and have forward dns servers"
             )
-        super().clean()
+        return super().clean()
 
     def _post_clean(self):
         # ttl=None needs to make it through.  See also APIEditMixin

--- a/src/maasserver/forms/domain.py
+++ b/src/maasserver/forms/domain.py
@@ -46,7 +46,7 @@ class DomainForm(MAASModelForm):
         # supposed to run _after_ field-level validation has run.
         #
         # You can see that the method that this overrides in the parent
-        # specifically says that it is a "hook for doing any extra
+        # (BaseForm) specifically says that it is a "hook for doing any extra
         # form-wide cleaning after Field.clean() has
         # been called on every field."
         if self.cleaned_data.get("authoritative") and self.cleaned_data.get(

--- a/src/maasserver/forms/domain.py
+++ b/src/maasserver/forms/domain.py
@@ -25,7 +25,7 @@ class DomainForm(MAASModelForm):
 
     forward_dns_servers = IPPortListFormField(default_port=53, required=False)
 
-    def save(self):
+    def save(self, *args, **kwargs):
         super(MAASModelForm, self).save()
         fwd_srvrs = self.cleaned_data.get("forward_dns_servers")
         if fwd_srvrs is not None:

--- a/src/maasserver/forms/domain.py
+++ b/src/maasserver/forms/domain.py
@@ -40,22 +40,21 @@ class DomainForm(MAASModelForm):
         return self.instance
 
     def clean(self):
-        # Using "cleaned_data" here, inside a `clean` method
-        # that later calls super().clean() looks like things are out
-        # of order, but the way Django works is that this method is
-        # supposed to run _after_ field-level validation has run.
-        #
-        # You can see that the method that this overrides in the parent
-        # (BaseForm) specifically says that it is a "hook for doing any extra
-        # form-wide cleaning after Field.clean() has
-        # been called on every field."
-        if self.cleaned_data.get("authoritative") and self.cleaned_data.get(
-            "forward_dns_servers", ""
-        ):
+        cleaned_data = super().clean()
+
+        authoritative = cleaned_data.get("authoritative")
+        authoritative = (
+            authoritative
+            if authoritative is not None
+            else self.instance.authoritative
+        )
+
+        if authoritative and cleaned_data.get("forward_dns_servers"):
             raise ValidationError(
                 "a domain cannot be both authoritative and have forward dns servers"
             )
-        return super().clean()
+
+        return cleaned_data
 
     def _post_clean(self):
         # ttl=None needs to make it through.  See also APIEditMixin

--- a/src/maasserver/forms/domain.py
+++ b/src/maasserver/forms/domain.py
@@ -49,8 +49,8 @@ class DomainForm(MAASModelForm):
         # specifically says that it is a "hook for doing any extra
         # form-wide cleaning after Field.clean() has
         # been called on every field."
-        if self.cleaned_data.get("authoritative") and len(
-            self.cleaned_data.get("forward_dns_servers", "")
+        if self.cleaned_data.get("authoritative") and self.cleaned_data.get(
+            "forward_dns_servers", ""
         ):
             raise ValidationError(
                 "a domain cannot be both authoritative and have forward dns servers"

--- a/src/maasserver/forms/tests/test_domain.py
+++ b/src/maasserver/forms/tests/test_domain.py
@@ -161,3 +161,27 @@ class TestDomainForm(MAASServerTestCase):
             }
         )
         self.assertRaises(ValueError, form.save)
+
+    def test_authoritative_with_forward_dns_servers_is_not_valid(self):
+        name = factory.make_name("domain")
+        forward_dns_servers = [factory.make_ip_address() for _ in range(0, 2)]
+        form = DomainForm(
+            {
+                "name": name,
+                "authoritative": "true",
+                "forward_dns_servers": " ".join(forward_dns_servers),
+            }
+        )
+        self.assertFalse(form.is_valid(), form.errors)
+
+    def test_non_authoritative_with_forward_dns_servers_is_valid(self):
+        name = factory.make_name("domain")
+        forward_dns_servers = [factory.make_ip_address() for _ in range(0, 2)]
+        form = DomainForm(
+            {
+                "name": name,
+                "authoritative": "false",
+                "forward_dns_servers": " ".join(forward_dns_servers),
+            }
+        )
+        self.assertTrue(form.is_valid(), form.errors)

--- a/src/maasserver/forms/tests/test_domain.py
+++ b/src/maasserver/forms/tests/test_domain.py
@@ -162,6 +162,17 @@ class TestDomainForm(MAASServerTestCase):
         )
         self.assertRaises(ValueError, form.save)
 
+    def test_default_authoritative_with_forward_dns_servers_is_not_valid(self):
+        name = factory.make_name("domain")
+        forward_dns_servers = [factory.make_ip_address() for _ in range(0, 2)]
+        form = DomainForm(
+            {
+                "name": name,
+                "forward_dns_servers": " ".join(forward_dns_servers),
+            }
+        )
+        self.assertFalse(form.is_valid(), form.errors)
+
     def test_authoritative_with_forward_dns_servers_is_not_valid(self):
         name = factory.make_name("domain")
         forward_dns_servers = [factory.make_ip_address() for _ in range(0, 2)]


### PR DESCRIPTION
The main issue was that the validation was being done before any treatment of the inputs, so `self.data.get("authoritative")` was returning the string that was used in the CLI command (or the API). 

Specifically, for example, setting `authoritative=false` resulted in the code thinking that there was a violation.

Funnily enough, setting `authoritative` to an empty string would let things pass through, even though authoritative at the end (in the model) would be True due to its default value there.

Resolves [LP:2147570](https://bugs.launchpad.net/maas/+bug/2147570)