### PR TITLE
fix(storage): FilesystemGroup name generation with multiple nodes

### DIFF
--- a/src/maasserver/models/filesystemgroup.py
+++ b/src/maasserver/models/filesystemgroup.py
@@ -145,16 +145,6 @@ class BaseFilesystemGroupManager(Manager):
                 idx = max(idx, name_idx)
         return f"{prefix}{idx + 1}"
 
-    def get_available_name_for(self, filesystem_group):
-        """Return an available name that can be used for a `VirtualBlockDevice`
-        based on the `filesystem_group`'s group_type and other block devices
-        on the node.
-        """
-        return self.get_available_name_for_node(
-            filesystem_group.group_type,
-            filesystem_group.get_node(),
-        )
-
 
 class FilesystemGroupManager(BaseFilesystemGroupManager):
     """All the FilesystemGroup objects together."""

--- a/src/maasserver/models/filesystemgroup.py
+++ b/src/maasserver/models/filesystemgroup.py
@@ -131,18 +131,12 @@ class BaseFilesystemGroupManager(Manager):
             | partition_query
         ).distinct()
 
-    def get_available_name_for(self, filesystem_group):
-        """Return an available name that can be used for a `VirtualBlockDevice`
-        based on the `filesystem_group`'s group_type and other block devices
-        on the node.
-        """
-        prefix = filesystem_group.get_name_prefix()
-        node = filesystem_group.get_node()
+    def get_available_name_for_node(self, group_type, node):
+        """Return an available name for the given group_type and node."""
+        prefix = FilesystemGroup.get_name_prefix(group_type)
         idx = -1
-        for filesystem_group in self.filter_by_node(node).filter(
-            name__startswith=prefix
-        ):
-            name = filesystem_group.name.replace(prefix, "")
+        for group in self.filter_by_node(node).filter(name__startswith=prefix):
+            name = group.name.replace(prefix, "")
             try:
                 name_idx = int(name)
             except ValueError:
@@ -150,6 +144,16 @@ class BaseFilesystemGroupManager(Manager):
             else:
                 idx = max(idx, name_idx)
         return f"{prefix}{idx + 1}"
+
+    def get_available_name_for(self, filesystem_group):
+        """Return an available name that can be used for a `VirtualBlockDevice`
+        based on the `filesystem_group`'s group_type and other block devices
+        on the node.
+        """
+        return self.get_available_name_for_node(
+            filesystem_group.group_type,
+            filesystem_group.get_node(),
+        )
 
 
 class FilesystemGroupManager(BaseFilesystemGroupManager):
@@ -208,10 +212,6 @@ class RAIDManager(BaseFilesystemGroupManager):
     ):
         from maasserver.models.filesystem import Filesystem
 
-        # Create a FilesystemGroup for this RAID
-        raid = RAID(group_type=level, name=name, uuid=uuid)
-        raid.save()
-
         if block_devices is None:
             block_devices = []
         if partitions is None:
@@ -226,11 +226,21 @@ class RAIDManager(BaseFilesystemGroupManager):
         elif spare_devices:
             bdev = spare_devices[0]
         elif partitions or spare_partitions:
-            bdev = partitions[0].partition_table.block_device
+            bdev = (partitions or spare_partitions)[
+                0
+            ].partition_table.block_device
         else:
             bdev = None  # this only happens if there are no devices at all, in
             # which case no filesystem is created
         node_config = bdev.node_config if bdev else None
+
+        if name is None and node_config is not None:
+            name = RAID.objects.get_available_name_for_node(
+                level, node_config.node
+            )
+        raid = RAID(group_type=level, name=name, uuid=uuid)
+        raid.save()
+
         for block_device in block_devices:
             Filesystem.objects.create(
                 node_config=node_config,
@@ -320,8 +330,9 @@ class BcacheManager(BaseFilesystemGroupManager):
         from maasserver.models.filesystem import Filesystem
 
         if backing_device is not None:
+            node_config = backing_device.node_config
             backing_filesystem = Filesystem(
-                node_config=backing_device.node_config,
+                node_config=node_config,
                 block_device=backing_device,
                 fstype=FILESYSTEM_TYPE.BCACHE_BACKING,
             )
@@ -335,7 +346,11 @@ class BcacheManager(BaseFilesystemGroupManager):
                 fstype=FILESYSTEM_TYPE.BCACHE_BACKING,
             )
 
-        # Setup the cache FilesystemGroup and attach the filesystems to it.
+        if name is None:
+            name = self.get_available_name_for_node(
+                FILESYSTEM_GROUP_TYPE.BCACHE, node_config.node
+            )
+
         bcache_filesystem_group = FilesystemGroup.objects.create(
             name=name,
             uuid=uuid,
@@ -784,10 +799,6 @@ class FilesystemGroup(CleanSave, TimestampedModel):
                 "Volume group cannot be smaller than its logical volumes."
             )
 
-        # Set the name correctly based on the type and generate a new UUID
-        # if needed.
-        if self.group_type is not None and self.name is None:
-            self.name = FilesystemGroup.objects.get_available_name_for(self)
         # XXX this is needed because tests pass uuid=None by default
         if not self.uuid:
             self.uuid = uuid4()
@@ -836,16 +847,16 @@ class FilesystemGroup(CleanSave, TimestampedModel):
         else:
             raise ValueError("Unknown group_type.")
 
-    def get_name_prefix(self):
-        """Return the prefix that should be used when setting the name of
-        this FilesystemGroup."""
-        if self.is_lvm():
+    @staticmethod
+    def get_name_prefix(group_type):
+        """Return the name prefix for the given group_type."""
+        if group_type == FILESYSTEM_GROUP_TYPE.LVM_VG:
             return "vg"
-        elif self.is_raid():
+        elif group_type in FILESYSTEM_GROUP_RAID_TYPES:
             return "md"
-        elif self.is_bcache():
+        elif group_type == FILESYSTEM_GROUP_TYPE.BCACHE:
             return "bcache"
-        elif self.is_vmfs():
+        elif group_type == FILESYSTEM_GROUP_TYPE.VMFS6:
             return "vmfs"
         else:
             raise ValidationError("Unknown group_type.")

--- a/src/maasserver/models/tests/test_filesystemgroup.py
+++ b/src/maasserver/models/tests/test_filesystemgroup.py
@@ -523,7 +523,7 @@ class TestFilesystemGroupManager(MAASServerTestCase):
             group_type=FILESYSTEM_GROUP_TYPE.BCACHE
         )
         filesystem_group.save()
-        prefix = filesystem_group.get_name_prefix()
+        prefix = FilesystemGroup.get_name_prefix(filesystem_group.group_type)
         current_idx = int(filesystem_group.name.replace(prefix, ""))
         self.assertEqual(
             f"{prefix}{current_idx + 1}",
@@ -535,7 +535,7 @@ class TestFilesystemGroupManager(MAASServerTestCase):
             group_type=FILESYSTEM_GROUP_TYPE.BCACHE
         )
         filesystem_group.save()
-        prefix = filesystem_group.get_name_prefix()
+        prefix = FilesystemGroup.get_name_prefix(filesystem_group.group_type)
         filesystem_group.name = "{}{}".format(prefix, factory.make_name("bad"))
         filesystem_group.save()
         self.assertEqual(
@@ -1758,10 +1758,9 @@ class TestFilesystemGroupGetNamePrefix(MAASServerTestCase):
     ]
 
     def test_returns_prefix(self):
-        filesystem_group = factory.make_FilesystemGroup(
-            group_type=self.group_type
+        self.assertEqual(
+            self.prefix, FilesystemGroup.get_name_prefix(self.group_type)
         )
-        self.assertEqual(self.prefix, filesystem_group.get_name_prefix())
 
 
 class TestFilesystemGroupGetVirtualBlockDeviceBlockSize(MAASServerTestCase):
@@ -1944,6 +1943,32 @@ class TestRAID(MAASServerTestCase):
             2,
             raid.filesystems.filter(fstype=FILESYSTEM_TYPE.RAID_SPARE).count(),
         )
+
+    def test_create_raid_auto_name_with_multiple_nodes(self):
+        node_a = factory.make_Node()
+        node_b = factory.make_Node()
+        # Pre-occupy md0 on node_b — a buggy implementation would pick this
+        # up and incorrectly skip to md1 for node_a's first RAID.
+        RAID.objects.create_raid(
+            block_devices=[
+                factory.make_PhysicalBlockDevice(node=node_b) for _ in range(2)
+            ],
+            level=FILESYSTEM_GROUP_TYPE.RAID_1,
+        )
+        raid0 = RAID.objects.create_raid(
+            block_devices=[
+                factory.make_PhysicalBlockDevice(node=node_a) for _ in range(2)
+            ],
+            level=FILESYSTEM_GROUP_TYPE.RAID_1,
+        )
+        self.assertEqual("md0", raid0.virtual_device.name)
+        raid1 = RAID.objects.create_raid(
+            block_devices=[
+                factory.make_PhysicalBlockDevice(node=node_a) for _ in range(2)
+            ],
+            level=FILESYSTEM_GROUP_TYPE.RAID_1,
+        )
+        self.assertEqual("md1", raid1.virtual_device.name)
 
     def test_create_raid_0_with_a_spare_fails(self):
         node = factory.make_Node()
@@ -2622,6 +2647,7 @@ class TestBcache(MAASServerTestCase):
     def test_create_bcache_with_virtual_block_devices(self):
         """Checks creation of a Bcache with virtual block devices for caching
         and backing roles."""
+        factory.make_Node()
         node = factory.make_Node()
         backing_size = 10 * 1000**4
         cache_size = 1000**4
@@ -2666,6 +2692,31 @@ class TestBcache(MAASServerTestCase):
         self.assertEqual(
             bcache, backing_device.get_effective_filesystem().filesystem_group
         )
+        self.assertEqual("md0", cache_device.name)
+        self.assertEqual("md1", backing_device.name)
+
+    def test_create_bcache_auto_name_with_multiple_nodes(self):
+        node_a = factory.make_Node()
+        node_b = factory.make_Node()
+        # Pre-occupy bcache0 on node_b — a buggy implementation would pick
+        # this up and incorrectly skip to bcache1 for node_a's first Bcache.
+        Bcache.objects.create_bcache(
+            cache_set=factory.make_CacheSet(node=node_b),
+            backing_device=factory.make_PhysicalBlockDevice(node=node_b),
+            cache_mode=CACHE_MODE_TYPE.WRITEBACK,
+        )
+        bcache0 = Bcache.objects.create_bcache(
+            cache_set=factory.make_CacheSet(node=node_a),
+            backing_device=factory.make_PhysicalBlockDevice(node=node_a),
+            cache_mode=CACHE_MODE_TYPE.WRITEBACK,
+        )
+        self.assertEqual("bcache0", bcache0.virtual_device.name)
+        bcache1 = Bcache.objects.create_bcache(
+            cache_set=factory.make_CacheSet(node=node_a),
+            backing_device=factory.make_PhysicalBlockDevice(node=node_a),
+            cache_mode=CACHE_MODE_TYPE.WRITEBACK,
+        )
+        self.assertEqual("bcache1", bcache1.virtual_device.name)
 
     def test_create_bcache_with_partitions(self):
         """Checks creation of a Bcache with partitions for caching and backing

--- a/src/maasserver/models/tests/test_filesystemgroup.py
+++ b/src/maasserver/models/tests/test_filesystemgroup.py
@@ -527,7 +527,10 @@ class TestFilesystemGroupManager(MAASServerTestCase):
         current_idx = int(filesystem_group.name.replace(prefix, ""))
         self.assertEqual(
             f"{prefix}{current_idx + 1}",
-            FilesystemGroup.objects.get_available_name_for(filesystem_group),
+            FilesystemGroup.objects.get_available_name_for_node(
+                filesystem_group.group_type,
+                filesystem_group.get_node(),
+            ),
         )
 
     def test_get_available_name_for_ignores_bad_int(self):
@@ -540,7 +543,10 @@ class TestFilesystemGroupManager(MAASServerTestCase):
         filesystem_group.save()
         self.assertEqual(
             "%s0" % prefix,
-            FilesystemGroup.objects.get_available_name_for(filesystem_group),
+            FilesystemGroup.objects.get_available_name_for_node(
+                filesystem_group.group_type,
+                filesystem_group.get_node(),
+            ),
         )
 
 

--- a/src/maasserver/testing/factory.py
+++ b/src/maasserver/testing/factory.py
@@ -3272,6 +3272,17 @@ class Factory(maastesting.factory.Factory):
                 cache_mode = self.pick_enum(CACHE_MODE_TYPE)
             if cache_set is None:
                 cache_set = self.make_CacheSet(node=node)
+        if node is None:
+            if filesystems:
+                node = filesystems[0].node_config.node
+            else:
+                node = self.make_Node()
+
+        if name is None and node is not None:
+            name = FilesystemGroup.objects.get_available_name_for_node(
+                group_type, node
+            )
+
         group = FilesystemGroup(
             uuid=uuid,
             group_type=group_type,
@@ -3282,8 +3293,6 @@ class Factory(maastesting.factory.Factory):
         )
         group.save()
         if filesystems is None:
-            if node is None:
-                node = self.make_Node()
             node_config = node.current_config
             if not node.physicalblockdevice_set.exists():
                 # Add the boot disk and leave it as is.


### PR DESCRIPTION
FilesystemGroup.get_available_name_for() incorrectly inferred the node when assigning sequential names (md0, md1, bcache0, etc.) to virtual block devices. It used a deprecated Django pattern where unsaved instances passed to queryset filters would accidentally match any node's boot filesystem via WHERE filesystem_group_id IS NULL. In multi-node deployments, this could return an arbitrary node, causing name collisions or IntegrityError on the BlockDevice unique_together constraint.

Resolves LP:2148204