### PR TITLE
fix(maasservicelayer): remove NULL node IDs after aggregation in list_racks_with_summary

### DIFF
--- a/src/maasservicelayer/db/repositories/racks.py
+++ b/src/maasservicelayer/db/repositories/racks.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.  This software is licensed under the
+# Copyright 2025-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 from sqlalchemy import func, select, Table
@@ -33,9 +33,9 @@ class RacksRepository(BaseRepository[Rack]):
             select(
                 RackTable.c.id,
                 RackTable.c.name,
-                func.array_agg(NodeTable.c.system_id).label(
-                    "registered_agents_system_ids"
-                ),
+                func.array_remove(
+                    func.array_agg(NodeTable.c.system_id), None
+                ).label("registered_agents_system_ids"),
             )
             .select_from(RackTable)
             .outerjoin(AgentTable, AgentTable.c.rack_id == RackTable.c.id)

--- a/src/tests/maasservicelayer/db/repositories/test_racks.py
+++ b/src/tests/maasservicelayer/db/repositories/test_racks.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Canonical Ltd.  This software is licensed under the
+# Copyright 2025-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 import pytest
@@ -66,3 +66,31 @@ class TestRacksRepository(RepositoryCommonTests[Rack]):
         assert result.items[0].name == "rack-1"
         assert len(result.items[0].registered_agents_system_ids) == 1
         assert result.items[0].registered_agents_system_ids[0] == "abc123"
+
+    async def test_list_with_summary_no_agents(
+        self, repository_instance: RacksRepository, fixture: Fixture
+    ):
+        await create_test_rack_entry(fixture, "rack-1", id=1)
+
+        result = await repository_instance.list_with_summary(1, 20)
+
+        assert result.total == 1
+        assert result.items[0].name == "rack-1"
+        assert len(result.items[0].registered_agents_system_ids) == 0
+
+    async def test_list_with_summary_null_rackcontroller_ids_are_removed(
+        self, repository_instance: RacksRepository, fixture: Fixture
+    ):
+        await create_test_rack_entry(fixture, "rack-1", id=1)
+        await create_test_agents_entry(
+            fixture=fixture,
+            uuid="test_id",
+            rack_id=1,
+            rackcontroller_id=None,  # type: ignore
+        )
+
+        result = await repository_instance.list_with_summary(1, 20)
+
+        assert result.total == 1
+        assert result.items[0].name == "rack-1"
+        assert len(result.items[0].registered_agents_system_ids) == 0


### PR DESCRIPTION
## Done

- Added `func.array_remove` to strip the NULL values out of the array produced after `func.array_agg`
- This issue was encountered while reviewing [this PR](https://github.com/canonical/maas-ui/pull/5982), which caused error code 500 in the backend when trying to add a new rack
- Updated tests to include the above scenarios

 
