### PR TITLE
fix: deploy workflow should terminate as expected (#103)

### DIFF
--- a/src/maasserver/models/node.py
+++ b/src/maasserver/models/node.py
@@ -6018,6 +6018,7 @@ class Node(CleanSave, TimestampedModel):
             ),
             task_queue="region",
             id_reuse_policy=WorkflowIDReusePolicy.ALLOW_DUPLICATE,
+            execution_timeout=timedelta(minutes=timeout + 10),
         )
         if not dd.called:
             return dd

--- a/src/maastemporalworker/workflow/deploy.py
+++ b/src/maastemporalworker/workflow/deploy.py
@@ -326,9 +326,6 @@ class DeployManyWorkflow:
                 param,
                 id=f"deploy:{param.system_id}",
                 task_queue=param.task_queue,
-                retry_policy=RetryPolicy(
-                    maximum_interval=DEFAULT_DEPLOY_RETRY_TIMEOUT
-                ),
                 execution_timeout=timedelta(minutes=param.timeout),
             )
             pending.append(wf)
@@ -401,7 +398,7 @@ class DeployWorkflow:
             task_queue=params.power_params.task_queue,
             start_to_close_timeout=POWER_ACTION_ACTIVITY_TIMEOUT,
             retry_policy=RetryPolicy(
-                maximum_interval=DEFAULT_DEPLOY_RETRY_TIMEOUT
+                maximum_attempts=3,
             ),
         )
 
@@ -418,7 +415,7 @@ class DeployWorkflow:
                 task_queue=params.power_params.task_queue,
                 start_to_close_timeout=POWER_ACTION_ACTIVITY_TIMEOUT,
                 retry_policy=RetryPolicy(
-                    maximum_interval=DEFAULT_DEPLOY_RETRY_TIMEOUT
+                    maximum_attempts=3,
                 ),
             )
         else:
@@ -434,7 +431,7 @@ class DeployWorkflow:
                 task_queue=params.power_params.task_queue,
                 start_to_close_timeout=POWER_ACTION_ACTIVITY_TIMEOUT,
                 retry_policy=RetryPolicy(
-                    maximum_interval=DEFAULT_DEPLOY_RETRY_TIMEOUT,
+                    maximum_attempts=3,
                 ),
             )
         if new_result["state"] != result["state"]:
@@ -475,7 +472,7 @@ class DeployWorkflow:
                 task_queue=params.power_params.task_queue,
                 start_to_close_timeout=POWER_ACTION_ACTIVITY_TIMEOUT,
                 retry_policy=RetryPolicy(
-                    maximum_interval=DEFAULT_DEPLOY_RETRY_TIMEOUT
+                    maximum_attempts=3,
                 ),
             )
         else:

--- a/src/tests/maastemporalworker/workflow/test_deploy.py
+++ b/src/tests/maastemporalworker/workflow/test_deploy.py
@@ -14,6 +14,7 @@ from temporalio.service import RPCError
 from temporalio.testing import ActivityEnvironment, WorkflowEnvironment
 from temporalio.worker import Worker
 
+from maascommon.constants import NODE_TIMEOUT
 from maascommon.enums.node import NodeStatus
 from maascommon.workflows.deploy import (
     DEPLOY_MANY_WORKFLOW_NAME,
@@ -40,6 +41,8 @@ from maastemporalworker.workflow.deploy import (
     GET_BOOT_ORDER_ACTIVITY_NAME,
     GetBootOrderParam,
     GetBootOrderResult,
+    MARK_NODE_FAILED_ACTIVITY_NAME,
+    MarkNodeFailedParam,
     SET_BOOT_ORDER_ACTIVITY_NAME,
     SET_NODE_STATUS_ACTIVITY_NAME,
     SetBootOrderParam,
@@ -940,6 +943,125 @@ class TestDeployManyWorkflow:
                 assert len(calls["power_cycle"]) == 0
                 assert len(calls["set_power_state"]) == 3
                 assert len(calls["power_reset"]) == 0
+
+    async def test_power_on_always_failing_marks_node_failed_deployment(
+        self,
+        fixture: Fixture,
+        db_connection: AsyncConnection,
+        db: Database,
+    ) -> None:
+        bmc = await create_test_bmc_entry(fixture)
+        machine = await create_test_machine_entry(fixture, bmc_id=bmc["id"])
+        subnet = await create_test_subnet_entry(fixture)
+        [ip] = await create_test_staticipaddress_entry(fixture, subnet=subnet)
+        await create_test_interface_dict(fixture, node=machine, ips=[ip])
+        await create_test_blockdevice_entry(fixture, node=machine)
+
+        deploy_timeout_minutes = 2 * NODE_TIMEOUT
+        deploy_many_timeout_minutes = 2 * NODE_TIMEOUT + 10
+
+        calls = defaultdict(list)
+
+        @activity.defn(name=SET_NODE_STATUS_ACTIVITY_NAME)
+        async def set_node_status(params: SetNodeStatusParam) -> None:
+            calls["set_node_status"].append(params.status)
+
+        @activity.defn(name=GET_BOOT_ORDER_ACTIVITY_NAME)
+        async def get_boot_order(
+            params: GetBootOrderParam,
+        ) -> GetBootOrderResult:
+            calls["get_boot_order"].append(True)
+            return GetBootOrderResult(system_id=params.system_id, order=[])
+
+        @activity.defn(name=MARK_NODE_FAILED_ACTIVITY_NAME)
+        async def mark_node_failed(params: MarkNodeFailedParam) -> None:
+            calls["mark_node_failed"].append(params.system_id)
+
+        @activity.defn(name=POWER_QUERY_ACTIVITY_NAME)
+        async def power_query(params: PowerQueryParam) -> PowerQueryResult:
+            calls["power_query"].append(True)
+            return PowerQueryResult(state="off")
+
+        @activity.defn(name=POWER_ON_ACTIVITY_NAME)
+        async def power_on(params: PowerOnParam) -> PowerOnResult:
+            calls["power_on"].append(True)
+            raise RuntimeError("power on failed")
+
+        @activity.defn(name=POWER_CYCLE_ACTIVITY_NAME)
+        async def power_cycle(params: PowerCycleParam) -> PowerCycleResult:
+            calls["power_cycle"].append(True)
+            return PowerCycleResult(state="on")
+
+        @activity.defn(name=POWER_OFF_ACTIVITY_NAME)
+        async def power_off(params: PowerOffParam) -> PowerOffResult:
+            calls["power_off"].append(True)
+            return PowerOffResult(state="off")
+
+        @activity.defn(name=POWER_RESET_ACTIVITY_NAME)
+        async def power_reset(params: PowerResetParam) -> PowerResetResult:
+            calls["power_reset"].append(True)
+            return PowerResetResult(state="on")
+
+        @activity.defn(name=SET_POWER_STATE_ACTIVITY_NAME)
+        async def set_power_state(params: SetPowerStateParam) -> None:
+            calls["set_power_state"].append(True)
+
+        async with await WorkflowEnvironment.start_time_skipping() as env:
+            async with Worker(
+                env.client,
+                task_queue="region",
+                workflows=[DeployManyWorkflow, DeployWorkflow],
+                activities=[
+                    set_node_status,
+                    get_boot_order,
+                    mark_node_failed,
+                    power_query,
+                    power_cycle,
+                    power_on,
+                    power_off,
+                    power_reset,
+                    set_power_state,
+                ],
+            ) as worker:
+                wf = await env.client.start_workflow(
+                    DEPLOY_MANY_WORKFLOW_NAME,
+                    DeployManyParam(
+                        params=[
+                            DeployParam(
+                                system_id=machine["system_id"],
+                                ephemeral_deploy=False,
+                                can_set_boot_order=False,
+                                task_queue=worker.task_queue,
+                                power_params=PowerParam(
+                                    system_id=machine["system_id"],
+                                    driver_type=bmc["power_type"],
+                                    driver_opts=bmc["power_parameters"],
+                                    task_queue=worker.task_queue,
+                                    is_dpu=machine["is_dpu"],
+                                ),
+                                timeout=deploy_timeout_minutes,
+                            ),
+                        ],
+                    ),
+                    id=f"workflow-{uuid.uuid4()}",
+                    task_queue=worker.task_queue,
+                    execution_timeout=timedelta(
+                        minutes=deploy_many_timeout_minutes
+                    ),
+                )
+
+                await env.sleep(
+                    duration=timedelta(minutes=deploy_many_timeout_minutes + 5)
+                )
+                await wf.result()
+
+                assert len(calls["set_node_status"]) == 0
+                assert len(calls["mark_node_failed"]) == 1
+                assert calls["mark_node_failed"][0] == machine["system_id"]
+                assert len(calls["power_query"]) == 1
+                assert len(calls["power_on"]) == 3
+                assert len(calls["power_cycle"]) == 0
+                assert len(calls["set_power_state"]) == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- remove retry policy from DeployManyWorkflow child DeployWorkflow as there is no need to retry the full deployment workflow, but only the activities
- set a sane number of max_retries to power related activities. Use 3 attempts to match the activities of existing Power only workflows
- Set the DeployManyWorkflow to max timeout 10 minutes after the max timeout of the child DeployWorkflow to give the parent a chance to harvest the timeout errors of child. This is needed to provide the parent the option to set the machines as Failed Deployment

Resolves: LP:2147037
(cherry picked from commit d434a71dcec15ba976ce80fe9ed21b9a33cafec0)