### PR TITLE
fix: change python version used by RTD (#137)

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-22.04
+  os: ubuntu-24.04
   tools:
-    python: "3.11"
+    python: "3.12"
   jobs:
     post_checkout:
     - git fetch --unshallow || true


### PR DESCRIPTION
Our code uses some things that are not available in 3.11, like `override` from typing.