### PR TITLE
fix(deps): add assume_scheme to URLField for Django 6.0 compatibility

### DIFF
--- a/src/maasserver/fields.py
+++ b/src/maasserver/fields.py
@@ -569,6 +569,10 @@ class URLOrPPAFormField(forms.URLField):
     }
     default_validators = [URLOrPPAValidator()]
 
+    def __init__(self, **kwargs):
+        kwargs.setdefault("assume_scheme", "http")
+        super().__init__(**kwargs)
+
     def to_python(self, value):
         # Call grandparent method (CharField) to get string value.
         value = super(forms.URLField, self).to_python(value)

--- a/src/maasserver/forms/__init__.py
+++ b/src/maasserver/forms/__init__.py
@@ -1919,6 +1919,7 @@ class UbuntuForm(Form):
             "Archive used by nodes to retrieve packages for Intel "
             "architectures, e.g. http://archive.ubuntu.com/ubuntu."
         ),
+        assume_scheme="http",
     )
     ports_archive = forms.URLField(
         label="Ports archive",
@@ -1927,6 +1928,7 @@ class UbuntuForm(Form):
             "Archive used by nodes to retrieve packages for non-Intel "
             "architectures, e.g. http://ports.ubuntu.com/ubuntu-ports."
         ),
+        assume_scheme="http",
     )
 
     def __init__(self, *args, **kwargs):

--- a/src/maasserver/forms/settings.py
+++ b/src/maasserver/forms/settings.py
@@ -411,6 +411,7 @@ CONFIG_ITEMS = {
             "label": HttpProxyConfig.description,
             "required": False,
             "help_text": HttpProxyConfig.help_text,
+            "assume_scheme": "http",
         },
     },
     DefaultDnsTtlConfig.name: {


### PR DESCRIPTION
Django 6.0 will change the default URL scheme from 'http' to 'https'. Explicitly set assume_scheme='http' for URLField declarations to silence RemovedInDjango60Warning and maintain current behavior.