### PR TITLE
build: fix binary source paths in debian install files

### DIFF
--- a/debian/maas-agent.install
+++ b/debian/maas-agent.install
@@ -1,3 +1,3 @@
 debian/extras/99-maas-agent-sudoers etc/sudoers.d
 
-bin/maas-agent usr/sbin
+usr/sbin/maas-agent

--- a/debian/maas-netmon.install
+++ b/debian/maas-netmon.install
@@ -1,3 +1,3 @@
 debian/extras/99-maas-netmon-sudoers etc/sudoers.d
 
-bin/maas-netmon usr/sbin
+usr/sbin/maas-netmon

--- a/debian/maas-region-api.install
+++ b/debian/maas-region-api.install
@@ -27,6 +27,6 @@ usr/bin/maas-temporal-worker usr/sbin
 debian/tmp/usr/lib/python3*/dist-packages/maasservicelayer
 
 # Install OpenFGA binaries
-bin/maas-openfga usr/sbin
-bin/maas-openfga-migrator usr/sbin
-bin/maas-openfga-app-migrator usr/sbin
+usr/sbin/maas-openfga
+usr/sbin/maas-openfga-migrator
+usr/sbin/maas-openfga-app-migrator


### PR DESCRIPTION
Corrects the source paths for maas-agent, maas-netmon, and OpenFGA binaries in their respective .install files from bin/ to usr/sbin/, matching the actual build output locations.