### PR TITLE
feat(maasservicelayer): add bulk-remove and bulk-create operations for users and entitlements in groups

### DIFF
--- a/src/maasapiserver/v3/api/public/handlers/usergroups.py
+++ b/src/maasapiserver/v3/api/public/handlers/usergroups.py
@@ -1,10 +1,10 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from typing import Union
+from typing import Annotated, Union
 
 from fastapi import Depends, Header, Query, Response
-from pydantic import conlist
+from pydantic import Field
 from starlette import status
 
 from maasapiserver.common.api.base import Handler, handler
@@ -61,6 +61,7 @@ from maasservicelayer.exceptions.constants import (
     INVALID_ARGUMENT_VIOLATION_TYPE,
     USER_ALREADY_IN_GROUP,
 )
+from maasservicelayer.models.fields import UniqueList
 from maasservicelayer.services import ServiceCollectionV3
 from maasservicelayer.services.openfga_tuples import EntitlementsBuilderFactory
 from maasservicelayer.services.usergroups import (
@@ -527,7 +528,7 @@ class UserGroupsHandler(Handler):
     async def bulk_remove_group_members(
         self,
         group_id: int,
-        ids: conlist(int, min_items=1, unique_items=True) = Query(  # pyright: ignore[reportInvalidTypeForm] # noqa: B008
+        ids: Annotated[UniqueList[int], Field(min_length=1)] = Query(  # noqa: B008
             description="ids of users to remove from the group", alias="id"
         ),
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008

--- a/src/maasapiserver/v3/api/public/handlers/usergroups.py
+++ b/src/maasapiserver/v3/api/public/handlers/usergroups.py
@@ -724,9 +724,6 @@ class UserGroupsHandler(Handler):
 
         await services.openfga_tuples.bulk_delete_entitlements(
             group_id,
-            [
-                (item.entitlement, item.resource_type, item.resource_id)
-                for item in bulk_request.items
-            ],
+            items=[item.to_spec() for item in bulk_request.items],
         )
         return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/maasapiserver/v3/api/public/handlers/usergroups.py
+++ b/src/maasapiserver/v3/api/public/handlers/usergroups.py
@@ -422,7 +422,7 @@ class UserGroupsHandler(Handler):
         return Response(status_code=200)
 
     @handler(
-        path="/groups/{group_id}/members:batchCreate",
+        path="/groups/{group_id}/members:batch_create",
         methods=["POST"],
         tags=TAGS,
         responses={
@@ -679,7 +679,7 @@ class UserGroupsHandler(Handler):
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @handler(
-        path="/groups/{group_id}/entitlements:batchDelete",
+        path="/groups/{group_id}/entitlements:batch_delete",
         methods=["POST"],
         tags=TAGS,
         responses={

--- a/src/maasapiserver/v3/api/public/handlers/usergroups.py
+++ b/src/maasapiserver/v3/api/public/handlers/usergroups.py
@@ -4,6 +4,7 @@
 from typing import Union
 
 from fastapi import Depends, Header, Query, Response
+from pydantic import conlist
 from starlette import status
 
 from maasapiserver.common.api.base import Handler, handler
@@ -14,10 +15,12 @@ from maasapiserver.common.api.models.responses.errors import (
 )
 from maasapiserver.v3.api import services
 from maasapiserver.v3.api.public.models.requests.entitlements import (
+    BulkEntitlementDeleteRequest,
     EntitlementRequest,
 )
 from maasapiserver.v3.api.public.models.requests.query import PaginationParams
 from maasapiserver.v3.api.public.models.requests.usergroup_members import (
+    BulkGroupMemberRequest,
     UserGroupMemberRequest,
 )
 from maasapiserver.v3.api.public.models.requests.usergroups import (
@@ -334,18 +337,31 @@ class UserGroupsHandler(Handler):
     async def list_group_members(
         self,
         group_id: int,
+        pagination_params: PaginationParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> UserGroupMembersListResponse:
         group = await services.usergroups.get_by_id(group_id)
         if not group:
             raise NotFoundException()
 
-        members = await services.usergroups.list_usergroup_members(group_id)
+        members = await services.usergroups.list_usergroup_members_page(
+            group_id,
+            page=pagination_params.page,
+            size=pagination_params.size,
+        )
+        next_link = None
+        if members.has_next(pagination_params.page, pagination_params.size):
+            next_link = (
+                f"{V3_API_PREFIX}/groups/{group_id}/members?"
+                f"{pagination_params.to_next_href_format()}"
+            )
         return UserGroupMembersListResponse(
             items=[
                 UserGroupMemberResponse.from_model(member)
-                for member in members
+                for member in members.items
             ],
+            total=members.total,
+            next=next_link,
         )
 
     @handler(
@@ -405,6 +421,63 @@ class UserGroupsHandler(Handler):
         return Response(status_code=200)
 
     @handler(
+        path="/groups/{group_id}/members:batchCreate",
+        methods=["POST"],
+        tags=TAGS,
+        responses={
+            200: {},
+            404: {"model": NotFoundBodyResponse},
+            409: {"model": ConflictBodyResponse},
+        },
+        response_model_exclude_none=True,
+        status_code=200,
+        dependencies=[
+            Depends(
+                check_permissions(
+                    openfga_permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES
+                )
+            )
+        ],
+    )
+    async def bulk_add_group_members(
+        self,
+        group_id: int,
+        bulk_request: BulkGroupMemberRequest,
+        services: ServiceCollectionV3 = Depends(services),  # noqa: B008
+    ) -> Response:
+        group = await services.usergroups.get_by_id(group_id)
+        if not group:
+            raise NotFoundException()
+
+        for user_id in bulk_request.user_ids:
+            user = await services.users.get_by_id(id=user_id)
+            if not user:
+                raise NotFoundException(
+                    details=[
+                        BaseExceptionDetail(
+                            type=INVALID_ARGUMENT_VIOLATION_TYPE,
+                            message=f"User with ID `{user_id}` not found.",
+                        )
+                    ]
+                )
+
+        try:
+            await services.usergroups.bulk_add_users_to_group(
+                group_id, bulk_request.user_ids
+            )
+        except UserAlreadyInGroup as err:
+            raise ConflictException(
+                details=[
+                    BaseExceptionDetail(
+                        type=USER_ALREADY_IN_GROUP,
+                        message=str(err),
+                    )
+                ]
+            ) from err
+
+        return Response(status_code=200)
+
+    @handler(
         path="/groups/{group_id}/members/{user_id}",
         methods=["DELETE"],
         tags=TAGS,
@@ -434,6 +507,38 @@ class UserGroupsHandler(Handler):
         await services.usergroups.remove_user_from_group(group_id, user_id)
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
+    @handler(
+        path="/groups/{group_id}/members",
+        methods=["DELETE"],
+        tags=TAGS,
+        responses={
+            204: {},
+            404: {"model": NotFoundBodyResponse},
+        },
+        status_code=204,
+        dependencies=[
+            Depends(
+                check_permissions(
+                    openfga_permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES
+                )
+            )
+        ],
+    )
+    async def bulk_remove_group_members(
+        self,
+        group_id: int,
+        ids: conlist(int, min_items=1, unique_items=True) = Query(  # pyright: ignore[reportInvalidTypeForm] # noqa: B008
+            description="ids of users to remove from the group", alias="id"
+        ),
+        services: ServiceCollectionV3 = Depends(services),  # noqa: B008
+    ):
+        group = await services.usergroups.get_by_id(group_id)
+        if not group:
+            raise NotFoundException()
+
+        await services.usergroups.bulk_remove_users_from_group(group_id, ids)
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
     # Entitlement endpoints
 
     @handler(
@@ -459,17 +564,32 @@ class UserGroupsHandler(Handler):
     async def list_group_entitlements(
         self,
         group_id: int,
+        pagination_params: PaginationParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> EntitlementsListResponse:
         group = await services.usergroups.get_by_id(group_id)
         if not group:
             raise NotFoundException()
 
-        entitlements = await services.openfga_tuples.list_entitlements(
-            group_id
+        entitlements = await services.openfga_tuples.list_entitlements_page(
+            group_id,
+            page=pagination_params.page,
+            size=pagination_params.size,
         )
+        next_link = None
+        if entitlements.has_next(
+            pagination_params.page, pagination_params.size
+        ):
+            next_link = (
+                f"{V3_API_PREFIX}/groups/{group_id}/entitlements?"
+                f"{pagination_params.to_next_href_format()}"
+            )
         return EntitlementsListResponse(
-            items=[EntitlementResponse.from_model(t) for t in entitlements],
+            items=[
+                EntitlementResponse.from_model(e) for e in entitlements.items
+            ],
+            total=entitlements.total,
+            next=next_link,
         )
 
     @handler(
@@ -554,5 +674,58 @@ class UserGroupsHandler(Handler):
 
         await services.openfga_tuples.delete_entitlement(
             group_id, entitlement, resource_type, resource_id
+        )
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    @handler(
+        path="/groups/{group_id}/entitlements:batchDelete",
+        methods=["POST"],
+        tags=TAGS,
+        responses={
+            204: {},
+            400: {"model": BadRequestBodyResponse},
+            404: {"model": NotFoundBodyResponse},
+        },
+        status_code=204,
+        dependencies=[
+            Depends(
+                check_permissions(
+                    openfga_permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES
+                )
+            )
+        ],
+    )
+    async def bulk_remove_group_entitlements(
+        self,
+        group_id: int,
+        bulk_request: BulkEntitlementDeleteRequest,
+        services: ServiceCollectionV3 = Depends(services),  # noqa: B008
+    ) -> Response:
+        group = await services.usergroups.get_by_id(group_id)
+        if not group:
+            raise NotFoundException()
+
+        for item in bulk_request.items:
+            is_valid, error_message = (
+                EntitlementsBuilderFactory.validate_entitlement(
+                    item.entitlement, item.resource_type
+                )
+            )
+            if not is_valid:
+                raise BadRequestException(
+                    details=[
+                        BaseExceptionDetail(
+                            type=INVALID_ARGUMENT_VIOLATION_TYPE,
+                            message=error_message,  # type: ignore[reportArgumentType]
+                        )
+                    ]
+                )
+
+        await services.openfga_tuples.bulk_delete_entitlements(
+            group_id,
+            [
+                (item.entitlement, item.resource_type, item.resource_id)
+                for item in bulk_request.items
+            ],
         )
         return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/src/maasapiserver/v3/api/public/models/requests/entitlements.py
+++ b/src/maasapiserver/v3/api/public/models/requests/entitlements.py
@@ -1,7 +1,7 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, conlist, Field
 
 from maascommon.openfga.base import OpenFGAEntitlementResourceType
 from maasservicelayer.db.filters import QuerySpec
@@ -74,3 +74,15 @@ class EntitlementRequest(BaseModel):
                     ]
                 )
         return factory.build_tuple(group_id, self.resource_id)
+
+
+class BulkEntitlementDeleteItem(BaseModel):
+    resource_type: OpenFGAEntitlementResourceType = Field(
+        description="The resource type (e.g. 'maas', 'pool')."
+    )
+    resource_id: int = Field(description="The resource ID.")
+    entitlement: str = Field(description="The entitlement name.")
+
+
+class BulkEntitlementDeleteRequest(BaseModel):
+    items: conlist(BulkEntitlementDeleteItem, min_items=1)  # pyright: ignore[reportInvalidTypeForm]

--- a/src/maasapiserver/v3/api/public/models/requests/entitlements.py
+++ b/src/maasapiserver/v3/api/public/models/requests/entitlements.py
@@ -19,6 +19,7 @@ from maasservicelayer.exceptions.constants import (
     INVALID_ARGUMENT_VIOLATION_TYPE,
 )
 from maasservicelayer.models.fields import UniqueList
+from maasservicelayer.models.openfga_tuple import EntitlementDeleteSpec
 from maasservicelayer.services import ServiceCollectionV3
 from maasservicelayer.services.openfga_tuples import (
     EntitlementsBuilderFactory,
@@ -87,6 +88,13 @@ class BulkEntitlementDeleteItem(BaseModel):
     )
     resource_id: int = Field(description="The resource ID.")
     entitlement: str = Field(description="The entitlement name.")
+
+    def to_spec(self) -> EntitlementDeleteSpec:
+        return EntitlementDeleteSpec(
+            entitlement=self.entitlement,
+            resource_type=self.resource_type,
+            resource_id=self.resource_id,
+        )
 
 
 class BulkEntitlementDeleteRequest(BaseModel):

--- a/src/maasapiserver/v3/api/public/models/requests/entitlements.py
+++ b/src/maasapiserver/v3/api/public/models/requests/entitlements.py
@@ -1,7 +1,9 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from pydantic import BaseModel, conlist, Field
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field
 
 from maascommon.openfga.base import OpenFGAEntitlementResourceType
 from maasservicelayer.db.filters import QuerySpec
@@ -16,6 +18,7 @@ from maasservicelayer.exceptions.catalog import (
 from maasservicelayer.exceptions.constants import (
     INVALID_ARGUMENT_VIOLATION_TYPE,
 )
+from maasservicelayer.models.fields import UniqueList
 from maasservicelayer.services import ServiceCollectionV3
 from maasservicelayer.services.openfga_tuples import (
     EntitlementsBuilderFactory,
@@ -77,6 +80,8 @@ class EntitlementRequest(BaseModel):
 
 
 class BulkEntitlementDeleteItem(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     resource_type: OpenFGAEntitlementResourceType = Field(
         description="The resource type (e.g. 'maas', 'pool')."
     )
@@ -85,4 +90,6 @@ class BulkEntitlementDeleteItem(BaseModel):
 
 
 class BulkEntitlementDeleteRequest(BaseModel):
-    items: conlist(BulkEntitlementDeleteItem, min_items=1)  # pyright: ignore[reportInvalidTypeForm]
+    items: Annotated[
+        UniqueList[BulkEntitlementDeleteItem], Field(min_length=1)  # type: ignore[valid-type]
+    ]

--- a/src/maasapiserver/v3/api/public/models/requests/usergroup_members.py
+++ b/src/maasapiserver/v3/api/public/models/requests/usergroup_members.py
@@ -1,7 +1,11 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from pydantic import BaseModel, conlist, Field
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+from maasservicelayer.models.fields import UniqueList
 
 
 class UserGroupMemberRequest(BaseModel):
@@ -9,6 +13,6 @@ class UserGroupMemberRequest(BaseModel):
 
 
 class BulkGroupMemberRequest(BaseModel):
-    user_ids: conlist(int, min_items=1) = Field(  # pyright: ignore[reportInvalidTypeForm]
+    user_ids: Annotated[UniqueList[int], Field(min_length=1)] = Field(  # pyright: ignore[reportInvalidTypeForm]
         description="The IDs of the users to add to the group."
     )

--- a/src/maasapiserver/v3/api/public/models/requests/usergroup_members.py
+++ b/src/maasapiserver/v3/api/public/models/requests/usergroup_members.py
@@ -1,8 +1,14 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, conlist, Field
 
 
 class UserGroupMemberRequest(BaseModel):
     user_id: int = Field(description="The ID of the user to add to the group.")
+
+
+class BulkGroupMemberRequest(BaseModel):
+    user_ids: conlist(int, min_items=1) = Field(  # pyright: ignore[reportInvalidTypeForm]
+        description="The IDs of the users to add to the group."
+    )

--- a/src/maasapiserver/v3/api/public/models/responses/entitlements.py
+++ b/src/maasapiserver/v3/api/public/models/responses/entitlements.py
@@ -5,6 +5,7 @@ from typing import Self
 
 from pydantic import BaseModel
 
+from maasapiserver.v3.api.public.models.responses.base import PaginatedResponse
 from maasservicelayer.models.openfga_tuple import OpenFGATuple
 
 
@@ -23,6 +24,5 @@ class EntitlementResponse(BaseModel):
         )
 
 
-class EntitlementsListResponse(BaseModel):
+class EntitlementsListResponse(PaginatedResponse[EntitlementResponse]):
     kind = "EntitlementsList"
-    items: list[EntitlementResponse]

--- a/src/maasapiserver/v3/api/public/models/responses/entitlements.py
+++ b/src/maasapiserver/v3/api/public/models/responses/entitlements.py
@@ -5,6 +5,7 @@ from typing import Self
 
 from pydantic import BaseModel, Field
 
+from maasapiserver.v3.api.public.models.responses.base import PaginatedResponse
 from maasservicelayer.models.openfga_tuple import OpenFGATuple
 
 
@@ -23,6 +24,5 @@ class EntitlementResponse(BaseModel):
         )
 
 
-class EntitlementsListResponse(BaseModel):
-    kind: str = Field(default="EntitlementsList")
-    items: list[EntitlementResponse]
+class EntitlementsListResponse(PaginatedResponse[EntitlementResponse]):
+    kind = "EntitlementsList"

--- a/src/maasapiserver/v3/api/public/models/responses/entitlements.py
+++ b/src/maasapiserver/v3/api/public/models/responses/entitlements.py
@@ -25,4 +25,4 @@ class EntitlementResponse(BaseModel):
 
 
 class EntitlementsListResponse(PaginatedResponse[EntitlementResponse]):
-    kind = "EntitlementsList"
+    kind: str = Field(default="EntitlementsList")

--- a/src/maasapiserver/v3/api/public/models/responses/usergroup_members.py
+++ b/src/maasapiserver/v3/api/public/models/responses/usergroup_members.py
@@ -5,6 +5,7 @@ from typing import Self
 
 from pydantic import BaseModel
 
+from maasapiserver.v3.api.public.models.responses.base import PaginatedResponse
 from maasservicelayer.models.usergroup_members import UserGroupMember
 
 
@@ -23,6 +24,5 @@ class UserGroupMemberResponse(BaseModel):
         )
 
 
-class UserGroupMembersListResponse(BaseModel):
+class UserGroupMembersListResponse(PaginatedResponse[UserGroupMemberResponse]):
     kind = "UserGroupMembersList"
-    items: list[UserGroupMemberResponse]

--- a/src/maasapiserver/v3/api/public/models/responses/usergroup_members.py
+++ b/src/maasapiserver/v3/api/public/models/responses/usergroup_members.py
@@ -25,4 +25,4 @@ class UserGroupMemberResponse(BaseModel):
 
 
 class UserGroupMembersListResponse(PaginatedResponse[UserGroupMemberResponse]):
-    kind = "UserGroupMembersList"
+    kind: str = Field(default="UserGroupMembersList")

--- a/src/maasapiserver/v3/api/public/models/responses/usergroup_members.py
+++ b/src/maasapiserver/v3/api/public/models/responses/usergroup_members.py
@@ -5,6 +5,7 @@ from typing import Self
 
 from pydantic import BaseModel, Field
 
+from maasapiserver.v3.api.public.models.responses.base import PaginatedResponse
 from maasservicelayer.models.usergroup_members import UserGroupMember
 
 
@@ -23,6 +24,5 @@ class UserGroupMemberResponse(BaseModel):
         )
 
 
-class UserGroupMembersListResponse(BaseModel):
-    kind: str = Field(default="UserGroupMembersList")
-    items: list[UserGroupMemberResponse]
+class UserGroupMembersListResponse(PaginatedResponse[UserGroupMemberResponse]):
+    kind = "UserGroupMembersList"

--- a/src/maasservicelayer/db/repositories/openfga_tuples.py
+++ b/src/maasservicelayer/db/repositories/openfga_tuples.py
@@ -17,7 +17,10 @@ from maasservicelayer.db.mappers.base import (
 from maasservicelayer.db.repositories.base import Repository
 from maasservicelayer.db.tables import OpenFGATupleTable
 from maasservicelayer.models.base import ListResult, ResourceBuilder
-from maasservicelayer.models.openfga_tuple import OpenFGATuple
+from maasservicelayer.models.openfga_tuple import (
+    EntitlementDeleteSpec,
+    OpenFGATuple,
+)
 from maasservicelayer.utils.date import utcnow
 
 
@@ -46,18 +49,18 @@ class OpenFGATuplesClauseFactory(ClauseFactory):
 
     @classmethod
     def with_entitlement_tuples(
-        cls, tuples: list[tuple[str, str, str]]
+        cls, specs: list[EntitlementDeleteSpec]
     ) -> Clause:
         return cls.or_clauses(
             [
                 cls.and_clauses(
                     [
-                        cls.with_relation(relation),
-                        cls.with_object_type(object_type),
-                        cls.with_object_id(object_id),
+                        cls.with_relation(spec.entitlement),
+                        cls.with_object_type(spec.resource_type),
+                        cls.with_object_id(str(spec.resource_id)),
                     ]
                 )
-                for relation, object_type, object_id in tuples
+                for spec in specs
             ]
         )
 

--- a/src/maasservicelayer/db/repositories/openfga_tuples.py
+++ b/src/maasservicelayer/db/repositories/openfga_tuples.py
@@ -1,8 +1,9 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, desc, select
 from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.sql.functions import count
 from sqlalchemy.sql.operators import eq
 
 from maascommon.enums.openfga import OPENFGA_STORE_ID
@@ -15,7 +16,7 @@ from maasservicelayer.db.mappers.base import (
 )
 from maasservicelayer.db.repositories.base import Repository
 from maasservicelayer.db.tables import OpenFGATupleTable
-from maasservicelayer.models.base import ResourceBuilder
+from maasservicelayer.models.base import ListResult, ResourceBuilder
 from maasservicelayer.models.openfga_tuple import OpenFGATuple
 from maasservicelayer.utils.date import utcnow
 
@@ -38,6 +39,27 @@ class OpenFGATuplesClauseFactory(ClauseFactory):
     @classmethod
     def with_user(cls, user: str) -> Clause:
         return Clause(condition=eq(OpenFGATupleTable.c._user, user))
+
+    @classmethod
+    def with_users(cls, users: list[str]) -> Clause:
+        return Clause(condition=OpenFGATupleTable.c._user.in_(users))
+
+    @classmethod
+    def with_entitlement_tuples(
+        cls, tuples: list[tuple[str, str, str]]
+    ) -> Clause:
+        return cls.or_clauses(
+            [
+                cls.and_clauses(
+                    [
+                        cls.with_relation(relation),
+                        cls.with_object_type(object_type),
+                        cls.with_object_id(object_id),
+                    ]
+                )
+                for relation, object_type, object_id in tuples
+            ]
+        )
 
 
 class OpenFGATuplesDataMapper(BaseDomainDataMapper):
@@ -109,7 +131,56 @@ class OpenFGATuplesRepository(Repository):
         result_dict["user"] = result_dict.pop("_user")
         return OpenFGATuple(**result_dict)
 
+    async def bulk_upsert(self, builders: list[OpenFGATupleBuilder]) -> None:
+        if not builders:
+            return
+        new_timestamp = utcnow()
+        values_list = [
+            {
+                **self.get_mapper().build_resource(builder).get_values(),
+                "store": OPENFGA_STORE_ID,
+                "inserted_at": new_timestamp,
+                "ulid": generate_ulid(),
+            }
+            for builder in builders
+        ]
+        stmt = insert(OpenFGATupleTable).values(values_list)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[
+                "store",
+                "object_type",
+                "object_id",
+                "relation",
+                "_user",
+            ],
+            set_={"inserted_at": new_timestamp},
+        )
+        await self.execute_stmt(stmt)
+
     async def delete_many(self, query: QuerySpec) -> None:
         stmt = delete(OpenFGATupleTable).returning(OpenFGATupleTable)
         stmt = query.enrich_stmt(stmt)
         await self.execute_stmt(stmt)
+
+    async def list_entitlements(
+        self, page: int, size: int, query: QuerySpec
+    ) -> ListResult[OpenFGATuple]:
+        total_stmt = select(count()).select_from(OpenFGATupleTable)
+        total_stmt = query.enrich_stmt(total_stmt)
+        total = (await self.execute_stmt(total_stmt)).scalar_one()
+
+        stmt = (
+            select(OpenFGATupleTable)
+            .select_from(OpenFGATupleTable)
+            .order_by(desc(OpenFGATupleTable.c.inserted_at))
+            .offset((page - 1) * size)
+            .limit(size)
+        )
+        stmt = query.enrich_stmt(stmt)
+        result = await self.execute_stmt(stmt)
+        items = []
+        for row in result:
+            row_asdict = row._asdict()
+            row_asdict["user"] = row_asdict.pop("_user")
+            items.append(OpenFGATuple(**row_asdict))
+        return ListResult(items=items, total=total)

--- a/src/maasservicelayer/db/repositories/usergroups_members.py
+++ b/src/maasservicelayer/db/repositories/usergroups_members.py
@@ -25,6 +25,10 @@ class UserGroupMembersClauseFactory(ClauseFactory):
     def with_id(cls, user_id: int) -> Clause:
         return Clause(condition=eq(UserGroupMembersView.c.id, user_id))
 
+    @classmethod
+    def with_ids(cls, user_ids: list[int]) -> Clause:
+        return Clause(condition=UserGroupMembersView.c.id.in_(user_ids))
+
 
 class UserGroupMembersRepository(ReadOnlyRepository[UserGroupMember]):
     def get_repository_table(self) -> Table:

--- a/src/maasservicelayer/models/openfga_tuple.py
+++ b/src/maasservicelayer/models/openfga_tuple.py
@@ -1,9 +1,19 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
+from dataclasses import dataclass
+
 from pydantic import BaseModel
 
+from maascommon.openfga.base import OpenFGAEntitlementResourceType
 from maasservicelayer.models.base import generate_builder
+
+
+@dataclass(frozen=True)
+class EntitlementDeleteSpec:
+    entitlement: str
+    resource_type: OpenFGAEntitlementResourceType
+    resource_id: int
 
 
 @generate_builder()

--- a/src/maasservicelayer/services/openfga_tuples.py
+++ b/src/maasservicelayer/services/openfga_tuples.py
@@ -13,7 +13,10 @@ from maasservicelayer.db.repositories.openfga_tuples import (
     OpenFGATuplesRepository,
 )
 from maasservicelayer.models.base import ListResult
-from maasservicelayer.models.openfga_tuple import OpenFGATuple
+from maasservicelayer.models.openfga_tuple import (
+    EntitlementDeleteSpec,
+    OpenFGATuple,
+)
 from maasservicelayer.services.base import Service, ServiceCache
 
 
@@ -315,19 +318,15 @@ class OpenFGATupleService(Service):
     async def bulk_delete_entitlements(
         self,
         group_id: int,
-        items: list[tuple[str, str, int]],
+        items: list[EntitlementDeleteSpec],
     ) -> None:
-        tuples = [
-            (entitlement_name, resource_type, str(resource_id))
-            for entitlement_name, resource_type, resource_id in items
-        ]
         query = QuerySpec(
             where=OpenFGATuplesClauseFactory.and_clauses(
                 [
                     OpenFGATuplesClauseFactory.with_user(
                         f"group:{group_id}#member"
                     ),
-                    OpenFGATuplesClauseFactory.with_entitlement_tuples(tuples),
+                    OpenFGATuplesClauseFactory.with_entitlement_tuples(items),
                 ]
             )
         )

--- a/src/maasservicelayer/services/openfga_tuples.py
+++ b/src/maasservicelayer/services/openfga_tuples.py
@@ -12,6 +12,7 @@ from maasservicelayer.db.repositories.openfga_tuples import (
     OpenFGATuplesClauseFactory,
     OpenFGATuplesRepository,
 )
+from maasservicelayer.models.base import ListResult
 from maasservicelayer.models.openfga_tuple import OpenFGATuple
 from maasservicelayer.services.base import Service, ServiceCache
 
@@ -229,6 +230,31 @@ class OpenFGATupleService(Service):
         )
         await self.delete_many(query)
 
+    async def bulk_remove_users_from_group(
+        self, group_id: int, user_ids: list[int]
+    ) -> None:
+        users = [f"user:{user_id}" for user_id in user_ids]
+        query = QuerySpec(
+            where=OpenFGATuplesClauseFactory.and_clauses(
+                [
+                    OpenFGATuplesClauseFactory.with_users(users),
+                    OpenFGATuplesClauseFactory.with_relation("member"),
+                    OpenFGATuplesClauseFactory.with_object_type("group"),
+                    OpenFGATuplesClauseFactory.with_object_id(str(group_id)),
+                ]
+            )
+        )
+        await self.delete_many(query)
+
+    async def bulk_add_users_to_group(
+        self, group_id: int, user_ids: list[int]
+    ) -> None:
+        builders = [
+            OpenFGATupleBuilder.build_user_member_group(user_id, group_id)
+            for user_id in user_ids
+        ]
+        await self.openfga_tuple_repository.bulk_upsert(builders)
+
     async def list_entitlements(
         self,
         group_id: int,
@@ -243,6 +269,25 @@ class OpenFGATupleService(Service):
             )
         )
         return await self.get_many(query)
+
+    async def list_entitlements_page(
+        self,
+        group_id: int,
+        page: int,
+        size: int,
+    ) -> ListResult[OpenFGATuple]:
+        query = QuerySpec(
+            where=OpenFGATuplesClauseFactory.and_clauses(
+                [
+                    OpenFGATuplesClauseFactory.with_user(
+                        f"group:{group_id}#member"
+                    )
+                ]
+            )
+        )
+        return await self.openfga_tuple_repository.list_entitlements(
+            page, size, query
+        )
 
     async def delete_entitlement(
         self,
@@ -262,6 +307,27 @@ class OpenFGATupleService(Service):
                     OpenFGATuplesClauseFactory.with_object_id(
                         str(resource_id)
                     ),
+                ]
+            )
+        )
+        await self.delete_many(query)
+
+    async def bulk_delete_entitlements(
+        self,
+        group_id: int,
+        items: list[tuple[str, str, int]],
+    ) -> None:
+        tuples = [
+            (entitlement_name, resource_type, str(resource_id))
+            for entitlement_name, resource_type, resource_id in items
+        ]
+        query = QuerySpec(
+            where=OpenFGATuplesClauseFactory.and_clauses(
+                [
+                    OpenFGATuplesClauseFactory.with_user(
+                        f"group:{group_id}#member"
+                    ),
+                    OpenFGATuplesClauseFactory.with_entitlement_tuples(tuples),
                 ]
             )
         )

--- a/src/maasservicelayer/services/usergroups.py
+++ b/src/maasservicelayer/services/usergroups.py
@@ -102,6 +102,17 @@ class UserGroupsService(
             )
         )
 
+    async def list_usergroup_members_page(
+        self, group_id: int, page: int, size: int
+    ) -> ListResult[UserGroupMember]:
+        return await self.usergroup_members_repository.list(
+            page=page,
+            size=size,
+            query=QuerySpec(
+                where=UserGroupMembersClauseFactory.with_group_id(group_id)
+            ),
+        )
+
     async def list_groups_statistics(
         self,
         page: int,
@@ -115,4 +126,32 @@ class UserGroupsService(
     async def remove_user_from_group(self, group_id: int, user_id: int):
         await self.openfga_tuples_service.remove_user_from_group(
             group_id, user_id
+        )
+
+    async def bulk_add_users_to_group(
+        self, group_id: int, user_ids: List[int]
+    ) -> None:
+        already_member = await self.usergroup_members_repository.exists(
+            QuerySpec(
+                where=UserGroupMembersClauseFactory.and_clauses(
+                    [
+                        UserGroupMembersClauseFactory.with_group_id(group_id),
+                        UserGroupMembersClauseFactory.with_ids(user_ids),
+                    ]
+                )
+            )
+        )
+        if already_member:
+            raise UserAlreadyInGroup(
+                "One or more users are already members of the group."
+            )
+        await self.openfga_tuples_service.bulk_add_users_to_group(
+            group_id, user_ids
+        )
+
+    async def bulk_remove_users_from_group(
+        self, group_id: int, user_ids: List[int]
+    ) -> None:
+        await self.openfga_tuples_service.bulk_remove_users_from_group(
+            group_id, user_ids
         )

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_usergroups.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_usergroups.py
@@ -45,7 +45,10 @@ from maasservicelayer.exceptions.constants import (
     UNIQUE_CONSTRAINT_VIOLATION_TYPE,
 )
 from maasservicelayer.models.base import ListResult
-from maasservicelayer.models.openfga_tuple import OpenFGATuple
+from maasservicelayer.models.openfga_tuple import (
+    EntitlementDeleteSpec,
+    OpenFGATuple,
+)
 from maasservicelayer.models.usergroup_members import UserGroupMember
 from maasservicelayer.models.usergroups import UserGroup, UserGroupStatistics
 from maasservicelayer.models.users import User
@@ -1232,9 +1235,17 @@ class TestUserGroupsApi(ApiCommonTests):
         assert response.status_code == 204
         services_mock.openfga_tuples.bulk_delete_entitlements.assert_called_once_with(
             TEST_GROUP.id,
-            [
-                ("can_edit_machines", "maas", 0),
-                ("can_edit_machines", "pool", 5),
+            items=[
+                EntitlementDeleteSpec(
+                    entitlement="can_edit_machines",
+                    resource_type="maas",
+                    resource_id=0,
+                ),
+                EntitlementDeleteSpec(
+                    entitlement="can_edit_machines",
+                    resource_type="pool",
+                    resource_id=5,
+                ),
             ],
         )
 

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_usergroups.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_usergroups.py
@@ -152,7 +152,7 @@ class TestUserGroupsApi(ApiCommonTests):
             ),
             Endpoint(
                 method="POST",
-                path=f"{self.BASE_PATH}/1/members:batchCreate",
+                path=f"{self.BASE_PATH}/1/members:batch_create",
                 permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
             ),
             Endpoint(
@@ -162,7 +162,7 @@ class TestUserGroupsApi(ApiCommonTests):
             ),
             Endpoint(
                 method="POST",
-                path=f"{self.BASE_PATH}/1/entitlements:batchDelete",
+                path=f"{self.BASE_PATH}/1/entitlements:batch_delete",
                 permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
             ),
         ]
@@ -1074,7 +1074,7 @@ class TestUserGroupsApi(ApiCommonTests):
         error_response = ErrorBodyResponse(**response.json())
         assert error_response.code == 400
 
-    # POST /groups/{group_id}/members:batchCreate
+    # POST /groups/{group_id}/members:batch_create
     async def test_bulk_add_members(
         self,
         services_mock: ServiceCollectionV3,
@@ -1091,7 +1091,7 @@ class TestUserGroupsApi(ApiCommonTests):
         services_mock.users.get_by_id.return_value = TEST_USER
 
         response = await client.post(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batchCreate",
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batch_create",
             json=jsonable_encoder(bulk_request),
         )
         assert response.status_code == 200
@@ -1109,7 +1109,7 @@ class TestUserGroupsApi(ApiCommonTests):
         services_mock.usergroups.get_by_id.return_value = None
 
         response = await client.post(
-            f"{self.BASE_PATH}/999/members:batchCreate",
+            f"{self.BASE_PATH}/999/members:batch_create",
             json=jsonable_encoder(bulk_request),
         )
         assert response.status_code == 404
@@ -1129,7 +1129,7 @@ class TestUserGroupsApi(ApiCommonTests):
         services_mock.users.get_by_id.return_value = None
 
         response = await client.post(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batchCreate",
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batch_create",
             json=jsonable_encoder(bulk_request),
         )
         assert response.status_code == 404
@@ -1152,7 +1152,7 @@ class TestUserGroupsApi(ApiCommonTests):
         services_mock.users.get_by_id.return_value = TEST_USER
 
         response = await client.post(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batchCreate",
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batch_create",
             json=jsonable_encoder(bulk_request),
         )
         assert response.status_code == 409
@@ -1193,7 +1193,7 @@ class TestUserGroupsApi(ApiCommonTests):
         )
         assert response.status_code == 404
 
-    # POST /groups/{group_id}/entitlements:batchDelete
+    # POST /groups/{group_id}/entitlements:batch_delete
     async def test_bulk_remove_entitlements(
         self,
         services_mock: ServiceCollectionV3,
@@ -1226,7 +1226,7 @@ class TestUserGroupsApi(ApiCommonTests):
         )
 
         response = await mocked_api_client_user.post(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements:batchDelete",
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements:batch_delete",
             json=jsonable_encoder(bulk_request.dict()),
         )
         assert response.status_code == 204
@@ -1259,7 +1259,7 @@ class TestUserGroupsApi(ApiCommonTests):
         services_mock.usergroups.get_by_id.return_value = None
 
         response = await client.post(
-            f"{self.BASE_PATH}/999/entitlements:batchDelete",
+            f"{self.BASE_PATH}/999/entitlements:batch_delete",
             json=jsonable_encoder(bulk_request),
         )
         assert response.status_code == 404
@@ -1285,7 +1285,7 @@ class TestUserGroupsApi(ApiCommonTests):
         services_mock.usergroups.get_by_id.return_value = TEST_GROUP
 
         response = await client.post(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements:batchDelete",
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements:batch_delete",
             json=jsonable_encoder(bulk_request),
         )
         assert response.status_code == 400

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_usergroups.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_usergroups.py
@@ -10,9 +10,12 @@ import pytest
 
 from maasapiserver.common.api.models.responses.errors import ErrorBodyResponse
 from maasapiserver.v3.api.public.models.requests.entitlements import (
+    BulkEntitlementDeleteItem,
+    BulkEntitlementDeleteRequest,
     EntitlementRequest,
 )
 from maasapiserver.v3.api.public.models.requests.usergroup_members import (
+    BulkGroupMemberRequest,
     UserGroupMemberRequest,
 )
 from maasapiserver.v3.api.public.models.requests.usergroups import (
@@ -145,6 +148,21 @@ class TestUserGroupsApi(ApiCommonTests):
                 path=f"{self.BASE_PATH}/1/entitlements"
                 "?resource_type=maas&resource_id=0"
                 "&entitlement=can_edit_machines",
+                permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+            ),
+            Endpoint(
+                method="POST",
+                path=f"{self.BASE_PATH}/1/members:batchCreate",
+                permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+            ),
+            Endpoint(
+                method="DELETE",
+                path=f"{self.BASE_PATH}/1/members?id=10",
+                permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+            ),
+            Endpoint(
+                method="POST",
+                path=f"{self.BASE_PATH}/1/entitlements:batchDelete",
                 permission=MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
             ),
         ]
@@ -438,7 +456,7 @@ class TestUserGroupsApi(ApiCommonTests):
         assert response.status_code == 204
 
     # GET /groups/{group_id}/members
-    async def test_list_members(
+    async def test_list_members_other_page(
         self,
         services_mock: ServiceCollectionV3,
         mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
@@ -448,42 +466,73 @@ class TestUserGroupsApi(ApiCommonTests):
         )
         services_mock.usergroups = Mock(UserGroupsService)
         services_mock.usergroups.get_by_id.return_value = TEST_GROUP
-        services_mock.usergroups.list_usergroup_members.return_value = [
-            UserGroupMember(
-                id=10, group_id=1, username="user1", email="u1@test.com"
-            ),
-            UserGroupMember(
-                id=20, group_id=1, username="user2", email="u2@test.com"
-            ),
-        ]
+        services_mock.usergroups.list_usergroup_members_page = AsyncMock(
+            return_value=ListResult[UserGroupMember](
+                items=[
+                    UserGroupMember(
+                        id=10,
+                        group_id=1,
+                        username="user1",
+                        email="u1@test.com",
+                    ),
+                ],
+                total=2,
+            )
+        )
 
         response = await client.get(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/members"
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members?size=1"
+        )
+        assert response.status_code == 200
+        members_response = UserGroupMembersListResponse(**response.json())
+        assert len(members_response.items) == 1
+        assert members_response.total == 2
+        assert members_response.items[0].username == "user1"
+        assert (
+            members_response.next
+            == f"{self.BASE_PATH}/{TEST_GROUP.id}/members?page=2&size=1"
+        )
+
+    async def test_list_members_no_other_page(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
+        )
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+        services_mock.usergroups.list_usergroup_members_page = AsyncMock(
+            return_value=ListResult[UserGroupMember](
+                items=[
+                    UserGroupMember(
+                        id=10,
+                        group_id=1,
+                        username="user1",
+                        email="u1@test.com",
+                    ),
+                    UserGroupMember(
+                        id=20,
+                        group_id=1,
+                        username="user2",
+                        email="u2@test.com",
+                    ),
+                ],
+                total=2,
+            )
+        )
+
+        response = await client.get(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members?size=2"
         )
         assert response.status_code == 200
         members_response = UserGroupMembersListResponse(**response.json())
         assert len(members_response.items) == 2
+        assert members_response.total == 2
         assert members_response.items[0].username == "user1"
         assert members_response.items[1].username == "user2"
-
-    async def test_list_members_empty(
-        self,
-        services_mock: ServiceCollectionV3,
-        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
-    ) -> None:
-        client = mocked_api_client_user_with_permissions(
-            MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
-        )
-        services_mock.usergroups = Mock(UserGroupsService)
-        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
-        services_mock.usergroups.list_usergroup_members.return_value = []
-
-        response = await client.get(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/members"
-        )
-        assert response.status_code == 200
-        members_response = UserGroupMembersListResponse(**response.json())
-        assert len(members_response.items) == 0
+        assert members_response.next is None
 
     async def test_list_members_404(
         self,
@@ -513,11 +562,6 @@ class TestUserGroupsApi(ApiCommonTests):
         services_mock.users.get_by_id.return_value = TEST_USER
         services_mock.usergroups = Mock(UserGroupsService)
         services_mock.usergroups.add_user_to_group_by_id.return_value = None
-        services_mock.usergroups.list_usergroup_members.return_value = [
-            UserGroupMember(
-                id=10, group_id=1, username="user1", email="u1@test.com"
-            ),
-        ]
 
         response = await client.post(
             f"{self.BASE_PATH}/{TEST_GROUP.id}/members",
@@ -602,7 +646,7 @@ class TestUserGroupsApi(ApiCommonTests):
         assert response.status_code == 404
 
     # GET /groups/{group_id}/entitlements
-    async def test_list_entitlements(
+    async def test_list_entitlements_other_page(
         self,
         services_mock: ServiceCollectionV3,
         mocked_api_client_user: AsyncClient,
@@ -615,60 +659,83 @@ class TestUserGroupsApi(ApiCommonTests):
                 {MAASResourceEntitlement.CAN_VIEW_IDENTITIES}
             )
         )
-        services_mock.openfga_tuples.list_entitlements = AsyncMock(
-            return_value=[
-                OpenFGATuple(
-                    object_type="maas",
-                    object_id="0",
-                    relation="can_edit_machines",
-                    user="group:1#member",
-                    user_type="userset",
-                ),
-                OpenFGATuple(
-                    object_type="pool",
-                    object_id="5",
-                    relation="can_deploy_machines",
-                    user="group:1#member",
-                    user_type="userset",
-                ),
-            ]
+        services_mock.openfga_tuples.list_entitlements_page = AsyncMock(
+            return_value=ListResult[OpenFGATuple](
+                items=[
+                    OpenFGATuple(
+                        object_type="maas",
+                        object_id="0",
+                        relation="can_edit_machines",
+                        user="group:1#member",
+                        user_type="userset",
+                    ),
+                ],
+                total=2,
+            )
         )
 
         response = await mocked_api_client_user.get(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements"
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements?size=1"
+        )
+        assert response.status_code == 200
+        result = EntitlementsListResponse(**response.json())
+        assert len(result.items) == 1
+        assert result.total == 2
+        assert result.items[0].resource_type == "maas"
+        assert result.items[0].entitlement == "can_edit_machines"
+        assert (
+            result.next
+            == f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements?page=2&size=1"
+        )
+
+    async def test_list_entitlements_no_other_page(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user: AsyncClient,
+    ) -> None:
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+        services_mock.openfga_tuples = Mock(OpenFGATupleService)
+        services_mock.openfga_tuples.get_client.return_value = (
+            AsyncOpenFGAClientMock(
+                {MAASResourceEntitlement.CAN_VIEW_IDENTITIES}
+            )
+        )
+        services_mock.openfga_tuples.list_entitlements_page = AsyncMock(
+            return_value=ListResult[OpenFGATuple](
+                items=[
+                    OpenFGATuple(
+                        object_type="maas",
+                        object_id="0",
+                        relation="can_edit_machines",
+                        user="group:1#member",
+                        user_type="userset",
+                    ),
+                    OpenFGATuple(
+                        object_type="pool",
+                        object_id="5",
+                        relation="can_deploy_machines",
+                        user="group:1#member",
+                        user_type="userset",
+                    ),
+                ],
+                total=2,
+            )
+        )
+
+        response = await mocked_api_client_user.get(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements?size=2"
         )
         assert response.status_code == 200
         result = EntitlementsListResponse(**response.json())
         assert len(result.items) == 2
+        assert result.total == 2
         assert result.items[0].resource_type == "maas"
         assert result.items[0].entitlement == "can_edit_machines"
         assert result.items[1].resource_type == "pool"
         assert result.items[1].resource_id == 5
         assert result.items[1].entitlement == "can_deploy_machines"
-
-    async def test_list_entitlements_empty(
-        self,
-        services_mock: ServiceCollectionV3,
-        mocked_api_client_user: AsyncClient,
-    ) -> None:
-        services_mock.usergroups = Mock(UserGroupsService)
-        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
-        services_mock.openfga_tuples = Mock(OpenFGATupleService)
-        services_mock.openfga_tuples.get_client.return_value = (
-            AsyncOpenFGAClientMock(
-                {MAASResourceEntitlement.CAN_VIEW_IDENTITIES}
-            )
-        )
-        services_mock.openfga_tuples.list_entitlements = AsyncMock(
-            return_value=[]
-        )
-
-        response = await mocked_api_client_user.get(
-            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements"
-        )
-        assert response.status_code == 200
-        result = EntitlementsListResponse(**response.json())
-        assert len(result.items) == 0
+        assert result.next is None
 
     async def test_list_entitlements_group_not_found(
         self,
@@ -1002,6 +1069,224 @@ class TestUserGroupsApi(ApiCommonTests):
                 "resource_id": 0,
                 "entitlement": "nonexistent",
             },
+        )
+        assert response.status_code == 400
+        error_response = ErrorBodyResponse(**response.json())
+        assert error_response.code == 400
+
+    # POST /groups/{group_id}/members:batchCreate
+    async def test_bulk_add_members(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        bulk_request = BulkGroupMemberRequest(user_ids=[10, 20])
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+        services_mock.usergroups.bulk_add_users_to_group.return_value = None
+        services_mock.users = Mock(UsersService)
+        services_mock.users.get_by_id.return_value = TEST_USER
+
+        response = await client.post(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batchCreate",
+            json=jsonable_encoder(bulk_request),
+        )
+        assert response.status_code == 200
+
+    async def test_bulk_add_members_group_not_found(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        bulk_request = BulkGroupMemberRequest(user_ids=[10])
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = None
+
+        response = await client.post(
+            f"{self.BASE_PATH}/999/members:batchCreate",
+            json=jsonable_encoder(bulk_request),
+        )
+        assert response.status_code == 404
+
+    async def test_bulk_add_members_user_not_found(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        bulk_request = BulkGroupMemberRequest(user_ids=[999])
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+        services_mock.users = Mock(UsersService)
+        services_mock.users.get_by_id.return_value = None
+
+        response = await client.post(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batchCreate",
+            json=jsonable_encoder(bulk_request),
+        )
+        assert response.status_code == 404
+
+    async def test_bulk_add_members_already_in_group(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        bulk_request = BulkGroupMemberRequest(user_ids=[10])
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+        services_mock.usergroups.bulk_add_users_to_group.side_effect = (
+            UserAlreadyInGroup()
+        )
+        services_mock.users = Mock(UsersService)
+        services_mock.users.get_by_id.return_value = TEST_USER
+
+        response = await client.post(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members:batchCreate",
+            json=jsonable_encoder(bulk_request),
+        )
+        assert response.status_code == 409
+
+    # DELETE /groups/{group_id}/members
+    async def test_bulk_remove_members(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+        services_mock.usergroups.bulk_remove_users_from_group.return_value = (
+            None
+        )
+
+        response = await client.delete(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/members?id=10&id=20",
+        )
+        assert response.status_code == 204
+
+    async def test_bulk_remove_members_group_not_found(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = None
+
+        response = await client.delete(
+            f"{self.BASE_PATH}/999/members?id=10",
+        )
+        assert response.status_code == 404
+
+    # POST /groups/{group_id}/entitlements:batchDelete
+    async def test_bulk_remove_entitlements(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user: AsyncClient,
+    ) -> None:
+        bulk_request = BulkEntitlementDeleteRequest(
+            items=[
+                BulkEntitlementDeleteItem(
+                    resource_type="maas",
+                    resource_id=0,
+                    entitlement="can_edit_machines",
+                ),
+                BulkEntitlementDeleteItem(
+                    resource_type="pool",
+                    resource_id=5,
+                    entitlement="can_edit_machines",
+                ),
+            ]
+        )
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+        services_mock.openfga_tuples = Mock(OpenFGATupleService)
+        services_mock.openfga_tuples.get_client.return_value = (
+            AsyncOpenFGAClientMock(
+                {MAASResourceEntitlement.CAN_EDIT_IDENTITIES}
+            )
+        )
+        services_mock.openfga_tuples.bulk_delete_entitlements = AsyncMock(
+            return_value=None
+        )
+
+        response = await mocked_api_client_user.post(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements:batchDelete",
+            json=jsonable_encoder(bulk_request.dict()),
+        )
+        assert response.status_code == 204
+        services_mock.openfga_tuples.bulk_delete_entitlements.assert_called_once_with(
+            TEST_GROUP.id,
+            [
+                ("can_edit_machines", "maas", 0),
+                ("can_edit_machines", "pool", 5),
+            ],
+        )
+
+    async def test_bulk_remove_entitlements_group_not_found(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        bulk_request = BulkEntitlementDeleteRequest(
+            items=[
+                BulkEntitlementDeleteItem(
+                    resource_type="maas",
+                    resource_id=0,
+                    entitlement="can_edit_machines",
+                )
+            ]
+        )
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = None
+
+        response = await client.post(
+            f"{self.BASE_PATH}/999/entitlements:batchDelete",
+            json=jsonable_encoder(bulk_request),
+        )
+        assert response.status_code == 404
+
+    async def test_bulk_remove_entitlements_invalid_entitlement(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_EDIT_IDENTITIES,
+        )
+        bulk_request = BulkEntitlementDeleteRequest(
+            items=[
+                BulkEntitlementDeleteItem(
+                    resource_type="maas",
+                    resource_id=0,
+                    entitlement="nonexistent_entitlement",
+                )
+            ]
+        )
+        services_mock.usergroups = Mock(UserGroupsService)
+        services_mock.usergroups.get_by_id.return_value = TEST_GROUP
+
+        response = await client.post(
+            f"{self.BASE_PATH}/{TEST_GROUP.id}/entitlements:batchDelete",
+            json=jsonable_encoder(bulk_request),
         )
         assert response.status_code == 400
         error_response = ErrorBodyResponse(**response.json())

--- a/src/tests/maasservicelayer/db/repositories/test_openfga_tuples.py
+++ b/src/tests/maasservicelayer/db/repositories/test_openfga_tuples.py
@@ -15,6 +15,7 @@ from maasservicelayer.db.repositories.openfga_tuples import (
     OpenFGATuplesRepository,
 )
 from maasservicelayer.db.tables import OpenFGATupleTable
+from maasservicelayer.models.openfga_tuple import EntitlementDeleteSpec
 from tests.fixtures.factories.openfga_tuples import create_openfga_tuple
 from tests.maasapiserver.fixtures.db import Fixture
 from tests.utils.ulid import is_ulid
@@ -56,8 +57,16 @@ class TestOpenFGATuplesClauseFactory:
     def test_with_entitlement_tuples(self) -> None:
         clause = OpenFGATuplesClauseFactory.with_entitlement_tuples(
             [
-                ("can_view_machines", "pool", "1"),
-                ("can_edit_machines", "pool", "2"),
+                EntitlementDeleteSpec(
+                    entitlement="can_view_machines",
+                    resource_type="pool",
+                    resource_id=1,
+                ),
+                EntitlementDeleteSpec(
+                    entitlement="can_edit_machines",
+                    resource_type="pool",
+                    resource_id=2,
+                ),
             ]
         )
         sql_str = str(

--- a/src/tests/maasservicelayer/db/repositories/test_openfga_tuples.py
+++ b/src/tests/maasservicelayer/db/repositories/test_openfga_tuples.py
@@ -45,6 +45,30 @@ class TestOpenFGATuplesClauseFactory:
             clause.condition.compile(compile_kwargs={"literal_binds": True})
         ) == ("openfga.tuple._user = 'user:user'")
 
+    def test_with_users(self) -> None:
+        clause = OpenFGATuplesClauseFactory.with_users(
+            ["user:1", "user:2", "user:3"]
+        )
+        assert str(
+            clause.condition.compile(compile_kwargs={"literal_binds": True})
+        ) == ("openfga.tuple._user IN ('user:1', 'user:2', 'user:3')")
+
+    def test_with_entitlement_tuples(self) -> None:
+        clause = OpenFGATuplesClauseFactory.with_entitlement_tuples(
+            [
+                ("can_view_machines", "pool", "1"),
+                ("can_edit_machines", "pool", "2"),
+            ]
+        )
+        sql_str = str(
+            clause.condition.compile(compile_kwargs={"literal_binds": True})
+        )
+        assert "can_view_machines" in sql_str
+        assert "can_edit_machines" in sql_str
+        assert "'pool'" in sql_str
+        assert "'1'" in sql_str
+        assert "'2'" in sql_str
+
 
 @pytest.mark.usefixtures("ensuremaasdb")
 @pytest.mark.asyncio
@@ -144,3 +168,86 @@ class TestOpenFGATuplesRepository:
             eq(OpenFGATupleTable.c.relation, "member"),
         )
         assert len(tuples) == 0
+
+    async def test_bulk_upsert(
+        self, db_connection: AsyncConnection, fixture: Fixture
+    ) -> None:
+        repository = OpenFGATuplesRepository(Context(connection=db_connection))
+
+        builders = [
+            OpenFGATupleBuilder(
+                user=f"user:{i}",
+                user_type="user",
+                relation="member",
+                object_type="group",
+                object_id="bulk-group",
+            )
+            for i in range(1, 4)
+        ]
+        await repository.bulk_upsert(builders)
+
+        tuples = await fixture.get(
+            OpenFGATupleTable.fullname,
+            eq(OpenFGATupleTable.c.object_id, "bulk-group"),
+        )
+        assert len(tuples) == 3
+        users = {t["_user"] for t in tuples}
+        assert users == {"user:1", "user:2", "user:3"}
+        assert all(t["store"] == OPENFGA_STORE_ID for t in tuples)
+        assert all(is_ulid(t["ulid"]) for t in tuples)
+
+    async def test_list_entitlements(
+        self, db_connection: AsyncConnection, fixture: Fixture
+    ) -> None:
+        repository = OpenFGATuplesRepository(Context(connection=db_connection))
+
+        await create_openfga_tuple(
+            fixture,
+            user="group:10#member",
+            user_type="userset",
+            relation="can_edit_machines",
+            object_type="maas",
+            object_id="0",
+        )
+        await create_openfga_tuple(
+            fixture,
+            user="group:10#member",
+            user_type="userset",
+            relation="can_view_machines",
+            object_type="pool",
+            object_id="5",
+        )
+        # unrelated group that should not appear
+        await create_openfga_tuple(
+            fixture,
+            user="group:20#member",
+            user_type="userset",
+            relation="can_edit_machines",
+            object_type="maas",
+            object_id="0",
+        )
+
+        query = QuerySpec(
+            where=OpenFGATuplesClauseFactory.with_user("group:10#member")
+        )
+        first_page = await repository.list_entitlements(
+            page=1, size=1, query=query
+        )
+        assert first_page.total == 2
+        assert len(first_page.items) == 1
+
+        second_page = await repository.list_entitlements(
+            page=2, size=1, query=query
+        )
+        assert second_page.total == 2
+        assert len(second_page.items) == 1
+
+        all_relations = {
+            first_page.items[0].relation,
+            second_page.items[0].relation,
+        }
+        assert all_relations == {"can_edit_machines", "can_view_machines"}
+        assert all(
+            t.user == "group:10#member"
+            for t in first_page.items + second_page.items
+        )

--- a/src/tests/maasservicelayer/services/test_openfga_tuples.py
+++ b/src/tests/maasservicelayer/services/test_openfga_tuples.py
@@ -56,6 +56,53 @@ class TestIntegrationOpenFGAService:
         assert tuples[0].object_id == "0"
         assert tuples[0].user == "group:999#member"
 
+    async def test_list_entitlements_page(
+        self, fixture: Fixture, services: ServiceCollectionV3
+    ):
+        await create_openfga_tuple(
+            fixture,
+            "group:888#member",
+            "userset",
+            "can_edit_machines",
+            "maas",
+            "0",
+        )
+        await create_openfga_tuple(
+            fixture,
+            "group:888#member",
+            "userset",
+            "can_view_machines",
+            "pool",
+            "10",
+        )
+        # unrelated group that should not appear
+        await create_openfga_tuple(
+            fixture,
+            "group:889#member",
+            "userset",
+            "can_view_machines",
+            "pool",
+            "10",
+        )
+
+        first_page = await services.openfga_tuples.list_entitlements_page(
+            888, page=1, size=1
+        )
+        assert first_page.total == 2
+        assert len(first_page.items) == 1
+
+        second_page = await services.openfga_tuples.list_entitlements_page(
+            888, page=2, size=1
+        )
+        assert second_page.total == 2
+        assert len(second_page.items) == 1
+
+        all_relations = {
+            first_page.items[0].relation,
+            second_page.items[0].relation,
+        }
+        assert all_relations == {"can_edit_machines", "can_view_machines"}
+
     async def test_upsert(
         self,
         fixture: Fixture,
@@ -174,6 +221,114 @@ class TestIntegrationOpenFGAService:
         )
         assert len(retrieved_tuple) == 0
 
+    async def test_bulk_remove_users_from_group(
+        self, fixture: Fixture, services: ServiceCollectionV3
+    ):
+        await create_openfga_tuple(
+            fixture, "user:1", "user", "member", "group", "10"
+        )
+        await create_openfga_tuple(
+            fixture, "user:2", "user", "member", "group", "10"
+        )
+        await create_openfga_tuple(
+            fixture, "user:3", "user", "member", "group", "10"
+        )
+        # unrelated group membership that should not be removed
+        await create_openfga_tuple(
+            fixture, "user:99", "user", "member", "group", "20"
+        )
+
+        await services.openfga_tuples.bulk_remove_users_from_group(
+            10, [1, 2, 3]
+        )
+
+        removed = await fixture.get(
+            OpenFGATupleTable.fullname,
+            and_(
+                eq(OpenFGATupleTable.c.object_type, "group"),
+                eq(OpenFGATupleTable.c.object_id, "10"),
+            ),
+        )
+        assert len(removed) == 0
+
+        unrelated = await fixture.get(
+            OpenFGATupleTable.fullname,
+            and_(
+                eq(OpenFGATupleTable.c.object_type, "group"),
+                eq(OpenFGATupleTable.c.object_id, "20"),
+                eq(OpenFGATupleTable.c._user, "user:99"),
+            ),
+        )
+        assert len(unrelated) == 1
+
+    async def test_bulk_add_users_to_group(
+        self, fixture: Fixture, services: ServiceCollectionV3
+    ):
+        await services.openfga_tuples.bulk_add_users_to_group(
+            4000, [10, 20, 30]
+        )
+
+        tuples = await fixture.get(
+            OpenFGATupleTable.fullname,
+            and_(
+                eq(OpenFGATupleTable.c.object_type, "group"),
+                eq(OpenFGATupleTable.c.object_id, "4000"),
+                eq(OpenFGATupleTable.c.relation, "member"),
+            ),
+        )
+        assert len(tuples) == 3
+        users = {t["_user"] for t in tuples}
+        assert users == {"user:10", "user:20", "user:30"}
+
+    async def test_bulk_delete_entitlements(
+        self, fixture: Fixture, services: ServiceCollectionV3
+    ):
+        await create_openfga_tuple(
+            fixture,
+            "group:5000#member",
+            "userset",
+            "can_edit_machines",
+            "maas",
+            "0",
+        )
+        await create_openfga_tuple(
+            fixture,
+            "group:5000#member",
+            "userset",
+            "can_view_machines",
+            "pool",
+            "99",
+        )
+        # unrelated group entitlement that should not be removed
+        await create_openfga_tuple(
+            fixture,
+            "group:6000#member",
+            "userset",
+            "can_edit_machines",
+            "maas",
+            "0",
+        )
+
+        await services.openfga_tuples.bulk_delete_entitlements(
+            5000,
+            [
+                ("can_edit_machines", "maas", 0),
+                ("can_view_machines", "pool", 99),
+            ],
+        )
+
+        deleted = await fixture.get(
+            OpenFGATupleTable.fullname,
+            eq(OpenFGATupleTable.c._user, "group:5000#member"),
+        )
+        assert len(deleted) == 0
+
+        unrelated = await fixture.get(
+            OpenFGATupleTable.fullname,
+            eq(OpenFGATupleTable.c._user, "group:6000#member"),
+        )
+        assert len(unrelated) == 1
+
 
 @pytest.mark.asyncio
 class TestOpenFGAService:
@@ -257,6 +412,105 @@ class TestOpenFGAService:
         assert "can_deploy_machines" in sql_str
         assert "'pool'" in sql_str
         assert "'42'" in sql_str
+
+    async def test_bulk_remove_users_from_group(self) -> None:
+        mock_repository = Mock(OpenFGATuplesRepository)
+        mock_repository.delete_many = AsyncMock(return_value=None)
+        service = OpenFGATupleService(
+            context=Context(),
+            openfga_tuple_repository=mock_repository,
+            cache=OpenFGAServiceCache(),
+        )
+
+        await service.bulk_remove_users_from_group(
+            group_id=7, user_ids=[10, 20, 30]
+        )
+
+        mock_repository.delete_many.assert_called_once()
+        query = mock_repository.delete_many.call_args[0][0]
+        compiled = query.where.condition.compile(
+            compile_kwargs={"literal_binds": True}
+        )
+        sql_str = str(compiled)
+        assert "user:10" in sql_str
+        assert "user:20" in sql_str
+        assert "user:30" in sql_str
+        assert "member" in sql_str
+        assert "'group'" in sql_str
+        assert "'7'" in sql_str
+
+    async def test_bulk_add_users_to_group(self) -> None:
+        mock_repository = Mock(OpenFGATuplesRepository)
+        mock_repository.bulk_upsert = AsyncMock(return_value=None)
+        service = OpenFGATupleService(
+            context=Context(),
+            openfga_tuple_repository=mock_repository,
+            cache=OpenFGAServiceCache(),
+        )
+
+        await service.bulk_add_users_to_group(group_id=8, user_ids=[1, 2, 3])
+
+        mock_repository.bulk_upsert.assert_called_once()
+        builders = mock_repository.bulk_upsert.call_args[0][0]
+        assert len(builders) == 3
+        users = {b.user for b in builders}
+        assert users == {"user:1", "user:2", "user:3"}
+        assert all(b.relation == "member" for b in builders)
+        assert all(b.object_type == "group" for b in builders)
+        assert all(b.object_id == "8" for b in builders)
+
+    async def test_bulk_delete_entitlements(self) -> None:
+        mock_repository = Mock(OpenFGATuplesRepository)
+        mock_repository.delete_many = AsyncMock(return_value=None)
+        service = OpenFGATupleService(
+            context=Context(),
+            openfga_tuple_repository=mock_repository,
+            cache=OpenFGAServiceCache(),
+        )
+
+        await service.bulk_delete_entitlements(
+            group_id=9,
+            items=[
+                ("can_edit_machines", "maas", 0),
+                ("can_view_machines", "pool", 42),
+            ],
+        )
+
+        mock_repository.delete_many.assert_called_once()
+        query = mock_repository.delete_many.call_args[0][0]
+        compiled = query.where.condition.compile(
+            compile_kwargs={"literal_binds": True}
+        )
+        sql_str = str(compiled)
+        assert "group:9#member" in sql_str
+        assert "can_edit_machines" in sql_str
+        assert "'maas'" in sql_str
+        assert "can_view_machines" in sql_str
+        assert "'pool'" in sql_str
+        assert "'42'" in sql_str
+
+    async def test_list_entitlements_page(self) -> None:
+        mock_repository = Mock(OpenFGATuplesRepository)
+        mock_repository.list_entitlements = AsyncMock(
+            return_value=Mock(items=[], total=0)
+        )
+        service = OpenFGATupleService(
+            context=Context(),
+            openfga_tuple_repository=mock_repository,
+            cache=OpenFGAServiceCache(),
+        )
+
+        await service.list_entitlements_page(group_id=3, page=2, size=10)
+
+        mock_repository.list_entitlements.assert_called_once()
+        call_args = mock_repository.list_entitlements.call_args[0]
+        page, size, query = call_args
+        assert page == 2
+        assert size == 10
+        compiled = query.where.condition.compile(
+            compile_kwargs={"literal_binds": True}
+        )
+        assert "group:3#member" in str(compiled)
 
 
 class TestMAASTupleBuilderFactory:

--- a/src/tests/maasservicelayer/services/test_openfga_tuples.py
+++ b/src/tests/maasservicelayer/services/test_openfga_tuples.py
@@ -14,6 +14,7 @@ from maasservicelayer.db.repositories.openfga_tuples import (
     OpenFGATuplesRepository,
 )
 from maasservicelayer.db.tables import OpenFGATupleTable
+from maasservicelayer.models.openfga_tuple import EntitlementDeleteSpec
 from maasservicelayer.services import OpenFGATupleService, ServiceCollectionV3
 from maasservicelayer.services.openfga_tuples import (
     EntitlementsBuilderFactory,
@@ -312,8 +313,16 @@ class TestIntegrationOpenFGAService:
         await services.openfga_tuples.bulk_delete_entitlements(
             5000,
             [
-                ("can_edit_machines", "maas", 0),
-                ("can_view_machines", "pool", 99),
+                EntitlementDeleteSpec(
+                    entitlement="can_edit_machines",
+                    resource_type="maas",
+                    resource_id=0,
+                ),
+                EntitlementDeleteSpec(
+                    entitlement="can_view_machines",
+                    resource_type="pool",
+                    resource_id=99,
+                ),
             ],
         )
 
@@ -471,8 +480,16 @@ class TestOpenFGAService:
         await service.bulk_delete_entitlements(
             group_id=9,
             items=[
-                ("can_edit_machines", "maas", 0),
-                ("can_view_machines", "pool", 42),
+                EntitlementDeleteSpec(
+                    entitlement="can_edit_machines",
+                    resource_type="maas",
+                    resource_id=0,
+                ),
+                EntitlementDeleteSpec(
+                    entitlement="can_view_machines",
+                    resource_type="pool",
+                    resource_id=42,
+                ),
             ],
         )
 

--- a/src/tests/maasservicelayer/services/test_usergroups.py
+++ b/src/tests/maasservicelayer/services/test_usergroups.py
@@ -264,6 +264,58 @@ class TestUserGroupsService:
             1, 10
         )
 
+    async def test_bulk_add_users_to_group(self) -> None:
+        usergroup_members_repository = Mock(UserGroupMembersRepository)
+        usergroup_members_repository.exists.return_value = False
+        openfga_tuples_service = Mock(OpenFGATupleService)
+
+        service = UserGroupsService(
+            context=Context(),
+            usergroups_repository=Mock(UserGroupsRepository),
+            usergroup_members_repository=usergroup_members_repository,
+            openfga_tuples_service=openfga_tuples_service,
+        )
+
+        await service.bulk_add_users_to_group(TEST_GROUP.id, [1, 2, 3])
+        usergroup_members_repository.exists.assert_awaited_once()
+        openfga_tuples_service.bulk_add_users_to_group.assert_awaited_once_with(
+            TEST_GROUP.id, [1, 2, 3]
+        )
+
+    async def test_bulk_add_users_to_group_raises_if_already_member(
+        self,
+    ) -> None:
+        usergroup_members_repository = Mock(UserGroupMembersRepository)
+        usergroup_members_repository.exists.return_value = True
+        openfga_tuples_service = Mock(OpenFGATupleService)
+
+        service = UserGroupsService(
+            context=Context(),
+            usergroups_repository=Mock(UserGroupsRepository),
+            usergroup_members_repository=usergroup_members_repository,
+            openfga_tuples_service=openfga_tuples_service,
+        )
+
+        with pytest.raises(UserAlreadyInGroup):
+            await service.bulk_add_users_to_group(TEST_GROUP.id, [1, 2, 3])
+        usergroup_members_repository.exists.assert_awaited_once()
+        openfga_tuples_service.bulk_add_users_to_group.assert_not_awaited()
+
+    async def test_bulk_remove_users_from_group(self) -> None:
+        openfga_tuples_service = Mock(OpenFGATupleService)
+
+        service = UserGroupsService(
+            context=Context(),
+            usergroups_repository=Mock(UserGroupsRepository),
+            usergroup_members_repository=Mock(UserGroupMembersRepository),
+            openfga_tuples_service=openfga_tuples_service,
+        )
+
+        await service.bulk_remove_users_from_group(TEST_GROUP.id, [1, 2, 3])
+        openfga_tuples_service.bulk_remove_users_from_group.assert_awaited_once_with(
+            TEST_GROUP.id, [1, 2, 3]
+        )
+
 
 @pytest.mark.asyncio
 class TestIntegrationUserGroupsService:
@@ -518,3 +570,104 @@ class TestIntegrationUserGroupsService:
     ) -> None:
         with pytest.raises(UserGroupNotFound):
             await services.usergroups.add_user_to_group_by_id(1, 99999)
+
+    async def test_bulk_add_users_to_group(
+        self,
+        fixture: Fixture,
+        services: ServiceCollectionV3,
+    ) -> None:
+        group = await create_test_usergroup(
+            fixture, name="bulk-add-group", description="test"
+        )
+        user1 = await create_test_user(
+            fixture, username="bulk1", email="bulk1@example.com"
+        )
+        user2 = await create_test_user(
+            fixture, username="bulk2", email="bulk2@example.com"
+        )
+
+        await services.usergroups.bulk_add_users_to_group(
+            group.id, [user1.id, user2.id]
+        )
+
+        tuples = await fixture.get(
+            OpenFGATupleTable.fullname,
+            and_(
+                eq(OpenFGATupleTable.c.relation, "member"),
+                eq(OpenFGATupleTable.c.object_type, "group"),
+                eq(OpenFGATupleTable.c.object_id, str(group.id)),
+            ),
+        )
+        assert len(tuples) == 2
+        users_in_tuples = {t["_user"] for t in tuples}
+        assert users_in_tuples == {f"user:{user1.id}", f"user:{user2.id}"}
+
+    async def test_bulk_add_users_to_group_raises_if_already_member(
+        self,
+        fixture: Fixture,
+        services: ServiceCollectionV3,
+    ) -> None:
+        group = await create_test_usergroup(
+            fixture, name="bulk-add-conflict-group", description="test"
+        )
+        user = await create_test_user(fixture, username="already-member")
+
+        await create_openfga_tuple(
+            fixture,
+            f"user:{user.id}",
+            "user",
+            "member",
+            "group",
+            str(group.id),
+        )
+
+        with pytest.raises(UserAlreadyInGroup):
+            await services.usergroups.bulk_add_users_to_group(
+                group.id, [user.id]
+            )
+
+    async def test_bulk_remove_users_from_group(
+        self,
+        fixture: Fixture,
+        services: ServiceCollectionV3,
+    ) -> None:
+        group = await create_test_usergroup(
+            fixture, name="bulk-remove-group", description="test"
+        )
+        user1 = await create_test_user(
+            fixture, username="rem1", email="rem1@example.com"
+        )
+        user2 = await create_test_user(
+            fixture, username="rem2", email="rem2@example.com"
+        )
+
+        await create_openfga_tuple(
+            fixture,
+            f"user:{user1.id}",
+            "user",
+            "member",
+            "group",
+            str(group.id),
+        )
+        await create_openfga_tuple(
+            fixture,
+            f"user:{user2.id}",
+            "user",
+            "member",
+            "group",
+            str(group.id),
+        )
+
+        await services.usergroups.bulk_remove_users_from_group(
+            group.id, [user1.id, user2.id]
+        )
+
+        tuples = await fixture.get(
+            OpenFGATupleTable.fullname,
+            and_(
+                eq(OpenFGATupleTable.c.relation, "member"),
+                eq(OpenFGATupleTable.c.object_type, "group"),
+                eq(OpenFGATupleTable.c.object_id, str(group.id)),
+            ),
+        )
+        assert len(tuples) == 0


### PR DESCRIPTION
Added 3 new endpoints:
1. `POST /groups/{group_id}/members:batch_create`: For adding multiple users to a group in one operation. The `batch_create` suffix is appended to separate this endpoint from the `POST /groups/{group_id}/members` for adding a single member.
2. `DELETE /groups/{group_id}/members`: For removing multiple users from a group in one operation
3. `POST /groups/{group_id}/entitlements:batch_delete`: Removes multiple entitlements from a group in a single operation. Entitlements within a group do not have a unique `id`. Instead, each entitlement is identified by a combination of fields: `resource_type`, `resource_id`, and `entitlement` (e.g. `can_edit_machines`). Deleting multiple entitlements therefore requires sending a structured payload (e.g. an array of these field combinations).
While this could map to a `DELETE` endpoint, doing so would require a request body. In practice, request bodies on `DELETE` are discouraged by MDN (see [docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Methods/DELETE)). For this reason, `POST` is chosen. Also, the suffix `batch_delete` is appended because `POST /groups/{group_id}/entitlements` already exists for entitlement creation.

The following endpoints are modified and now include pagination:
1. `GET /groups/{group_id}/members`
2. `GET /groups/{group_id}/entitlements`

Resolves [MAASENG-6347](https://warthogs.atlassian.net/browse/MAASENG-6347)

[MAASENG-6347]: https://warthogs.atlassian.net/browse/MAASENG-6347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ