### PR TITLE
chore(ci): pick an image when manually running

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,8 +25,13 @@ jobs:
       go: ${{ steps.filter.outputs.go }}
       docs: ${{ steps.filter.outputs.docs }}
       lint: ${{ steps.filter.outputs.lint }}
+      image: ${{ steps.image.outputs.tag }}
     steps:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+
+      - name: Set build env image tag
+        id: image
+        run: echo "tag=${{ github.event.merge_group.base_ref || github.base_ref || github.ref_name }}" >> $GITHUB_OUTPUT
 
       - uses: dorny/paths-filter@61f87a10cd2c304679af17bb73ef192addf33c1c
         id: filter
@@ -63,7 +68,7 @@ jobs:
     if: >-
       ${{ !github.event.pull_request.draft && needs.changes.outputs.lint == 'true' }}
     container:
-      image: ghcr.io/${{ github.repository }}-build-env:${{ github.event_name == 'merge_group' && 'master' || github.base_ref }}
+      image: ghcr.io/${{ github.repository }}-build-env:${{ needs.changes.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -83,7 +88,7 @@ jobs:
       ${{ !github.event.pull_request.draft && needs.changes.outputs.python == 'true' }}
 
     container:
-      image: ghcr.io/${{ github.repository }}-build-env:${{ github.event_name == 'merge_group' && 'master' || github.base_ref }}
+      image: ghcr.io/${{ github.repository }}-build-env:${{ needs.changes.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -104,7 +109,7 @@ jobs:
       ${{ !github.event.pull_request.draft && needs.changes.outputs.go == 'true' }}
 
     container:
-      image: ghcr.io/${{ github.repository }}-build-env:${{ github.event_name == 'merge_group' && 'master' || github.base_ref }}
+      image: ghcr.io/${{ github.repository }}-build-env:${{ needs.changes.outputs.image }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Always use the target branch as the image tag: merge_group.base_ref
for merge queue runs, base_ref for PR runs, and ref_name for manual
runs (workflow_dispatch).

Compute the tag once in the changes job and expose it as an output
to avoid repeating the logic in every container job.
