### PR TITLE
fix: do not fail deploying node actions when deploy wf no longer exist

### DIFF
--- a/src/maasserver/models/node.py
+++ b/src/maasserver/models/node.py
@@ -62,7 +62,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from netaddr import IPAddress, IPNetwork
 import petname
-from temporalio.client import WorkflowFailureError, WorkflowQueryFailedError
+from temporalio.client import WorkflowFailureError
 from temporalio.common import WorkflowIDReusePolicy
 from twisted.internet import reactor
 from twisted.internet.defer import (
@@ -3983,10 +3983,7 @@ class Node(CleanSave, TimestampedModel):
         maaslog.info("%s: Releasing node", self.hostname)
 
         if self.status == NODE_STATUS.DEPLOYING:
-            try:
-                stop_workflow(f"deploy:{self.system_id}")
-            except WorkflowQueryFailedError as e:
-                maaslog.error(f"error canceling deployment: {e}")
+            stop_workflow(f"deploy:{self.system_id}")
         # Don't perform stop the node if its already off. Doing so will
         # place an action in the power registry which is not needed and can
         # block a following deploy action. See bug 1453954 for an example of
@@ -4194,12 +4191,7 @@ class Node(CleanSave, TimestampedModel):
             maaslog.error(f"{self.hostname}: Marking node failed{log_snippet}")
             if new_status == NODE_STATUS.FAILED_DEPLOYMENT:
                 maaslog.debug(f"Node '{self.hostname}' failed deployment")
-                try:
-                    stop_workflow(f"deploy:{self.system_id}")
-                except WorkflowQueryFailedError as e:
-                    maaslog.debug(
-                        f"failed to stop deploy:{self.system_id} workflow: {e}"
-                    )
+                stop_workflow(f"deploy:{self.system_id}")
         elif self.status == NODE_STATUS.NEW:
             # Silently ignore, failing a new node makes no sense.
             pass

--- a/src/maasserver/tests/test_workflow.py
+++ b/src/maasserver/tests/test_workflow.py
@@ -1,0 +1,90 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+"""Tests for the workflow module."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from temporalio.service import RPCError, RPCStatusCode
+from twisted.internet.defer import inlineCallbacks
+
+from maasserver import workflow as workflow_module
+from maastesting.crochet import wait_for
+from maastesting.testcase import MAASTestCase
+
+wait_for_reactor = wait_for()
+
+
+class TestStopWorkflow(MAASTestCase):
+    """Tests for stop_workflow function."""
+
+    @wait_for_reactor
+    @inlineCallbacks
+    def test_stops_workflow_successfully(self):
+        """Test that stop_workflow succeeds when workflow exists."""
+        mock_client = MagicMock()
+        mock_handle = MagicMock()
+        mock_handle.cancel = AsyncMock()
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+        self.patch(
+            workflow_module,
+            "get_client_async",
+            AsyncMock(return_value=mock_client),
+        )
+
+        # Should not raise any exception
+        yield workflow_module.stop_workflow("deploy:test-id")
+
+        mock_handle.cancel.assert_called_once()
+
+    @wait_for_reactor
+    @inlineCallbacks
+    def test_handles_workflow_not_found(self):
+        """Test that stop_workflow handles NOT_FOUND status gracefully."""
+        mock_client = MagicMock()
+        mock_handle = MagicMock()
+        mock_handle.cancel = AsyncMock(
+            side_effect=RPCError(
+                "workflow not found for ID: deploy:test-id",
+                RPCStatusCode.NOT_FOUND,
+                b"",
+            )
+        )
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+        self.patch(
+            workflow_module,
+            "get_client_async",
+            AsyncMock(return_value=mock_client),
+        )
+
+        # Should not raise - workflow already gone
+        yield workflow_module.stop_workflow("deploy:test-id")
+
+        mock_handle.cancel.assert_called_once()
+
+    @wait_for_reactor
+    @inlineCallbacks
+    def test_propagates_other_rpc_errors(self):
+        """Test that stop_workflow re-raises other RPCErrors."""
+        mock_client = MagicMock()
+        mock_handle = MagicMock()
+        mock_handle.cancel = AsyncMock(
+            side_effect=RPCError(
+                "connection refused", RPCStatusCode.UNAVAILABLE, b""
+            )
+        )
+        mock_client.get_workflow_handle = MagicMock(return_value=mock_handle)
+
+        self.patch(
+            workflow_module,
+            "get_client_async",
+            AsyncMock(return_value=mock_client),
+        )
+
+        with self.assertRaises(RPCError) as cm:
+            yield workflow_module.stop_workflow("deploy:test-id")
+
+        self.assertIn("connection refused", str(cm.exception))
+        mock_handle.cancel.assert_called_once()

--- a/src/maasserver/workflow/__init__.py
+++ b/src/maasserver/workflow/__init__.py
@@ -7,7 +7,7 @@ from functools import wraps
 from typing import Any, Optional
 import uuid
 
-from temporalio.service import RPCError
+from temporalio.service import RPCError, RPCStatusCode
 from twisted.internet.defer import Deferred, succeed
 
 from maastemporalworker.worker import get_client_async, REGION_TASK_QUEUE
@@ -158,4 +158,9 @@ async def signal_workflow(
 async def stop_workflow(workflow_id: str):
     client = await get_client_async()
     hdl = client.get_workflow_handle(workflow_id=workflow_id)
-    await hdl.cancel()
+    try:
+        await hdl.cancel()
+    except RPCError as e:
+        if e.status == RPCStatusCode.NOT_FOUND:
+            return
+        raise


### PR DESCRIPTION
- Properly check for no workflows found error (`RPCError` with status `RPCStatusCode.NOT_FOUND`)
- Remove `WorkflowQueryFailedError` blocks as `cancel()` is not throwing these errors at all and it was dead code

Resolves: LP:2148683