### PR TITLE
fix(ci): added explicit core26 install to maas-ui-sync.yaml

### DIFF
--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -53,6 +53,7 @@ jobs:
       - name: Build MAAS snap
         run: |
           sudo snap install snapcraft --classic
+          sudo snap install core26
           cd "$GITHUB_WORKSPACE"
           make snap
           make snap-clean


### PR DESCRIPTION
## Done

- Added explicit `core26` install step to support resolute images