### PR TITLE
fix(ci): use edge channel for core26

### DIFF
--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Build MAAS snap
         run: |
           sudo snap install snapcraft --classic
-          sudo snap install core26
+          sudo snap install --edge core26
           cd "$GITHUB_WORKSPACE"
           make snap
           make snap-clean


### PR DESCRIPTION
## Done

- Added `--edge` flag for `core26` snap install