### PR TITLE
fix: correct merge-group image tag

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,9 @@ jobs:
 
       - name: Set build env image tag
         id: image
-        run: echo "tag=${{ github.event.merge_group.base_ref || github.base_ref || github.ref_name }}" >> $GITHUB_OUTPUT
+        run: |
+          ref="${{ github.event.merge_group.base_ref || github.base_ref || github.ref_name }}"
+          echo "tag=${ref#refs/heads/}" >> $GITHUB_OUTPUT
 
       - uses: dorny/paths-filter@61f87a10cd2c304679af17bb73ef192addf33c1c
         id: filter

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,5 +152,5 @@ jobs:
     needs: [lint, test-python, test-go, test-docs]
     steps:
       - name: Check job results
-        if: needs.*.result == 'failure'
+        if: contains(needs.*.result, 'failure')
         run: exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -154,5 +154,5 @@ jobs:
     needs: [lint, test-python, test-go, test-docs]
     steps:
       - name: Check job results
-        if: contains(needs.*.result, 'failure')
+        if: needs.*.result == 'failure'
         run: exit 1

--- a/src/maasserver/forms/__init__.py
+++ b/src/maasserver/forms/__init__.py
@@ -927,7 +927,9 @@ class MachineForm(NodeForm):
             if not min_hwe_kernel:
                 cleaned_data["min_hwe_kernel"] = min_hwe_kernel = "hwe-22.04"
             elif not release_a_newer_than_b(min_hwe_kernel, "hwe-22.04"):
-                raise ValidationError(f"Invalid minimum {min_hwe_kernel} DPU kernel used. Only 'hwe-22.04' or newer are supported.")
+                raise ValidationError(
+                    f"Invalid minimum {min_hwe_kernel} DPU kernel used. Only 'hwe-22.04' or newer are supported."
+                )
 
             if hwe_kernel and not release_a_newer_than_b(
                 hwe_kernel, min_hwe_kernel

--- a/src/maasserver/forms/__init__.py
+++ b/src/maasserver/forms/__init__.py
@@ -927,9 +927,7 @@ class MachineForm(NodeForm):
             if not min_hwe_kernel:
                 cleaned_data["min_hwe_kernel"] = min_hwe_kernel = "hwe-22.04"
             elif not release_a_newer_than_b(min_hwe_kernel, "hwe-22.04"):
-                raise ValidationError(
-                    f"Invalid minimum {min_hwe_kernel} DPU kernel used. Only 'hwe-22.04' or newer are supported."
-                )
+                raise ValidationError(f"Invalid minimum {min_hwe_kernel} DPU kernel used. Only 'hwe-22.04' or newer are supported.")
 
             if hwe_kernel and not release_a_newer_than_b(
                 hwe_kernel, min_hwe_kernel


### PR DESCRIPTION
This PR fixes a bug in the CI pipeline:
- Docker pull fails on `merge_group` runs: `github.event.merge_group.base_ref` returns a full ref (refs/heads/master) instead of a short branch name, producing an invalid Docker image tag. Strip the refs/heads/ prefix with bash parameter expansion so the tag is consistent across all trigger types.