### PR TITLE
fix: correct ci-check gate

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -152,5 +152,5 @@ jobs:
     needs: [lint, test-python, test-go, test-docs]
     steps:
       - name: Check job results
-        if: needs.*.result == 'failure'
+        if: contains(needs.*.result, 'failure')
         run: exit 1


### PR DESCRIPTION
This PR fixes a bug in the CI pipeline:
- `ci-check` always passed: the condition `needs.*.result == 'failure'` incorrectly compares an array to a scalar, which never evaluates to true in GitHub Actions. I have updated this to `contains(needs.*.result, 'failure')`

The **Summary** section of the following two CI runs demonstrate the fix:
- Run 1 -> https://github.com/canonical/maas/actions/runs/24730561697
  shows the current behavior where `ci-check` passes regardless of failures in `lint`, `test-python`, `test-go`, or `test-docs`
- Run 2 -> https://github.com/canonical/maas/actions/runs/24712672300
  is a test run using the fix, where `ci-check` correctly fails when a dependency fails