### PR TITLE
feat: send version in Site Manager heartbeats, known config options when requested

### DIFF
--- a/src/maascommon/workflows/msm.py
+++ b/src/maascommon/workflows/msm.py
@@ -48,6 +48,8 @@ class MSMHeartbeatParam:
     site_name: str
     site_url: str
     rotation_interval_minutes: int
+    version: str | None = None
+    known_config_options: list[str] | None = None
     status: MachinesCountByStatus | None = None
 
 

--- a/src/maastemporalworker/temporal_script.py
+++ b/src/maastemporalworker/temporal_script.py
@@ -233,6 +233,8 @@ async def main() -> None:
                 msm_activity.check_enrol,
                 msm_activity.get_enrol,
                 msm_activity.get_heartbeat_data,
+                msm_activity.get_running_version,
+                msm_activity.get_known_config_options,
                 msm_activity.refresh_token,
                 msm_activity.send_enrol,
                 msm_activity.send_heartbeat,

--- a/src/maastemporalworker/workflow/msm.py
+++ b/src/maastemporalworker/workflow/msm.py
@@ -46,6 +46,7 @@ from maastemporalworker.workflow.utils import (
     activity_defn_with_context,
     workflow_run_with_context,
 )
+from provisioningserver.utils.version import get_running_version
 
 logger = structlog.getLogger()
 
@@ -68,6 +69,8 @@ MSM_SET_ENROL_ACTIVITY_NAME = "msm-set-enrol"
 MSM_VERIFY_TOKEN_ACTIVITY_NAME = "msm-verify-token"
 MSM_GET_ENROL_ACTIVITY_NAME = "msm-get-enrol"
 MSM_GET_HEARTBEAT_DATA_ACTIVITY_NAME = "msm-get-heartbeat-data"
+MSM_GET_KNOWN_CONFIG_OPTIONS = "msm-get-known-config-options"
+MSM_GET_VERSION_ACTIVITY_NAME = "msm-get-version"
 MSM_SEND_HEARTBEAT_ACTIVITY_NAME = "msm-send-heartbeat"
 MSM_SEND_ENROL_ACTIVITY_NAME = "msm-send-enrol"
 MSM_SET_BOOT_SOURCE_ACTIVITY_NAME = "msm-set-bootsource"
@@ -282,15 +285,39 @@ class MSMConnectorActivity(ActivityBase):
         async with self.start_transaction() as services:
             return await services.machines.count_machines_by_statuses()
 
+    @activity_defn_with_context(name=MSM_GET_VERSION_ACTIVITY_NAME)
+    async def get_running_version(self) -> str:
+        """Get the current version of this MAAS
+
+        Returns:
+            str: the simple X.Y.Z version string
+        """
+        version = get_running_version()
+        return f"{version.major}.{version.minor}.{version.point}"
+
+    @activity_defn_with_context(name=MSM_GET_KNOWN_CONFIG_OPTIONS)
+    async def get_known_config_options(self) -> list[str]:
+        """Get the configuration changes that this MAAS knows
+        how to handle.
+
+        Returns:
+            list[str]: the list of configuration option keys supported
+        """
+        # TODO: return the actual options when they're implemented
+        return []
+
     @activity_defn_with_context(name=MSM_SEND_HEARTBEAT_ACTIVITY_NAME)
-    async def send_heartbeat(self, input: MSMHeartbeatParam) -> int:
+    async def send_heartbeat(
+        self, input: MSMHeartbeatParam
+    ) -> tuple[int, bool]:
         """Send heartbeat data to MSM.
 
         Args:
             input (MSMHeartbeatParam): MSM heartbeat data
 
         Returns:
-            int: interval for the next update
+            tuple[int,bool]: interval for the next update and whether
+            the next heartbeat should send the known configuration options
         """
         headers = {
             "Authorization": f"bearer {input.jwt}",
@@ -300,7 +327,10 @@ class MSMConnectorActivity(ActivityBase):
             "name": input.site_name,
             "url": input.site_url,
             "machines_by_status": dataclasses.asdict(input.status),
+            "version": input.version,
         }
+        if input.known_config_options is not None:
+            data["known_config_options"] = input.known_config_options
 
         heartbeat_url = input.sm_url + MSM_DETAIL_EP
 
@@ -309,12 +339,16 @@ class MSMConnectorActivity(ActivityBase):
         ) as response:
             match response.status:
                 case 200:
-                    return int(
-                        response.headers["MSM-Heartbeat-Interval-Seconds"]
+                    body = await response.json()
+                    return (
+                        int(
+                            response.headers["MSM-Heartbeat-Interval-Seconds"]
+                        ),
+                        body.get("config_options_requested", False),
                     )
                 case 401 | 404:
                     logger.error("Enrolment cancelled by MSM, aborting")
-                    return -1
+                    return -1, False
                 case _:
                     raise ApplicationError(
                         f"got unexpected return code: HTTP {response.status}"
@@ -516,6 +550,7 @@ class MSMHeartbeatWorkflow:
         """
         self._running = True
         next_update = 0
+        send_config_opts = False
         while next_update >= 0:
             secret = await workflow.execute_activity(
                 MSM_GET_ENROL_ACTIVITY_NAME,
@@ -525,9 +560,27 @@ class MSMHeartbeatWorkflow:
                 MSM_GET_HEARTBEAT_DATA_ACTIVITY_NAME,
                 start_to_close_timeout=MSM_TIMEOUT,
             )
-            next_update = await workflow.execute_activity(
+            version = await workflow.execute_activity(
+                MSM_GET_VERSION_ACTIVITY_NAME,
+                start_to_close_timeout=MSM_TIMEOUT,
+            )
+            config_opts = (
+                await workflow.execute_activity(
+                    MSM_GET_KNOWN_CONFIG_OPTIONS,
+                    start_to_close_timeout=MSM_TIMEOUT,
+                )
+                if send_config_opts
+                else None
+            )
+            next_update, send_config_opts = await workflow.execute_activity(
                 MSM_SEND_HEARTBEAT_ACTIVITY_NAME,
-                dataclasses.replace(input, status=data, jwt=secret["jwt"]),
+                dataclasses.replace(
+                    input,
+                    status=data,
+                    jwt=secret["jwt"],
+                    version=version,
+                    known_config_options=config_opts,
+                ),
                 start_to_close_timeout=MSM_TIMEOUT,
                 retry_policy=RetryPolicy(
                     backoff_coefficient=1.0,

--- a/src/tests/maastemporalworker/workflow/test_msm.py
+++ b/src/tests/maastemporalworker/workflow/test_msm.py
@@ -690,7 +690,9 @@ class TestMSMHeartbeatWorkflow:
             input: MSMHeartbeatParam,
         ) -> tuple[int, bool]:
             calls["msm-send-heartbeat"].append(True)
-            return (-1, False)
+            if len(calls["msm-send-heartbeat"]) == 2:
+                return (-1, False)
+            return (1, True)
 
         @activity.defn(name=MSM_GET_ENROL_ACTIVITY_NAME)
         async def get_enrol() -> dict[str, Any]:
@@ -732,10 +734,10 @@ class TestMSMHeartbeatWorkflow:
                     task_queue=worker.task_queue,
                 )
 
-        assert len(calls["msm-get-heartbeat-data"]) == 1
-        assert len(calls["msm-send-heartbeat"]) == 1
-        assert len(calls["msm-get-enrol"]) == 1
-        assert len(calls["msm-get-version"]) == 1
+        assert len(calls["msm-get-heartbeat-data"]) == 2
+        assert len(calls["msm-send-heartbeat"]) == 2
+        assert len(calls["msm-get-enrol"]) == 2
+        assert len(calls["msm-get-version"]) == 2
         assert len(calls["msm-get-config-options"]) == 1
 
 

--- a/src/tests/maastemporalworker/workflow/test_msm.py
+++ b/src/tests/maastemporalworker/workflow/test_msm.py
@@ -36,7 +36,9 @@ from maastemporalworker.workflow.msm import (
     MSM_ENROL_EP,
     MSM_GET_ENROL_ACTIVITY_NAME,
     MSM_GET_HEARTBEAT_DATA_ACTIVITY_NAME,
+    MSM_GET_KNOWN_CONFIG_OPTIONS,
     MSM_GET_TOKEN_REFRESH_ACTIVITY_NAME,
+    MSM_GET_VERSION_ACTIVITY_NAME,
     MSM_REFRESH_EP,
     MSM_RESTORE_DEFAULT_BOOT_SOURCE_ACTIVITY_NAME,
     MSM_SEND_ENROL_ACTIVITY_NAME,
@@ -116,6 +118,8 @@ def hb_param() -> MSMHeartbeatParam:
             allocated=1,
             deployed=2,
         ),
+        version="3.8.0",
+        known_config_options=None,
     )
 
 
@@ -356,15 +360,19 @@ class TestMSMActivities:
             True,
             200,
             "",
+            body={"config_options_requested": False},
             headers={
                 "MSM-Heartbeat-Interval-Seconds": 300,
             },
         )
 
         env = ActivityEnvironment()
-        intval = await env.run(msm_act.send_heartbeat, hb_param)
+        intval, send_config_opts = await env.run(
+            msm_act.send_heartbeat, hb_param
+        )
 
         assert intval == 300
+        assert send_config_opts is False
         mocked_session.post.assert_called_once()
         args = mocked_session.post.call_args.args
         kwargs = mocked_session.post.call_args.kwargs
@@ -373,14 +381,19 @@ class TestMSMActivities:
         assert kwargs["json"]["name"] == _MAAS_SITE_NAME
         assert kwargs["json"]["url"] == _MAAS_URL
         assert "machines_by_status" in kwargs["json"]
+        assert kwargs["json"]["version"] == hb_param.version
+        assert "known_config_options" not in kwargs["json"]
 
     async def test_send_heartbeat_cancel(self, mocker, msm_act, hb_param):
         mocked_session = msm_act._session
         self._mock_post(mocker, mocked_session, True, 401, "")
 
         env = ActivityEnvironment()
-        intval = await env.run(msm_act.send_heartbeat, hb_param)
+        intval, send_config_opts = await env.run(
+            msm_act.send_heartbeat, hb_param
+        )
         assert intval == -1
+        assert send_config_opts is False
 
     async def test_refresh_token(self, mocker, msm_act, hb_param):
         mocked_session = msm_act._session
@@ -496,6 +509,21 @@ class TestMSMActivities:
         env = ActivityEnvironment()
         await env.run(msm_act.restore_default_boot_source)
         services_mock.image_sync.ensure_boot_source_definition.assert_called_once()
+
+    async def test_get_known_config_options(self, msm_act):
+        env = ActivityEnvironment()
+        config_opts = await env.run(msm_act.get_known_config_options)
+        # TODO: update once config workflow is implemented
+        assert config_opts == []
+
+    async def test_get_running_version(self, msm_act):
+        env = ActivityEnvironment()
+        version = await env.run(msm_act.get_running_version)
+        # Verify version is in X.Y.Z format
+        parts = version.split(".")
+        assert len(parts) == 3
+        for part in parts:
+            assert part.isdigit()
 
 
 class TestMSMEnrolWorkflow:
@@ -658,9 +686,11 @@ class TestMSMHeartbeatWorkflow:
             return MachinesCountByStatus(allocated=1, deployed=1)
 
         @activity.defn(name=MSM_SEND_HEARTBEAT_ACTIVITY_NAME)
-        async def send_heartbeat(input: MSMHeartbeatParam) -> int:
+        async def send_heartbeat(
+            input: MSMHeartbeatParam,
+        ) -> tuple[int, bool]:
             calls["msm-send-heartbeat"].append(True)
-            return -1
+            return (-1, False)
 
         @activity.defn(name=MSM_GET_ENROL_ACTIVITY_NAME)
         async def get_enrol() -> dict[str, Any]:
@@ -672,6 +702,16 @@ class TestMSMHeartbeatWorkflow:
                 "jwt_refresh_url": _JWT_REFRESH_URL,
             }
 
+        @activity.defn(name=MSM_GET_VERSION_ACTIVITY_NAME)
+        async def get_version() -> str:
+            calls["msm-get-version"].append(True)
+            return "3.4.0"
+
+        @activity.defn(name=MSM_GET_KNOWN_CONFIG_OPTIONS)
+        async def get_config_options() -> list[str]:
+            calls["msm-get-config-options"].append(True)
+            return []
+
         async with await WorkflowEnvironment.start_time_skipping() as env:
             async with Worker(
                 env.client,
@@ -681,6 +721,8 @@ class TestMSMHeartbeatWorkflow:
                     get_heartbeat_data,
                     send_heartbeat,
                     get_enrol,
+                    get_version,
+                    get_config_options,
                 ],
             ) as worker:
                 await env.client.execute_workflow(
@@ -693,6 +735,8 @@ class TestMSMHeartbeatWorkflow:
         assert len(calls["msm-get-heartbeat-data"]) == 1
         assert len(calls["msm-send-heartbeat"]) == 1
         assert len(calls["msm-get-enrol"]) == 1
+        assert len(calls["msm-get-version"]) == 1
+        assert len(calls["msm-get-config-options"]) == 1
 
 
 class TestMSMTokenRefreshWorkflow:

--- a/src/tests/maastemporalworker/workflow/test_msm.py
+++ b/src/tests/maastemporalworker/workflow/test_msm.py
@@ -3,6 +3,7 @@
 
 from collections import defaultdict
 from dataclasses import replace
+import re
 from typing import Any
 from unittest.mock import Mock, PropertyMock
 import uuid
@@ -384,6 +385,42 @@ class TestMSMActivities:
         assert kwargs["json"]["version"] == hb_param.version
         assert "known_config_options" not in kwargs["json"]
 
+    async def test_send_heartbeat_with_cfg_options(
+        self, mocker, msm_act, hb_param
+    ):
+        mocked_session = msm_act._session
+        self._mock_post(
+            mocker,
+            mocked_session,
+            True,
+            200,
+            "",
+            body={"config_options_requested": True},
+            headers={
+                "MSM-Heartbeat-Interval-Seconds": 300,
+            },
+        )
+
+        env = ActivityEnvironment()
+        hb_param.known_config_options = []
+        intval, send_config_opts = await env.run(
+            msm_act.send_heartbeat, hb_param
+        )
+
+        assert intval == 300
+        assert send_config_opts is True
+        mocked_session.post.assert_called_once()
+        args = mocked_session.post.call_args.args
+        kwargs = mocked_session.post.call_args.kwargs
+        assert args[0] == _MSM_DETAIL_URL
+        assert kwargs["headers"]["Authorization"] is not None
+        assert kwargs["json"]["name"] == _MAAS_SITE_NAME
+        assert kwargs["json"]["url"] == _MAAS_URL
+        assert "machines_by_status" in kwargs["json"]
+        assert kwargs["json"]["version"] == hb_param.version
+        # TODO: update once config workflow is implemented
+        assert kwargs["json"]["known_config_options"] == []
+
     async def test_send_heartbeat_cancel(self, mocker, msm_act, hb_param):
         mocked_session = msm_act._session
         self._mock_post(mocker, mocked_session, True, 401, "")
@@ -520,10 +557,7 @@ class TestMSMActivities:
         env = ActivityEnvironment()
         version = await env.run(msm_act.get_running_version)
         # Verify version is in X.Y.Z format
-        parts = version.split(".")
-        assert len(parts) == 3
-        for part in parts:
-            assert part.isdigit()
+        assert re.match(r"^\d+\.\d+\.\d+$", version)
 
 
 class TestMSMEnrolWorkflow:


### PR DESCRIPTION
Updates the Site Manager heartbeat workflow to send the current MAAS version and known configuration options when requested with each heartbeat. Until the configuration workflow is implemented, an empty list is sent as the known configuration options.