### PR TITLE
fix: accept lists and strings for expected audience when decoding JWT

### DIFF
--- a/src/maascommon/utils/jwt.py
+++ b/src/maascommon/utils/jwt.py
@@ -30,7 +30,7 @@ class JWTAudienceError(JWTDecodeError):
 def decode_unverified_jwt(
     token: str,
     check_expiration: bool = True,
-    expected_audience: str | list[str] | None = None,
+    expected_audience: str | None = None,
 ) -> dict[str, Any]:
     """Decode a JWT without verifying its signature to extract claims."""
     try:
@@ -45,11 +45,13 @@ def decode_unverified_jwt(
         if expected_audience is not None:
             aud = claims.get("aud")
             throw = False
-            match expected_audience:
+            match aud:
                 case str():
                     throw = aud != expected_audience
                 case list():
-                    throw = aud not in expected_audience
+                    throw = expected_audience not in aud
+                case None:
+                    throw = True
             if throw:
                 raise JWTAudienceError(
                     f"invalid audience: expected {expected_audience}, got {aud}"

--- a/src/maascommon/utils/jwt.py
+++ b/src/maascommon/utils/jwt.py
@@ -30,7 +30,7 @@ class JWTAudienceError(JWTDecodeError):
 def decode_unverified_jwt(
     token: str,
     check_expiration: bool = True,
-    expected_audience: str | None = None,
+    expected_audience: str | list[str] | None = None,
 ) -> dict[str, Any]:
     """Decode a JWT without verifying its signature to extract claims."""
     try:
@@ -44,11 +44,16 @@ def decode_unverified_jwt(
 
         if expected_audience is not None:
             aud = claims.get("aud")
-            if aud != expected_audience:
+            throw = False
+            match expected_audience:
+                case str():
+                    throw = aud != expected_audience
+                case list():
+                    throw = aud not in expected_audience
+            if throw:
                 raise JWTAudienceError(
                     f"invalid audience: expected {expected_audience}, got {aud}"
                 )
-
         return claims
 
     except (

--- a/src/maasservicelayer/services/msm.py
+++ b/src/maasservicelayer/services/msm.py
@@ -88,7 +88,7 @@ class MSMService(Service):
             claims = decode_unverified_jwt(
                 encoded,
                 check_expiration=False,
-                expected_audience=[SITE_AUDIENCE],
+                expected_audience=SITE_AUDIENCE,
             )
         except JWTDecodeError as ex:
             raise MSMException(str(ex)) from ex

--- a/src/maasservicelayer/services/msm.py
+++ b/src/maasservicelayer/services/msm.py
@@ -88,7 +88,7 @@ class MSMService(Service):
             claims = decode_unverified_jwt(
                 encoded,
                 check_expiration=False,
-                expected_audience=SITE_AUDIENCE,
+                expected_audience=[SITE_AUDIENCE],
             )
         except JWTDecodeError as ex:
             raise MSMException(str(ex)) from ex

--- a/src/tests/maascommon/utils/test_jwt.py
+++ b/src/tests/maascommon/utils/test_jwt.py
@@ -89,7 +89,7 @@ class TestDecodeUnverifiedJWT:
         token = create_test_jwt(payload)
         with pytest.raises(
             JWTDecodeError,
-            match=f"invalid audience",
+            match="invalid audience",
         ):
             decode_unverified_jwt(token, expected_audience=expected_aud)
 

--- a/src/tests/maascommon/utils/test_jwt.py
+++ b/src/tests/maascommon/utils/test_jwt.py
@@ -59,22 +59,39 @@ class TestDecodeUnverifiedJWT:
         decoded = decode_unverified_jwt(token, check_expiration=True)
         assert decoded["sub"] == "user123"
 
-    def test_decode_token_with_valid_audience(self):
-        payload = {"sub": "user123", "aud": "expected-audience"}
+    @pytest.mark.parameterize(
+        "payload_aud, expected_aud",
+        [
+            ("expected-audience", "expected-audience"),
+            (["expected-audience"], "expected-audience"),
+            (["expected-audience", "other-audience"], "expected-audience"),
+        ],
+    )
+    def test_decode_token_with_valid_audience(self, payload_aud, expected_aud):
+        payload = {"sub": "user123", "aud": payload_aud}
         token = create_test_jwt(payload)
-        decoded = decode_unverified_jwt(
-            token, expected_audience="expected-audience"
-        )
+        decoded = decode_unverified_jwt(token, expected_audience=expected_aud)
         assert decoded["sub"] == "user123"
 
-    def test_decode_token_with_invalid_audience(self):
-        payload = {"sub": "user123", "aud": "wrong-audience"}
+    @pytest.mark.parameterize(
+        "payload_aud, expected_aud",
+        [
+            ("expected-audience", "expected-aud"),
+            (["expected-audience"], "expected-aud"),
+            (["expected-audience", "other-audience"], "expected-aud"),
+            ([], "expected-aud"),
+        ],
+    )
+    def test_decode_token_with_invalid_audience(
+        self, payload_aud, expected_aud
+    ):
+        payload = {"sub": "user123", "aud": payload_aud}
         token = create_test_jwt(payload)
         with pytest.raises(
             JWTDecodeError,
-            match="invalid audience: expected expected-audience, got wrong-audience",
+            match=f"invalid audience: expected {expected_aud}, got {payload_aud}",
         ):
-            decode_unverified_jwt(token, expected_audience="expected-audience")
+            decode_unverified_jwt(token, expected_audience=expected_aud)
 
     def test_decode_token_missing_audience(self):
         payload = {"sub": "user123"}

--- a/src/tests/maascommon/utils/test_jwt.py
+++ b/src/tests/maascommon/utils/test_jwt.py
@@ -59,7 +59,7 @@ class TestDecodeUnverifiedJWT:
         decoded = decode_unverified_jwt(token, check_expiration=True)
         assert decoded["sub"] == "user123"
 
-    @pytest.mark.parameterize(
+    @pytest.mark.parametrize(
         "payload_aud, expected_aud",
         [
             ("expected-audience", "expected-audience"),
@@ -73,7 +73,7 @@ class TestDecodeUnverifiedJWT:
         decoded = decode_unverified_jwt(token, expected_audience=expected_aud)
         assert decoded["sub"] == "user123"
 
-    @pytest.mark.parameterize(
+    @pytest.mark.parametrize(
         "payload_aud, expected_aud",
         [
             ("expected-audience", "expected-aud"),

--- a/src/tests/maascommon/utils/test_jwt.py
+++ b/src/tests/maascommon/utils/test_jwt.py
@@ -89,7 +89,7 @@ class TestDecodeUnverifiedJWT:
         token = create_test_jwt(payload)
         with pytest.raises(
             JWTDecodeError,
-            match=f"invalid audience: expected {expected_aud}, got {payload_aud}",
+            match=f"invalid audience",
         ):
             decode_unverified_jwt(token, expected_audience=expected_aud)
 


### PR DESCRIPTION
Per RFC 7519, a JWT's `aud` claim can be a list of strings or a string, so enable checking for both when decoding an unverified JWT.