### PR TITLE
build: fix snap tree

### DIFF
--- a/snap/local/tree/usr/bin/run-squid
+++ b/snap/local/tree/usr/bin/run-squid
@@ -14,11 +14,11 @@ if [ ! -e "$SNAP_DATA/proxy/maas-proxy.conf" ]; then
 fi
 
 # Ensure that the cache is initialized.
-squid -z -d 5 -N -f "$SNAP_DATA/proxy/maas-proxy.conf"
+$SNAP/usr/sbin/squid-gnutls -z -d 5 -N -f "$SNAP_DATA/proxy/maas-proxy.conf"
 
 # Start squid, force kill it when the script is terminated. Squid sometimes
 # (most of the time) just does not want to die.
 trap 'kill -9 $PID; wait $PID' TERM INT
-squid -N -d 5 -f "$SNAP_DATA/proxy/maas-proxy.conf" &
+$SNAP/usr/sbin/squid-gnutls -N -d 5 -f "$SNAP_DATA/proxy/maas-proxy.conf" &
 PID=$!
 wait "$PID"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ confinement: strict
 base: core26
 build-base: devel
 assumes:
-  - snapd2.53
+  - snapd2.75
 system-usernames:
   snap_daemon: shared
 # epochs:
@@ -204,6 +204,8 @@ parts:
       - util-linux
       - wget # DLI
       - wsmancli # AMT
+    build-attributes:
+      - enable-usrmerge
     organize:
       lib/python3.*/site-packages/etc/*: etc/
       lib/python3.*/site-packages/usr/bin/*: usr/bin/
@@ -215,7 +217,6 @@ parts:
       usr/local/bin/*: usr/bin/
       usr/local/lib/python3.14/*: usr/lib/python3.14/
     stage:
-      - bin
       - etc/bind
       - etc/chrony
       - etc/freeipmi
@@ -223,8 +224,6 @@ parts:
       - etc/maas
       - etc/nginx
       - etc/openwsman
-      - sbin
-      - lib
       - -lib/python3.*/site-packages/etc
       - -lib/python3.*/site-packages/usr
       - -lib/python3/dist-packages/maastesting


### PR DESCRIPTION
- core26 requires snapd >= 2.75
- enable merged /usr mode
- fix squid path