### PR TITLE
fix: change expected bin path refs for core26

### DIFF
--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -46,4 +46,4 @@ for preseed in "${PRESEEDS[@]}"; do
 done
 
 # Perform migrations. Does nothing in 'rack' or 'none' mode.
-"$SNAP/bin/maas" migrate --configure
+"$SNAP/usr/bin/maas" migrate --configure

--- a/snap/local/tree/usr/bin/run-apiserver
+++ b/snap/local/tree/usr/bin/run-apiserver
@@ -11,4 +11,4 @@ export MAAS_INTERNALAPISERVER_HTTP_SOCKET_PATH="$SNAP_DATA/internalapiserver-htt
 export MAAS_REGION_CONFIG="$SNAP_DATA/regiond.conf"
 export MAAS_OPENFGA_HTTP_SOCKET_PATH="$SNAP_DATA/openfga-http.sock"
 
-exec "$SNAP/bin/maas-apiserver"
+exec "$SNAP/usr/bin/maas-apiserver"

--- a/snap/local/tree/usr/bin/run-named
+++ b/snap/local/tree/usr/bin/run-named
@@ -13,8 +13,8 @@ mkdir -p "$SNAP_DATA/bind/cache"
 
 # generate MAAS bind configuration
 MAAS_ZONE_FILE_CONFIG_DIR="$SNAP_DATA/bind" \
-    MAAS_DNS_CONFIG_DIR="$SNAP_DATA/bind" \
-    "$SNAP/bin/maas-rack" setup-dns --no-clobber
+  MAAS_DNS_CONFIG_DIR="$SNAP_DATA/bind" \
+  "$SNAP/usr/bin/maas-rack" setup-dns --no-clobber
 
 # named default socket limit (21k) can be higher than current limits.
 # Increase the limit to the max allowed and restrict named to this.
@@ -23,6 +23,6 @@ ulimit -n "$(ulimit -Hn)"
 MAAS_DNS_SOCK_LIMIT=$(ulimit -n)
 
 exec "$SNAP/usr/sbin/named" \
-    -c "$SNAP_DATA/bind/named.conf" \
-    -S "$MAAS_DNS_SOCK_LIMIT" \
-    -g
+  -c "$SNAP_DATA/bind/named.conf" \
+  -S "$MAAS_DNS_SOCK_LIMIT" \
+  -g

--- a/snap/local/tree/usr/bin/run-pebble-daemon
+++ b/snap/local/tree/usr/bin/run-pebble-daemon
@@ -11,7 +11,7 @@ export prometheus_multiproc_dir=/tmp/prometheus
 rm -rf "$prometheus_multiproc_dir"
 mkdir -p "$prometheus_multiproc_dir"
 
-"$SNAP/bin/reconfigure-pebble"
+"$SNAP/usr/bin/reconfigure-pebble"
 
 # Run the supervisor for the snap.
 exec pebble run --verbose

--- a/snap/local/tree/usr/bin/run-rackd
+++ b/snap/local/tree/usr/bin/run-rackd
@@ -5,16 +5,16 @@
 SNAP_MODE=$(cat "$SNAP_COMMON/snap_mode")
 
 if [ "$SNAP_MODE" = 'all' ] && [ ! -e "$SNAP_DATA/rackd.conf" ]; then
-    cat <<EOF >"$SNAP_DATA/rackd.conf"
+  cat <<EOF >"$SNAP_DATA/rackd.conf"
 maas_url: http://localhost:5240/MAAS
 EOF
 fi
 
 # Remove the dhcp configuration so its not started unless needed.
 rm -f \
-   "$SNAP_COMMON/maas/dhcpd.sock" \
-   "$SNAP_COMMON/maas/dhcpd.conf" \
-   "$SNAP_COMMON/maas/dhcpd6.conf"
+  "$SNAP_COMMON/maas/dhcpd.sock" \
+  "$SNAP_COMMON/maas/dhcpd.conf" \
+  "$SNAP_COMMON/maas/dhcpd6.conf"
 
 # Configure MAAS to work in a snap.
 export MAAS_PATH="$SNAP"
@@ -38,4 +38,4 @@ PERL5LIB="$SNAP/usr/share/perl5:$SNAP/usr/share/perl/${PERLVER}:$SNAP/usr/lib/$(
 
 mkdir -p "$MAAS_CACHE"
 
-exec "$SNAP/bin/rackd"
+exec "$SNAP/usr/bin/rackd"

--- a/snap/local/tree/usr/bin/run-regiond
+++ b/snap/local/tree/usr/bin/run-regiond
@@ -27,8 +27,8 @@ export MAAS_OPENFGA_HTTP_SOCKET_PATH="$SNAP_DATA/openfga-http.sock"
 # ensure these dirs exist here since the region creates config files for other
 # services
 mkdir -p \
-      "$MAAS_DNS_CONFIG_DIR" \
-      "$MAAS_PROXY_CONFIG_DIR" \
-      "$MAAS_SYSLOG_CONFIG_DIR"
+  "$MAAS_DNS_CONFIG_DIR" \
+  "$MAAS_PROXY_CONFIG_DIR" \
+  "$MAAS_SYSLOG_CONFIG_DIR"
 
-exec "$SNAP/bin/regiond"
+exec "$SNAP/usr/bin/regiond"

--- a/snap/local/tree/usr/bin/run-temporal-worker
+++ b/snap/local/tree/usr/bin/run-temporal-worker
@@ -13,4 +13,4 @@ export MAAS_DNS_CONFIG_DIR="$SNAP_DATA/bind"
 export MAAS_ZONE_FILE_CONFIG_DIR="$SNAP_DATA/bind"
 export MAAS_IMAGES_KEYRING_FILEPATH="/snap/maas/current/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg"
 
-exec "$SNAP/bin/maas-temporal-worker"
+exec "$SNAP/usr/bin/maas-temporal-worker"

--- a/snap/local/tree/usr/share/maas/pebble/layers/001-maas-base-layer.yaml
+++ b/snap/local/tree/usr/share/maas/pebble/layers/001-maas-base-layer.yaml
@@ -7,25 +7,25 @@ services:
   bind9:
     override: replace
     # Note: we use `sh -c` to expand the `$SNAP` environment variable
-    command: sh -c "exec systemd-cat -t named $SNAP/bin/run-named"
+    command: sh -c "exec systemd-cat -t named $SNAP/usr/bin/run-named"
     startup: disabled
 
   http:
     override: replace
-    command: sh -c "exec systemd-cat -t maas-http $SNAP/bin/run-nginx"
+    command: sh -c "exec systemd-cat -t maas-http $SNAP/usr/bin/run-nginx"
     startup: disabled
 
   ntp:
     override: replace
-    command: sh -c "exec systemd-cat -t chronyd $SNAP/bin/run-chronyd"
+    command: sh -c "exec systemd-cat -t chronyd $SNAP/usr/bin/run-chronyd"
     startup: disabled
 
   proxy:
     override: replace
-    command: sh -c "exec systemd-cat -t maas-proxy $SNAP/bin/run-squid"
+    command: sh -c "exec systemd-cat -t maas-proxy $SNAP/usr/bin/run-squid"
     startup: disabled
 
   syslog:
     override: replace
-    command: sh -c "exec $SNAP/bin/run-rsyslog"
+    command: sh -c "exec $SNAP/usr/bin/run-rsyslog"
     startup: disabled

--- a/snap/local/tree/usr/share/maas/pebble/layers/002-maas-region-layer.yaml
+++ b/snap/local/tree/usr/share/maas/pebble/layers/002-maas-region-layer.yaml
@@ -7,7 +7,7 @@ services:
   regiond:
     override: replace
     # Note: we use `sh -c` to expand the `$SNAP` environment variable
-    command: sh -c "exec systemd-cat -t maas-regiond $SNAP/bin/run-regiond"
+    command: sh -c "exec systemd-cat -t maas-regiond $SNAP/usr/bin/run-regiond"
     startup: enabled
     # Workaround for https://github.com/canonical/pebble/issues/231
     before:
@@ -20,7 +20,7 @@ services:
 
   apiserver:
     override: replace
-    command: sh -c "exec systemd-cat -t maas-apiserver $SNAP/bin/run-apiserver"
+    command: sh -c "exec systemd-cat -t maas-apiserver $SNAP/usr/bin/run-apiserver"
     startup: enabled
     before:
       - http
@@ -31,17 +31,17 @@ services:
 
   temporal:
     override: replace
-    command: sh -c "exec systemd-cat -t maas-temporal $SNAP/bin/run-temporal"
+    command: sh -c "exec systemd-cat -t maas-temporal $SNAP/usr/bin/run-temporal"
     startup: disabled
 
   temporal-worker:
     override: replace
-    command: sh -c "exec systemd-cat -t maas-temporal-worker $SNAP/bin/run-temporal-worker"
+    command: sh -c "exec systemd-cat -t maas-temporal-worker $SNAP/usr/bin/run-temporal-worker"
     startup: disabled
 
   openfga:
     override: replace
     startup: enabled
-    command: sh -c "exec systemd-cat -t maas-openfga $SNAP/bin/run-openfga"
+    command: sh -c "exec systemd-cat -t maas-openfga $SNAP/usr/bin/run-openfga"
     before:
       - syslog

--- a/snap/local/tree/usr/share/maas/pebble/layers/003-maas-rack-layer.yaml
+++ b/snap/local/tree/usr/share/maas/pebble/layers/003-maas-rack-layer.yaml
@@ -7,7 +7,7 @@ services:
   rackd:
     override: replace
     # Note: we use `sh -c` to expand the `$SNAP` environment variable
-    command: sh -c "exec systemd-cat -t maas-rackd $SNAP/bin/run-rackd"
+    command: sh -c "exec systemd-cat -t maas-rackd $SNAP/usr/bin/run-rackd"
     startup: enabled
     # Workaround for https://github.com/canonical/pebble/issues/231
     before:
@@ -22,14 +22,14 @@ services:
   dhcpd:
     override: replace
     startup: disabled
-    command: sh -c "exec systemd-cat -t dhcpd $SNAP/bin/run-dhcpd"
+    command: sh -c "exec systemd-cat -t dhcpd $SNAP/usr/bin/run-dhcpd"
 
   dhcpd6:
     override: replace
     startup: disabled
-    command: sh -c "exec systemd-cat -t dhcpd6 $SNAP/bin/run-dhcpd6"
+    command: sh -c "exec systemd-cat -t dhcpd6 $SNAP/usr/bin/run-dhcpd6"
 
   agent:
     override: replace
     startup: disabled
-    command: sh -c "exec systemd-cat -t maas-agent $SNAP/bin/run-maas-agent"
+    command: sh -c "exec systemd-cat -t maas-agent $SNAP/usr/bin/run-maas-agent"

--- a/src/maascli/snap.py
+++ b/src/maascli/snap.py
@@ -320,7 +320,7 @@ def migrate_db(capture=False):
     if capture:
         process = subprocess.Popen(
             [
-                os.path.join(os.environ["SNAP"], "bin", "maas-region"),
+                os.path.join(os.environ["SNAP"], "usr", "bin", "maas-region"),
                 "dbupgrade",
             ],
             stdout=subprocess.PIPE,
@@ -337,7 +337,7 @@ def migrate_db(capture=False):
     else:
         subprocess.check_call(
             [
-                os.path.join(os.environ["SNAP"], "bin", "maas-region"),
+                os.path.join(os.environ["SNAP"], "usr", "bin", "maas-region"),
                 "dbupgrade",
             ]
         )
@@ -959,7 +959,9 @@ class cmd_status(SnapCommand):
         else:
             process = subprocess.Popen(
                 [
-                    os.path.join(os.environ["SNAP"], "bin", "run-pebble"),
+                    os.path.join(
+                        os.environ["SNAP"], "usr", "bin", "run-pebble"
+                    ),
                     "services",
                 ],
                 stdout=subprocess.PIPE,


### PR DESCRIPTION
With core26, we changed paths of binaries from `/bin` to `/usr/bin`. We have several references to the `/bin` path in the code, and this PR changes them to appropriately reflect the expected ones now.

Note that it seems this does not affect snap builds due to symlinks. However, it affects the dev-snap when running `snap try` (as in there the symlinks do not seem to apply).