### PR TITLE
fix(ci): core26 and cypress fix for maas-ui-sync MAASENG-6450

### DIFF
--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -71,6 +71,8 @@ jobs:
           lxc exec maas-ui-tester-backend -- apt-get update
           lxc exec maas-ui-tester-backend -- apt-get install -y snapd
           lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
+          lxc exec maas-ui-tester-backend -- snap refresh snapd
+          lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -71,8 +71,6 @@ jobs:
           lxc exec maas-ui-tester-backend -- apt-get update
           lxc exec maas-ui-tester-backend -- apt-get install -y snapd
           lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
-          lxc exec maas-ui-tester-backend -- snap refresh snapd
-          lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -62,6 +62,10 @@ jobs:
           make snap
           # make snap-clean  # temporarily disabled for debugging
 
+      - name: Inspect snap contents
+        run: |
+          unsquashfs -l *.snap | grep "bin/maas" | head -20
+
       - name: Setup LXD container
         id: setup-lxd
         run: |

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -70,6 +70,7 @@ jobs:
           lxc exec maas-ui-tester-backend -- cloud-init status --wait
           lxc exec maas-ui-tester-backend -- snap install snapd --beta
           lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
+          lxc exec maas-ui-tester-backend -- snap install --edge core26
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -56,6 +56,7 @@ jobs:
       - name: Build MAAS snap
         run: |
           sudo snap install snapcraft --classic
+          sudo snap refresh snapd
           sudo snap install --edge core26
           cd "$GITHUB_WORKSPACE"
           make snap
@@ -67,6 +68,8 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           lxc launch ubuntu:24.04 maas-ui-tester-backend
           lxc exec maas-ui-tester-backend -- cloud-init status --wait
+          lxc exec maas-ui-tester-backend -- snap refresh snapd
+          lxc exec maas-ui-tester-backend -- snap install --edge core26
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -60,7 +60,7 @@ jobs:
           sudo snap install --edge core26
           cd "$GITHUB_WORKSPACE"
           make snap
-          make snap-clean
+          # make snap-clean  # temporarily disabled for debugging
 
       - name: Setup LXD container
         id: setup-lxd
@@ -72,6 +72,7 @@ jobs:
           lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
           lxc exec maas-ui-tester-backend -- snap install --edge core26
           lxc file push *.snap maas-ui-tester-backend/maas-snap
+          lxc exec maas-ui-tester-backend -- snap info /maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge
           lxc exec maas-ui-tester-backend -- snap install /maas-snap --dangerous

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -60,11 +60,7 @@ jobs:
           sudo snap install --edge core26
           cd "$GITHUB_WORKSPACE"
           make snap
-          # make snap-clean  # temporarily disabled for debugging
-
-      - name: Inspect snap contents
-        run: |
-          unsquashfs -l *.snap | grep "bin/maas" | head -20
+          make snap-clean
 
       - name: Setup LXD container
         id: setup-lxd
@@ -76,7 +72,6 @@ jobs:
           lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
           lxc exec maas-ui-tester-backend -- snap install --edge core26
           lxc file push *.snap maas-ui-tester-backend/maas-snap
-          lxc exec maas-ui-tester-backend -- snap info /maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge
           lxc exec maas-ui-tester-backend -- snap install /maas-snap --dangerous

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -106,6 +106,8 @@ jobs:
           npm install cypress
 
           mkdir -p cypress/e2e
+          mkdir -p cypress/support
+          touch cypress/support/e2e.js
           echo 'const { defineConfig } = require("cypress"); module.exports = defineConfig({ e2e: { setupNodeEvents(on, config) {} } });' > cypress.config.js
           echo 'describe("MAAS UI sync check", () => { it("loads and shows the initial setup page", () => { cy.visit(Cypress.env("URL")); cy.get("#maas-ui", { timeout: 30000 }).should("exist"); cy.contains(/Loading/i, { timeout: 30000 }).should("not.exist"); cy.contains("Failed to connect").should("not.exist"); cy.get(".p-card__title", { timeout: 30000 }).should("contain", "No admin user has been created yet"); }); });' > cypress/e2e/sync-check.cy.js
           npx cypress run

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -66,10 +66,8 @@ jobs:
         id: setup-lxd
         run: |
           cd "$GITHUB_WORKSPACE"
-          lxc launch ubuntu:24.04 maas-ui-tester-backend
+          lxc launch ubuntu:26.04 maas-ui-tester-backend
           lxc exec maas-ui-tester-backend -- cloud-init status --wait
-          lxc exec maas-ui-tester-backend -- snap refresh snapd
-          lxc exec maas-ui-tester-backend -- snap install --edge core26
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -68,6 +68,7 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           lxc launch ubuntu:26.04 maas-ui-tester-backend
           lxc exec maas-ui-tester-backend -- cloud-init status --wait
+          lxc exec maas-ui-tester-backend -- snap refresh snapd
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 0 * * *"
+  push:
+    branches:
+      - "maas-ui-sync-debug-*"
 
 permissions:
   contents: write

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -68,7 +68,9 @@ jobs:
           cd "$GITHUB_WORKSPACE"
           lxc launch ubuntu:26.04 maas-ui-tester-backend
           lxc exec maas-ui-tester-backend -- cloud-init status --wait
-          lxc exec maas-ui-tester-backend -- snap refresh snapd
+          lxc exec maas-ui-tester-backend -- apt-get update
+          lxc exec maas-ui-tester-backend -- apt-get install -y snapd
+          lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces
           lxc exec maas-ui-tester-backend -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -66,10 +66,9 @@ jobs:
         id: setup-lxd
         run: |
           cd "$GITHUB_WORKSPACE"
-          lxc launch ubuntu:26.04 maas-ui-tester-backend
+          lxc launch ubuntu-daily:resolute maas-ui-tester-backend
           lxc exec maas-ui-tester-backend -- cloud-init status --wait
-          lxc exec maas-ui-tester-backend -- apt-get update
-          lxc exec maas-ui-tester-backend -- apt-get install -y snapd
+          lxc exec maas-ui-tester-backend -- snap install snapd --beta
           lxc exec maas-ui-tester-backend -- snap wait system seed.loaded
           lxc file push *.snap maas-ui-tester-backend/maas-snap
           lxc file push utilities/connect-snap-interfaces maas-ui-tester-backend/connect-snap-interfaces

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -46,4 +46,4 @@ for preseed in "${PRESEEDS[@]}"; do
 done
 
 # Perform migrations. Does nothing in 'rack' or 'none' mode.
-"$SNAP/bin/maas" migrate --configure
+"$SNAP/usr/bin/maas" migrate --configure


### PR DESCRIPTION
## Done

- Added debug branch configuration to maas-ui-sync job
- Added snap refresh to "Build MAAS snap" step
- Switched LXD container image to `ubuntu-daily:resolute`
- Added snap and core26 installs to "Setup LXD container" step
- Added empty cypress support file

## Fixes

Resolves [MAASENG-6450](https://warthogs.atlassian.net/browse/MAASENG-6450)

[MAASENG-6450]: https://warthogs.atlassian.net/browse/MAASENG-6450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ