### PR TITLE
feat: add snap scripts to ci linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,6 +51,7 @@ jobs:
               - 'src/**/go.mod'
               - 'src/**/go.sum'
               - 'src/**/Makefile'
+              - 'snap/local/tree/usr/bin/*'
             python:
               - 'src/**/*.py'
               - 'utilities/generate_builders.py'


### PR DESCRIPTION
Adds snap scripts to github CI linting to match the filtering defined in the Makefile