### PR TITLE
fix: make html

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -54,6 +54,7 @@ pylxd==2.4.1
 pymongo==4.16.0
 pyOpenSSL==26.0.0
 python-jose==3.5.0
+python-ulid==3.1.0
 SQLAlchemy==2.0.49
 structlog==25.5.0
 Tempita==0.6.0


### PR DESCRIPTION
This PR fixes the `make html` commands because of a missing dependency.

Note that this also fixes the test-docs CI test.