### PR TITLE
ci: make python code changes trigger docs CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -64,6 +64,11 @@ jobs:
               - 'src/**/go.sum'
             docs:
               - 'docs/**'
+              - 'src/**/*.py'
+              - 'utilities/generate_builders.py'
+              - 'utilities/run-py-tests-ci'
+              - 'pyproject.toml'
+              - 'tox.ini'
 
   lint:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,6 @@ jobs:
             docs:
               - 'docs/**'
               - 'src/**/*.py'
-              - 'utilities/generate_builders.py'
               - 'utilities/run-py-tests-ci'
               - 'pyproject.toml'
               - 'tox.ini'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,6 +69,8 @@ jobs:
               - 'utilities/run-py-tests-ci'
               - 'pyproject.toml'
               - 'tox.ini'
+              - 'required-packages/base'
+              - 'snap/snapcraft.yaml'
 
   lint:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
This is necessary due to the automatic API and CLI generation.