### PR TITLE
fix: remove offline docs from snap-tree-sync cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -501,9 +501,6 @@ snap-tree-sync: $(UI_BUILD) clean-agent clean-openfga go-bins $(SNAP_UNPACKED_DI
 		$(UI_BUILD)/ \
 		$(SNAP_UNPACKED_DIR)/usr/share/maas/web/static/
 	$(RSYNC) \
-		$(OFFLINE_DOCS)/production-html-snap/ \
-		$(SNAP_UNPACKED_DIR)/usr/share/maas/web/static/docs/
-	$(RSYNC) \
 		snap/local/tree/ \
 		$(SNAP_UNPACKED_DIR)/
 	$(RSYNC) \


### PR DESCRIPTION
This is a leftover from the previous offline documentation process, and unnecessary since the docs can be tested separately.

It is also currently breaking the command since it uses previous references.

Note that this does not affect the build process of the offline docs into the snap itself, only when syncing the dev-snap tree with the code.