### PR TITLE
fix: coerce memory into int for machine listing

### DIFF
--- a/src/maasservicelayer/services/machines_v2.py
+++ b/src/maasservicelayer/services/machines_v2.py
@@ -262,7 +262,7 @@ class MachinesV2Service(Service, Repository):
             error_description=record["error_description"],
             zone=ModelRef(id=record["zone_id"], name=record["zone_name"]),
             cpu_count=record["cpu_count"],
-            memory=record["memory"],
+            memory=int(record["memory"]),
             power_state=record["power_state"],
             locked=record["locked"],
             permissions=[],


### PR DESCRIPTION
Pydantic v2 does not seem to coerce a decimal into an int implicitly, and we relied on this before.

This change preserves the way the machines listing was displayed before we updated our dependencies. 