### PR TITLE
fix: minimum DPU kernel validation (#171)

### DIFF
--- a/src/maasserver/forms/__init__.py
+++ b/src/maasserver/forms/__init__.py
@@ -929,14 +929,14 @@ class MachineForm(NodeForm):
                 cleaned_data["min_hwe_kernel"] = min_hwe_kernel = "hwe-22.04"
             elif not release_a_newer_than_b(min_hwe_kernel, "hwe-22.04"):
                 raise ValidationError(
-                    "Invalid DPU kernel provided. Only 'hwe-22.04' or newer are supported."
+                    f"Invalid minimum {min_hwe_kernel} DPU kernel used. Only 'hwe-22.04' or newer are supported."
                 )
 
-            if hwe_kernel and release_a_newer_than_b(
-                min_hwe_kernel, hwe_kernel
+            if hwe_kernel and not release_a_newer_than_b(
+                hwe_kernel, min_hwe_kernel
             ):
                 raise ValidationError(
-                    "Invalid DPU kernel provided. Only 'hwe-22.04' or newer are supported."
+                    f"Invalid {hwe_kernel} DPU kernel used. Only 'hwe-22.04' or newer are supported."
                 )
 
         return cleaned_data

--- a/src/maasserver/forms/tests/test_machine.py
+++ b/src/maasserver/forms/tests/test_machine.py
@@ -513,6 +513,56 @@ class TestMachineForm(MAASServerTestCase):
         )
         self.assertTrue(form.is_valid(), form._errors)
 
+    @patch(
+        "maasserver.utils.osystems.BootResource.objects.get_supported_kernel_compatibility_levels"
+    )
+    def test_dpu_hwe_kernel_equal_to_min_hwe_kernel_is_valid(
+        self, mock_supported_kernels
+    ):
+        mock_supported_kernels.return_value = ["hwe-22.04", "hwe-24.04"]
+        arch = make_usable_architecture(self, arch_name="arm64")
+
+        node = factory.make_Node(
+            is_dpu=True,
+            min_hwe_kernel="hwe-22.04",
+            hwe_kernel="hwe-22.04",
+            architecture=arch,
+        )
+        form = MachineForm(
+            data={
+                "architecture": arch,
+                "is_dpu": "true",
+                "min_hwe_kernel": "hwe-22.04",
+            },
+            instance=node,
+        )
+        self.assertTrue(form.is_valid(), form._errors)
+
+    @patch(
+        "maasserver.utils.osystems.BootResource.objects.get_supported_kernel_compatibility_levels"
+    )
+    def test_dpu_hwe_kernel_older_than_min_hwe_kernel_is_invalid(
+        self, mock_supported_kernels
+    ):
+        mock_supported_kernels.return_value = ["hwe-22.04", "hwe-24.04"]
+        arch = make_usable_architecture(self, arch_name="arm64")
+        node = factory.make_Node(
+            is_dpu=True,
+            min_hwe_kernel="hwe-22.04",
+            hwe_kernel="hwe-20.04",
+            architecture=arch,
+        )
+        form = MachineForm(
+            data={
+                "architecture": arch,
+                "is_dpu": "true",
+                "min_hwe_kernel": "hwe-22.04",
+                "hwe_kernel": "hwe-20.04",
+            },
+            instance=node,
+        )
+        self.assertFalse(form.is_valid())
+
 
 class TestAdminMachineForm(MAASServerTestCase):
     def test_AdminMachineForm_contains_limited_set_of_fields(self):


### PR DESCRIPTION
Resolves [2148598](https://bugs.launchpad.net/maas/+bug/2148598)

Cherry-picked from e08a92341684796631e278d55a96ffcfdb030cf0
