### PR TITLE
feat(ci): Auto-PR to MAAS UI for API contract changes MAASENG-6451

### DIFF
--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -116,3 +116,52 @@ jobs:
       - name: Generate API client
         working-directory: fe-repo
         run: yarn generate-api-client
+
+      - name: Restore openapi-ts config
+        working-directory: fe-repo
+        run: git checkout openapi-ts.config.ts
+
+      - name: Create PR branch and push
+        id: push-branch
+        working-directory: fe-repo
+        run: |
+          git config user.name "${{ vars.LANDER_USERNAME }}"
+          git config user.email "${{ vars.LANDER_EMAIL }}"
+
+          BRANCH="chore/update-api-client-${{ github.sha }}"
+          git checkout -b "$BRANCH"
+
+          git add src/app/apiclient/
+          
+          if git diff --cached --quiet; then
+            echo "No changes detected in the API client files, skipping PR."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git commit -m "chore: regenerate API client
+
+          Triggered by: ${{ github.repository }}@${{ github.sha }}"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR on MAAS UI repo
+        if: steps.push-branch.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.LANDER_GH_TOKEN }}
+        run: |
+          gh pr create \
+            --repo "canonical/maas-ui" \
+            --head "${{ steps.push-branch.outputs.branch }}" \
+            --base main \
+            --title "chore: regenerate API client" \
+            --body "$(cat <<'EOF'
+          ## Automated API client update
+
+          **MAAS repo:** \`${{ github.repository }}\`
+          **MAAS commit:** \`${{ github.sha }}\`
+
+          Please review the diff in \`src/app/apiclient/\` and merge when ready.
+          EOF
+          )"

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -124,30 +124,49 @@ jobs:
       - name: Create PR branch and push
         id: push-branch
         working-directory: fe-repo
+        env:
+          GH_TOKEN: ${{ secrets.LANDER_GH_TOKEN }}
         run: |
           git config user.name "${{ vars.LANDER_USERNAME }}"
           git config user.email "${{ vars.LANDER_EMAIL }}"
-
-          BRANCH="chore/update-api-client-${{ github.sha }}"
-          git checkout -b "$BRANCH"
+          git remote set-url origin "https://x-access-token:${{ secrets.LANDER_GH_TOKEN }}@github.com/canonical/maas-ui.git"
 
           git add src/app/apiclient/
-          
+
           if git diff --cached --quiet; then
             echo "No changes detected in the API client files, skipping PR."
             echo "has_changes=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+          # Check for an existing open PR from a previous run
+          existing_branch=$(gh pr list \
+            --repo canonical/maas-ui \
+            --state open \
+            --json headRefName \
+            --jq '[.[] | select(.headRefName | startswith("chore/update-api-client-"))] | first | .headRefName')
+
+          if [[ -n "$existing_branch" ]]; then
+            echo "Found existing PR branch: $existing_branch — pushing to it."
+            git checkout -b "$existing_branch"
+            echo "branch=$existing_branch" >> "$GITHUB_OUTPUT"
+            echo "is_new_pr=false" >> "$GITHUB_OUTPUT"
+          else
+            BRANCH="chore/update-api-client-${{ github.sha }}"
+            echo "No existing PR found — creating new branch: $BRANCH"
+            git checkout -b "$BRANCH"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            echo "is_new_pr=true" >> "$GITHUB_OUTPUT"
+          fi
 
           git commit -m "chore: regenerate API client
 
           Triggered by: ${{ github.repository }}@${{ github.sha }}"
-          git push origin "$BRANCH"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          git push origin "${{ steps.push-branch.outputs.branch }}"
 
       - name: Open PR on MAAS UI repo
-        if: steps.push-branch.outputs.has_changes == 'true'
+        if: steps.push-branch.outputs.has_changes == 'true' && steps.push-branch.outputs.is_new_pr == 'true'
         env:
           GH_TOKEN: ${{ secrets.LANDER_GH_TOKEN }}
         run: |

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -139,6 +139,15 @@ jobs:
       # -----------------------------------------------------------------------
       # Run the FE client generation script against the live demo instance.
       # -----------------------------------------------------------------------
+      - name: Download OpenAPI spec from live MAAS instance
+        run: |
+          export MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
+          curl --noproxy "${MAAS_IP}" -L \
+            "http://${MAAS_IP}:5240/MAAS/a/openapi.json" \
+            -o openapi-spec.json
+          echo "Downloaded OpenAPI spec:"
+          ls -lh openapi-spec.json
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
@@ -150,13 +159,47 @@ jobs:
         working-directory: fe-repo
         run: yarn install --frozen-lockfile
 
+      - name: Copy OpenAPI spec to MAAS UI repo
+        run: cp openapi-spec.json fe-repo/
+
+      - name: Update openapi-ts config to use local spec
+        working-directory: fe-repo
+        run: |
+          # Find and update the openapi-ts config file to use the local spec
+          if [[ -f "openapi-ts.config.ts" ]]; then
+            CONFIG_FILE="openapi-ts.config.ts"
+          elif [[ -f "openapi-ts.config.js" ]]; then
+            CONFIG_FILE="openapi-ts.config.js"
+          else
+            echo "ERROR: Could not find openapi-ts config file"
+            exit 1
+          fi
+          
+          # Backup the original config
+          cp "$CONFIG_FILE" "${CONFIG_FILE}.backup"
+          
+          # Replace the input URL with the local file
+          # This handles both single quotes and double quotes
+          sed -i "s|input:.*https://[^'\"]*|input: './openapi-spec.json'|g" "$CONFIG_FILE"
+          sed -i "s|'https://[^']*'|'./openapi-spec.json'|g" "$CONFIG_FILE"
+          sed -i 's|"https://[^"]*"|"./openapi-spec.json"|g' "$CONFIG_FILE"
+          
+          echo "Updated config file:"
+          cat "$CONFIG_FILE"
+
       - name: Generate API client
         working-directory: fe-repo
-        env:
-          # Point heyAPI at the live demo instance.
-          # Adjust the env var name to match what your openapi-ts config reads.
-          MAAS_BASE_URL: "http://${{ steps.setup-lxd.outputs.maas_ip }}:5240/MAAS"
         run: yarn generate-api-client
+
+      - name: Restore original openapi-ts config
+        working-directory: fe-repo
+        if: always()
+        run: |
+          if [[ -f "openapi-ts.config.ts.backup" ]]; then
+            mv openapi-ts.config.ts.backup openapi-ts.config.ts
+          elif [[ -f "openapi-ts.config.js.backup" ]]; then
+            mv openapi-ts.config.js.backup openapi-ts.config.js
+          fi
 
       # -----------------------------------------------------------------------
       # Commit the regenerated client and open a PR.
@@ -176,7 +219,20 @@ jobs:
 
           BRANCH="chore/update-api-client-${{ needs.check-api-contract-change.outputs.latest_schema_hash }}"
           git checkout -b "$BRANCH"
+          
+          # Show what changed
+          echo "Files modified:"
+          git status --short
+          
+          # Add only the generated client and hash file, not the config or spec
           git add src/app/apiclient/ .api-schema-hash
+          
+          # Verify there are changes to commit
+          if git diff --cached --quiet; then
+            echo "ERROR: No changes detected in the API client files"
+            exit 1
+          fi
+          
           git commit -m "chore: regenerate API client from updated contract
 
           Schema hash: ${{ needs.check-api-contract-change.outputs.latest_schema_hash }}

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -1,4 +1,4 @@
-name: Update maas-ui API client on contract change
+name: Update FE API client on contract change
 
 on:
   workflow_dispatch:
@@ -18,10 +18,10 @@ jobs:
       has_update: ${{ steps.compare.outputs.has_update }}
       latest_schema_hash: ${{ steps.compare.outputs.latest_schema_hash }}
     steps:
-      - name: Checkout MAAS repo
+      - name: Checkout canonical/maas
         uses: actions/checkout@v5
 
-      - name: Checkout MAAS UI repo
+      - name: Checkout canonical/maas-ui
         uses: actions/checkout@v5
         with:
           repository: canonical/maas-ui
@@ -67,10 +67,12 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout MAAS repo
+      - name: Checkout canonical/maas
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # snapcraft needs full history to generate docs
 
-      - name: Checkout MAAS UI repo
+      - name: Checkout canonical/maas-ui
         uses: actions/checkout@v5
         with:
           repository: canonical/maas-ui

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout canonical/maas
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - name: Checkout canonical/maas-ui
         uses: actions/checkout@v5
@@ -34,6 +36,7 @@ jobs:
           sudo snap refresh snapd
           sudo snap install --edge core26
           make snap
+          make snap-clean
 
       - name: Launch and configure LXD container
         id: setup-lxd

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -126,13 +126,6 @@ jobs:
 
           git add src/app/apiclient/
 
-          if git diff --cached --quiet; then
-            echo "No changes detected in the API client files, skipping PR."
-            echo "has_changes=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "has_changes=true" >> "$GITHUB_OUTPUT"
-
           existing_branch=$(gh pr list \
             --repo canonical/maas-ui \
             --state open \
@@ -142,7 +135,8 @@ jobs:
           if [[ -n "$existing_branch" ]]; then
             echo "Found existing PR branch: $existing_branch — pushing to it."
             BRANCH="$existing_branch"
-            git checkout -b "$BRANCH"
+            git fetch origin "$BRANCH"
+            git checkout -b "$BRANCH" "origin/$BRANCH"
             echo "is_new_pr=false" >> "$GITHUB_OUTPUT"
           else
             BRANCH="chore/update-api-client-${{ github.sha }}"
@@ -152,6 +146,14 @@ jobs:
           fi
 
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+          if git diff --cached --quiet; then
+            echo "No changes detected in the API client files, skipping."
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
           git commit -m "chore(api): regenerated API client
 
           Triggered by: ${{ github.repository }}@${{ github.sha }}"

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -143,12 +143,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: fe-repo/package-lock.json
+          cache: yarn
+          cache-dependency-path: fe-repo/yarn.lock
 
       - name: Install MAAS UI dependencies
         working-directory: fe-repo
-        run: npm ci
+        run: yarn install --frozen-lockfile
 
       - name: Generate API client
         working-directory: fe-repo
@@ -156,7 +156,7 @@ jobs:
           # Point heyAPI at the live demo instance.
           # Adjust the env var name to match what your openapi-ts config reads.
           MAAS_BASE_URL: "http://${{ steps.setup-lxd.outputs.maas_ip }}:5240/MAAS"
-        run: npm run generate-api-client
+        run: yarn generate-api-client
 
       # -----------------------------------------------------------------------
       # Commit the regenerated client and open a PR.

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -1,0 +1,207 @@
+name: Update maas-ui API client on contract change
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  push:
+    branches:
+      - "api-client-sync-debug-*"
+
+permissions:
+  contents: read
+
+jobs:
+  check-api-contract-change:
+    runs-on: ubuntu-latest
+    outputs:
+      has_update: ${{ steps.compare.outputs.has_update }}
+      latest_schema_hash: ${{ steps.compare.outputs.latest_schema_hash }}
+    steps:
+      - name: Checkout MAAS repo
+        uses: actions/checkout@v5
+
+      - name: Checkout MAAS UI repo
+        uses: actions/checkout@v5
+        with:
+          repository: canonical/maas-ui
+          token: ${{ secrets.LANDER_GH_TOKEN }}
+          path: fe-repo
+
+      # This step compares a hash of the BE's API source files against
+      # the hash that was recorded in the FE repo when the client was last generated.
+      # Since MAAS generates its OpenAPI spec dynamically from Python source code,
+      # we hash the API handler files and OpenAPI generation logic.
+      - name: Compare schema hash with last generated hash
+        id: compare
+        run: |
+          latest_schema_hash=$(find src/maasserver/api src/maasapiserver \
+            -type f -name "*.py" \
+            | sort | xargs sha256sum | sha256sum | awk '{print $1}')
+
+          recorded_hash_file="fe-repo/.api-schema-hash"
+          if [[ -f "$recorded_hash_file" ]]; then
+            recorded_hash=$(cat "$recorded_hash_file")
+          else
+            recorded_hash=""
+          fi
+
+          echo "Latest schema hash:   $latest_schema_hash"
+          echo "Recorded schema hash: $recorded_hash"
+
+          if [[ "$latest_schema_hash" == "$recorded_hash" ]]; then
+            echo "has_update=false" >> "$GITHUB_OUTPUT"
+            echo "No API contract change detected."
+          else
+            echo "has_update=true" >> "$GITHUB_OUTPUT"
+            echo "latest_schema_hash=$latest_schema_hash" >> "$GITHUB_OUTPUT"
+            echo "API contract change detected — client regeneration needed."
+          fi
+
+  regenerate-client-and-open-pr:
+    needs: check-api-contract-change
+    if: needs.check-api-contract-change.outputs.has_update == 'true'
+    runs-on: ubuntu-latest
+    # Allow this job to open PRs against the FE repo
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout MAAS repo
+        uses: actions/checkout@v5
+
+      - name: Checkout MAAS UI repo
+        uses: actions/checkout@v5
+        with:
+          repository: canonical/maas-ui
+          token: ${{ secrets.LANDER_GH_TOKEN }}
+          path: fe-repo
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------------
+      # Stand up the MAAS demo instance — adapted from the maas-ui sync workflow.
+      # -----------------------------------------------------------------------
+      - name: Setup LXD
+        uses: canonical/setup-lxd@v1
+        with:
+          channel: 5.21/stable
+
+      - name: Build MAAS snap
+        run: |
+          sudo snap install snapcraft --classic
+          sudo snap refresh snapd
+          sudo snap install --edge core26
+          cd "$GITHUB_WORKSPACE"
+          make snap
+          make snap-clean
+
+      - name: Launch and configure LXD container
+        id: setup-lxd
+        run: |
+          lxc launch ubuntu-daily:resolute maas-api-client-gen
+          lxc exec maas-api-client-gen -- cloud-init status --wait
+          lxc exec maas-api-client-gen -- snap install snapd --beta
+          lxc exec maas-api-client-gen -- snap wait system seed.loaded
+          lxc exec maas-api-client-gen -- snap install --edge core26
+          lxc file push *.snap maas-api-client-gen/maas.snap
+          lxc file push utilities/connect-snap-interfaces maas-api-client-gen/connect-snap-interfaces
+          lxc exec maas-api-client-gen -- snap install maas-test-db --channel=latest/edge
+          lxc exec maas-api-client-gen -- snap install /maas.snap --dangerous
+          lxc exec maas-api-client-gen -- /connect-snap-interfaces
+          export MAAS_IP=$(lxc query /1.0/containers/maas-api-client-gen/state \
+            | jq -r '.network.eth0.addresses[0].address')
+          echo "maas_ip=$MAAS_IP" >> "$GITHUB_OUTPUT"
+
+      - name: Initialize MAAS and wait for API readiness
+        run: |
+          export MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
+          lxc exec maas-api-client-gen -- maas init region+rack \
+            --maas-url="http://${MAAS_IP}:5240/MAAS" \
+            --database-uri maas-test-db:///
+          sleep 30
+          # Poll until the API is healthy (up to ~2 min)
+          for i in $(seq 1 8); do
+            status_code=$(curl --noproxy "${MAAS_IP}" -L \
+              "http://${MAAS_IP}:5240/MAAS/api/2.0/version/" \
+              -o /dev/null -w "%{http_code}" -s)
+            if [[ "$status_code" -eq 200 ]]; then
+              echo "API is ready."
+              exit 0
+            fi
+            echo "Attempt $i: API not ready yet (HTTP $status_code). Retrying in 15s..."
+            sleep 15
+          done
+          echo "API failed to become ready in time."
+          exit 1
+
+      # -----------------------------------------------------------------------
+      # Run the FE client generation script against the live demo instance.
+      # -----------------------------------------------------------------------
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: fe-repo/package-lock.json
+
+      - name: Install MAAS UI dependencies
+        working-directory: fe-repo
+        run: npm ci
+
+      - name: Generate API client
+        working-directory: fe-repo
+        env:
+          # Point heyAPI at the live demo instance.
+          # Adjust the env var name to match what your openapi-ts config reads.
+          MAAS_BASE_URL: "http://${{ steps.setup-lxd.outputs.maas_ip }}:5240/MAAS"
+        run: npm run generate-api-client
+
+      # -----------------------------------------------------------------------
+      # Commit the regenerated client and open a PR.
+      # -----------------------------------------------------------------------
+      - name: Record schema hash in MAAS UI repo
+        working-directory: fe-repo
+        run: |
+          echo "${{ needs.check-api-contract-change.outputs.latest_schema_hash }}" \
+            > .api-schema-hash
+
+      - name: Create PR branch and push
+        id: push-branch
+        working-directory: fe-repo
+        run: |
+          git config user.name "${{ vars.LANDER_USERNAME }}"
+          git config user.email "${{ vars.LANDER_EMAIL }}"
+
+          BRANCH="chore/update-api-client-${{ needs.check-api-contract-change.outputs.latest_schema_hash }}"
+          git checkout -b "$BRANCH"
+          git add src/app/apiclient/ .api-schema-hash
+          git commit -m "chore: regenerate API client from updated contract
+
+          Schema hash: ${{ needs.check-api-contract-change.outputs.latest_schema_hash }}
+          Triggered by: ${{ github.repository }}@${{ github.sha }}"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR on MAAS UI repo
+        env:
+          GH_TOKEN: ${{ secrets.LANDER_GH_TOKEN }}
+        run: |
+          gh pr create \
+            --repo "canonical/maas-ui" \
+            --head "${{ steps.push-branch.outputs.branch }}" \
+            --base main \
+            --title "chore: regenerate API client from updated contract" \
+            --body "$(cat <<'EOF'
+          ## Automated API client update
+
+          The OpenAPI contract on the MAAS repo has changed. This PR contains a
+          freshly regenerated client produced by running \`generate-api-client\`
+          against a live demo instance of the updated BE.
+
+          **MAAS repo:** \`${{ github.repository }}\`
+          **MAAS commit:** \`${{ github.sha }}\`
+          **Schema hash:** \`${{ needs.check-api-contract-change.outputs.latest_schema_hash }}\`
+
+          Please review the diff in \`src/app/apiclient/\` and merge when ready.
+          EOF
+          )"

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -15,8 +15,6 @@ jobs:
     steps:
       - name: Checkout canonical/maas
         uses: actions/checkout@v5
-        with:
-          fetch-depth: 0
 
       - name: Checkout canonical/maas-ui
         uses: actions/checkout@v5
@@ -24,7 +22,6 @@ jobs:
           repository: canonical/maas-ui
           token: ${{ secrets.LANDER_GH_TOKEN }}
           path: fe-repo
-          fetch-depth: 0
 
       - name: Setup LXD
         uses: canonical/setup-lxd@v1
@@ -37,7 +34,6 @@ jobs:
           sudo snap refresh snapd
           sudo snap install --edge core26
           make snap
-          make snap-clean
 
       - name: Launch and configure LXD container
         id: setup-lxd
@@ -82,13 +78,13 @@ jobs:
           MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
           curl --noproxy "${MAAS_IP}" -L \
             "http://${MAAS_IP}:5240/MAAS/a/openapi.json" \
-            -o openapi-spec.json
+            -o fe-repo/openapi-spec.json
 
       - name: Upload OpenAPI spec artifact
         uses: actions/upload-artifact@v4
         with:
           name: openapi-spec
-          path: openapi-spec.json
+          path: fe-repo/openapi-spec.json
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -100,9 +96,6 @@ jobs:
       - name: Install MAAS UI dependencies
         working-directory: fe-repo
         run: yarn install --frozen-lockfile
-
-      - name: Copy OpenAPI spec to MAAS UI repo
-        run: cp openapi-spec.json fe-repo/
 
       - name: Update openapi-ts config to use local spec
         working-directory: fe-repo
@@ -117,16 +110,13 @@ jobs:
         working-directory: fe-repo
         run: yarn generate-api-client
 
-      - name: Restore openapi-ts config
-        working-directory: fe-repo
-        run: git checkout openapi-ts.config.ts
-
       - name: Create PR branch and push
         id: push-branch
         working-directory: fe-repo
         env:
           GH_TOKEN: ${{ secrets.LANDER_GH_TOKEN }}
         run: |
+          git checkout openapi-ts.config.ts
           git config user.name "${{ vars.LANDER_USERNAME }}"
           git config user.email "${{ vars.LANDER_EMAIL }}"
           git remote set-url origin "https://x-access-token:${{ secrets.LANDER_GH_TOKEN }}@github.com/canonical/maas-ui.git"
@@ -140,7 +130,6 @@ jobs:
           fi
           echo "has_changes=true" >> "$GITHUB_OUTPUT"
 
-          # Check for an existing open PR from a previous run
           existing_branch=$(gh pr list \
             --repo canonical/maas-ui \
             --state open \
@@ -149,8 +138,8 @@ jobs:
 
           if [[ -n "$existing_branch" ]]; then
             echo "Found existing PR branch: $existing_branch — pushing to it."
-            git checkout -b "$existing_branch"
             BRANCH="$existing_branch"
+            git checkout -b "$BRANCH"
             echo "is_new_pr=false" >> "$GITHUB_OUTPUT"
           else
             BRANCH="chore/update-api-client-${{ github.sha }}"
@@ -160,7 +149,7 @@ jobs:
           fi
 
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-          git commit -m "chore: regenerate API client
+          git commit -m "chore(api): regenerated API client
 
           Triggered by: ${{ github.repository }}@${{ github.sha }}"
           git push origin "$BRANCH"
@@ -170,17 +159,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.LANDER_GH_TOKEN }}
         run: |
-          gh pr create \
+          PR_URL=$(gh pr create \
             --repo "canonical/maas-ui" \
             --head "${{ steps.push-branch.outputs.branch }}" \
             --base main \
-            --title "chore: regenerate API client" \
+            --title "chore(api): regenerated API client" \
             --body "$(cat <<'EOF'
-          ## Automated API client update
+          ## Done
 
-          **MAAS repo:** \`${{ github.repository }}\`
-          **MAAS commit:** \`${{ github.sha }}\`
+          - Regenerated the API client
 
-          Please review the diff in \`src/app/apiclient/\` and merge when ready.
+          ## Note
+
+          This is an auto-generated PR, make sure to review the changes.
           EOF
-          )"
+          )")
+
+          gh pr edit "$PR_URL" \
+            --repo "canonical/maas-ui" \
+            --add-label "Review: Code needed"

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -107,17 +107,11 @@ jobs:
       - name: Update openapi-ts config to use local spec
         working-directory: fe-repo
         run: |
-          if [[ -f "openapi-ts.config.ts" ]]; then
-            CONFIG_FILE="openapi-ts.config.ts"
-          elif [[ -f "openapi-ts.config.js" ]]; then
-            CONFIG_FILE="openapi-ts.config.js"
-          else
-            echo "ERROR: Could not find openapi-ts config file"
-            exit 1
-          fi
-          sed -i "s|input:.*https://[^'\"]*|input: './openapi-spec.json'|g" "$CONFIG_FILE"
-          sed -i "s|'https://[^']*'|'./openapi-spec.json'|g" "$CONFIG_FILE"
-          sed -i 's|"https://[^"]*"|"./openapi-spec.json"|g' "$CONFIG_FILE"
+          python3 -c "
+          import re, pathlib
+          p = pathlib.Path('openapi-ts.config.ts')
+          p.write_text(re.sub(r'input:.*', \"input: './openapi-spec.json',\", p.read_text()))
+          "
 
       - name: Generate API client
         working-directory: fe-repo

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -1,76 +1,22 @@
 name: Update FE API client on contract change
 
 on:
-  workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
   push:
     branches:
       - "api-client-sync-debug-*"
+      - "master"
 
 permissions:
   contents: read
 
 jobs:
-  check-api-contract-change:
+  regenerate-client:
     runs-on: ubuntu-latest
-    outputs:
-      has_update: ${{ steps.compare.outputs.has_update }}
-      latest_schema_hash: ${{ steps.compare.outputs.latest_schema_hash }}
-    steps:
-      - name: Checkout canonical/maas
-        uses: actions/checkout@v5
-
-      - name: Checkout canonical/maas-ui
-        uses: actions/checkout@v5
-        with:
-          repository: canonical/maas-ui
-          token: ${{ secrets.LANDER_GH_TOKEN }}
-          path: fe-repo
-
-      # This step compares a hash of the BE's API source files against
-      # the hash that was recorded in the FE repo when the client was last generated.
-      # Since MAAS generates its OpenAPI spec dynamically from Python source code,
-      # we hash the API handler files and OpenAPI generation logic.
-      - name: Compare schema hash with last generated hash
-        id: compare
-        run: |
-          latest_schema_hash=$(find src/maasserver/api src/maasapiserver \
-            -type f -name "*.py" \
-            | sort | xargs sha256sum | sha256sum | awk '{print $1}')
-
-          recorded_hash_file="fe-repo/.api-schema-hash"
-          if [[ -f "$recorded_hash_file" ]]; then
-            recorded_hash=$(cat "$recorded_hash_file")
-          else
-            recorded_hash=""
-          fi
-
-          echo "Latest schema hash:   $latest_schema_hash"
-          echo "Recorded schema hash: $recorded_hash"
-
-          if [[ "$latest_schema_hash" == "$recorded_hash" ]]; then
-            echo "has_update=false" >> "$GITHUB_OUTPUT"
-            echo "No API contract change detected."
-          else
-            echo "has_update=true" >> "$GITHUB_OUTPUT"
-            echo "latest_schema_hash=$latest_schema_hash" >> "$GITHUB_OUTPUT"
-            echo "API contract change detected — client regeneration needed."
-          fi
-
-  regenerate-client-and-open-pr:
-    needs: check-api-contract-change
-    if: needs.check-api-contract-change.outputs.has_update == 'true'
-    runs-on: ubuntu-latest
-    # Allow this job to open PRs against the FE repo
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - name: Checkout canonical/maas
         uses: actions/checkout@v5
         with:
-          fetch-depth: 0  # snapcraft needs full history to generate docs
+          fetch-depth: 0
 
       - name: Checkout canonical/maas-ui
         uses: actions/checkout@v5
@@ -80,9 +26,6 @@ jobs:
           path: fe-repo
           fetch-depth: 0
 
-      # -----------------------------------------------------------------------
-      # Stand up the MAAS demo instance — adapted from the maas-ui sync workflow.
-      # -----------------------------------------------------------------------
       - name: Setup LXD
         uses: canonical/setup-lxd@v1
         with:
@@ -93,7 +36,6 @@ jobs:
           sudo snap install snapcraft --classic
           sudo snap refresh snapd
           sudo snap install --edge core26
-          cd "$GITHUB_WORKSPACE"
           make snap
           make snap-clean
 
@@ -110,18 +52,17 @@ jobs:
           lxc exec maas-api-client-gen -- snap install maas-test-db --channel=latest/edge
           lxc exec maas-api-client-gen -- snap install /maas.snap --dangerous
           lxc exec maas-api-client-gen -- /connect-snap-interfaces
-          export MAAS_IP=$(lxc query /1.0/containers/maas-api-client-gen/state \
+          MAAS_IP=$(lxc query /1.0/containers/maas-api-client-gen/state \
             | jq -r '.network.eth0.addresses[0].address')
           echo "maas_ip=$MAAS_IP" >> "$GITHUB_OUTPUT"
 
       - name: Initialize MAAS and wait for API readiness
         run: |
-          export MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
+          MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
           lxc exec maas-api-client-gen -- maas init region+rack \
             --maas-url="http://${MAAS_IP}:5240/MAAS" \
             --database-uri maas-test-db:///
           sleep 30
-          # Poll until the API is healthy (up to ~2 min)
           for i in $(seq 1 8); do
             status_code=$(curl --noproxy "${MAAS_IP}" -L \
               "http://${MAAS_IP}:5240/MAAS/api/2.0/version/" \
@@ -136,17 +77,18 @@ jobs:
           echo "API failed to become ready in time."
           exit 1
 
-      # -----------------------------------------------------------------------
-      # Run the FE client generation script against the live demo instance.
-      # -----------------------------------------------------------------------
       - name: Download OpenAPI spec from live MAAS instance
         run: |
-          export MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
+          MAAS_IP=${{ steps.setup-lxd.outputs.maas_ip }}
           curl --noproxy "${MAAS_IP}" -L \
             "http://${MAAS_IP}:5240/MAAS/a/openapi.json" \
             -o openapi-spec.json
-          echo "Downloaded OpenAPI spec:"
-          ls -lh openapi-spec.json
+
+      - name: Upload OpenAPI spec artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-spec
+          path: openapi-spec.json
 
       - name: Setup Node
         uses: actions/setup-node@v6
@@ -165,7 +107,6 @@ jobs:
       - name: Update openapi-ts config to use local spec
         working-directory: fe-repo
         run: |
-          # Find and update the openapi-ts config file to use the local spec
           if [[ -f "openapi-ts.config.ts" ]]; then
             CONFIG_FILE="openapi-ts.config.ts"
           elif [[ -f "openapi-ts.config.js" ]]; then
@@ -174,92 +115,10 @@ jobs:
             echo "ERROR: Could not find openapi-ts config file"
             exit 1
           fi
-          
-          # Backup the original config
-          cp "$CONFIG_FILE" "${CONFIG_FILE}.backup"
-          
-          # Replace the input URL with the local file
-          # This handles both single quotes and double quotes
           sed -i "s|input:.*https://[^'\"]*|input: './openapi-spec.json'|g" "$CONFIG_FILE"
           sed -i "s|'https://[^']*'|'./openapi-spec.json'|g" "$CONFIG_FILE"
           sed -i 's|"https://[^"]*"|"./openapi-spec.json"|g' "$CONFIG_FILE"
-          
-          echo "Updated config file:"
-          cat "$CONFIG_FILE"
 
       - name: Generate API client
         working-directory: fe-repo
         run: yarn generate-api-client
-
-      - name: Restore original openapi-ts config
-        working-directory: fe-repo
-        if: always()
-        run: |
-          if [[ -f "openapi-ts.config.ts.backup" ]]; then
-            mv openapi-ts.config.ts.backup openapi-ts.config.ts
-          elif [[ -f "openapi-ts.config.js.backup" ]]; then
-            mv openapi-ts.config.js.backup openapi-ts.config.js
-          fi
-
-      # -----------------------------------------------------------------------
-      # Commit the regenerated client and open a PR.
-      # -----------------------------------------------------------------------
-      - name: Record schema hash in MAAS UI repo
-        working-directory: fe-repo
-        run: |
-          echo "${{ needs.check-api-contract-change.outputs.latest_schema_hash }}" \
-            > .api-schema-hash
-
-      - name: Create PR branch and push
-        id: push-branch
-        working-directory: fe-repo
-        run: |
-          git config user.name "${{ vars.LANDER_USERNAME }}"
-          git config user.email "${{ vars.LANDER_EMAIL }}"
-
-          BRANCH="chore/update-api-client-${{ needs.check-api-contract-change.outputs.latest_schema_hash }}"
-          git checkout -b "$BRANCH"
-          
-          # Show what changed
-          echo "Files modified:"
-          git status --short
-          
-          # Add only the generated client and hash file, not the config or spec
-          git add src/app/apiclient/ .api-schema-hash
-          
-          # Verify there are changes to commit
-          if git diff --cached --quiet; then
-            echo "ERROR: No changes detected in the API client files"
-            exit 1
-          fi
-          
-          git commit -m "chore: regenerate API client from updated contract
-
-          Schema hash: ${{ needs.check-api-contract-change.outputs.latest_schema_hash }}
-          Triggered by: ${{ github.repository }}@${{ github.sha }}"
-          git push origin "$BRANCH"
-          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
-
-      - name: Open PR on MAAS UI repo
-        env:
-          GH_TOKEN: ${{ secrets.LANDER_GH_TOKEN }}
-        run: |
-          gh pr create \
-            --repo "canonical/maas-ui" \
-            --head "${{ steps.push-branch.outputs.branch }}" \
-            --base main \
-            --title "chore: regenerate API client from updated contract" \
-            --body "$(cat <<'EOF'
-          ## Automated API client update
-
-          The OpenAPI contract on the MAAS repo has changed. This PR contains a
-          freshly regenerated client produced by running \`generate-api-client\`
-          against a live demo instance of the updated BE.
-
-          **MAAS repo:** \`${{ github.repository }}\`
-          **MAAS commit:** \`${{ github.sha }}\`
-          **Schema hash:** \`${{ needs.check-api-contract-change.outputs.latest_schema_hash }}\`
-
-          Please review the diff in \`src/app/apiclient/\` and merge when ready.
-          EOF
-          )"

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -180,6 +180,11 @@ jobs:
           EOF
           )")
 
-          gh pr edit "$PR_URL" \
-            --repo "canonical/maas-ui" \
-            --add-label "Review: Code needed"
+          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
+
+          curl -L \
+            -X POST \
+            -H "Authorization: Bearer ${{ secrets.LANDER_GH_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/canonical/maas-ui/issues/${PR_NUMBER}/labels" \
+            -d '{"labels":["Review: Code needed"]}'

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -150,20 +150,20 @@ jobs:
           if [[ -n "$existing_branch" ]]; then
             echo "Found existing PR branch: $existing_branch — pushing to it."
             git checkout -b "$existing_branch"
-            echo "branch=$existing_branch" >> "$GITHUB_OUTPUT"
+            BRANCH="$existing_branch"
             echo "is_new_pr=false" >> "$GITHUB_OUTPUT"
           else
             BRANCH="chore/update-api-client-${{ github.sha }}"
             echo "No existing PR found — creating new branch: $BRANCH"
             git checkout -b "$BRANCH"
-            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
             echo "is_new_pr=true" >> "$GITHUB_OUTPUT"
           fi
 
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           git commit -m "chore: regenerate API client
 
           Triggered by: ${{ github.repository }}@${{ github.sha }}"
-          git push origin "${{ steps.push-branch.outputs.branch }}"
+          git push origin "$BRANCH"
 
       - name: Open PR on MAAS UI repo
         if: steps.push-branch.outputs.has_changes == 'true' && steps.push-branch.outputs.is_new_pr == 'true'

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -34,18 +34,18 @@ jobs:
         run: |
           sudo snap install snapcraft --classic
           sudo snap refresh snapd
-          sudo snap install --edge core26
+          sudo snap install --candidate core26
           make snap
           make snap-clean
 
       - name: Launch and configure LXD container
         id: setup-lxd
         run: |
-          lxc launch ubuntu-daily:resolute maas-api-client-gen
+          lxc launch ubuntu:resolute maas-api-client-gen
           lxc exec maas-api-client-gen -- cloud-init status --wait
           lxc exec maas-api-client-gen -- snap install snapd --beta
           lxc exec maas-api-client-gen -- snap wait system seed.loaded
-          lxc exec maas-api-client-gen -- snap install --edge core26
+          lxc exec maas-api-client-gen -- snap install --candidate core26
           lxc file push *.snap maas-api-client-gen/maas.snap
           lxc file push utilities/connect-snap-interfaces maas-api-client-gen/connect-snap-interfaces
           lxc exec maas-api-client-gen -- snap install maas-test-db --channel=latest/edge

--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -179,12 +179,3 @@ jobs:
           This is an auto-generated PR, make sure to review the changes.
           EOF
           )")
-
-          PR_NUMBER=$(echo "$PR_URL" | grep -oP '\d+$')
-
-          curl -L \
-            -X POST \
-            -H "Authorization: Bearer ${{ secrets.LANDER_GH_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/canonical/maas-ui/issues/${PR_NUMBER}/labels" \
-            -d '{"labels":["Review: Code needed"]}'


### PR DESCRIPTION
## Done

- Added `api-client-sync.yaml` workflow

## What it does

The workflow
- runs on pushes to `master` or `api-client-sync-debug-*` in `canonical/maas`
- checks out both `maas` and `maas-ui`
- builds `master` branch MAAS, and sets up an LXD MAAS instance
- downloads the OpenAPI spec, and exposes it as a GH Action artifact
- runs API client generation on the downloaded spec using MAAS UI's `main` configuration
- detects if there is an existing API client update branch in `canonical/maas-ui`, if not, creates one
- pushes the updated client files to the branch
- opens a PR to `main` in `canonical/maas-ui`

Here is an [example PR](https://github.com/canonical/maas-ui/pull/6004) generated by this workflow.