### PR TITLE
chore: update user stats endpoints to reflect new API guidelines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ snap-tree-sync: $(UI_BUILD) clean-agent clean-openfga go-bins $(SNAP_UNPACKED_DI
 		--exclude 'host-info' --exclude 'maas-offline-docs' \
 		--exclude '*.pyc' --exclude '__pycache__' \
 		src/ \
-		$(SNAP_UNPACKED_DIR)/usr/lib/python3/dist-packages/
+		$(SNAP_UNPACKED_DIR)/usr/lib/python3.*/dist-packages/
 	$(RSYNC) \
 		$(UI_BUILD)/ \
 		$(SNAP_UNPACKED_DIR)/usr/share/maas/web/static/

--- a/Makefile
+++ b/Makefile
@@ -496,7 +496,7 @@ snap-tree-sync: $(UI_BUILD) clean-agent clean-openfga go-bins $(SNAP_UNPACKED_DI
 		--exclude 'host-info' --exclude 'maas-offline-docs' \
 		--exclude '*.pyc' --exclude '__pycache__' \
 		src/ \
-		$(SNAP_UNPACKED_DIR)/usr/lib/python3.*/dist-packages/
+		$(SNAP_UNPACKED_DIR)/usr/lib/python3/dist-packages/
 	$(RSYNC) \
 		$(UI_BUILD)/ \
 		$(SNAP_UNPACKED_DIR)/usr/share/maas/web/static/

--- a/src/maasapiserver/v3/api/public/handlers/users.py
+++ b/src/maasapiserver/v3/api/public/handlers/users.py
@@ -29,8 +29,8 @@ from maasapiserver.v3.api.public.models.responses.users import (
     UserInfoResponse,
     UserResponse,
     UsersListResponse,
-    UsersWithSummaryListResponse,
-    UserWithSummaryResponse,
+    UsersStatisticsListResponse,
+    UserStatisticsResponse,
 )
 from maasapiserver.v3.auth.base import (
     check_authentication,
@@ -68,7 +68,7 @@ class UsersHandler(Handler):
         # /users/{user_id}. Therefore we need to specify a custom registration
         # order to disambiguate these paths.
         return [
-            "get_me_with_summary",
+            "get_me_statistics",
             "get_user_info",
             "complete_intro",
             "change_password_user",
@@ -78,7 +78,7 @@ class UsersHandler(Handler):
             "update_user",
             "delete_user",
             "change_password_admin",
-            "list_users_with_summary",
+            "list_users_statistics",
         ]
 
     @handler(
@@ -419,14 +419,13 @@ class UsersHandler(Handler):
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @handler(
-        path="/users_with_summary",
+        path="/users/statistics",
         methods=["GET"],
         tags=TAGS,
         responses={
-            200: {"model": UsersWithSummaryListResponse},
+            200: {"model": UsersStatisticsListResponse},
         },
-        summary="List users with a summary. ONLY FOR INTERNAL USAGE.",
-        description="List users with a summary. This endpoint is only for internal usage and might be changed or removed without notice.",
+        summary="List additional statistics of users, e.g. machine count.",
         status_code=200,
         response_model_exclude_none=True,
         dependencies=[
@@ -437,28 +436,28 @@ class UsersHandler(Handler):
             )
         ],
     )
-    async def list_users_with_summary(
+    async def list_users_statistics(
         self,
         pagination_params: PaginationParams = Depends(),  # noqa: B008
         filters: UsersFiltersParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
-    ) -> UsersWithSummaryListResponse:
-        users = await services.users.list_with_summary(
+    ) -> UsersStatisticsListResponse:
+        users = await services.users.list_statistics(
             page=pagination_params.page,
             size=pagination_params.size,
             query=QuerySpec(where=filters.to_clause()),
         )
-        return UsersWithSummaryListResponse(
+        return UsersStatisticsListResponse(
             items=[
-                UserWithSummaryResponse.from_model(
-                    user_with_summary=user,
+                UserStatisticsResponse.from_model(
+                    user_statistics=user,
                     self_base_hyperlink=f"{V3_API_PREFIX}/users",
                 )
                 for user in users.items
             ],
             total=users.total,
             next=(
-                f"{V3_API_PREFIX}/users_with_summary?"
+                f"{V3_API_PREFIX}/users_statistics?"
                 f"{pagination_params.to_next_href_format()}"
                 f"{filters.to_href_format()}"
                 if users.has_next(
@@ -469,31 +468,30 @@ class UsersHandler(Handler):
         )
 
     @handler(
-        path="/users/me_with_summary",
+        path="/users/me/statistics",
         methods=["GET"],
         tags=TAGS,
-        responses={200: {"model": UserWithSummaryResponse}},
-        summary="Get user with a summary. ONLY FOR INTERNAL USAGE.",
-        description="Get user with a summary. This endpoint is only for internal usage and might be changed or removed without notice.",
+        responses={200: {"model": UserStatisticsResponse}},
+        summary="Get additional statistics for the logged-in user, e.g. machine count.",
         status_code=200,
         response_model_exclude_none=True,
         dependencies=[Depends(check_authentication())],
     )
-    async def get_me_with_summary(
+    async def get_me_statistics(
         self,
         authenticated_user: AuthenticatedUser | None = Depends(  # noqa: B008
             get_authenticated_user
         ),
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
-    ) -> UserWithSummaryResponse:
+    ) -> UserStatisticsResponse:
         assert authenticated_user is not None
-        user = await services.users.get_by_id_with_summary(
+        user = await services.users.get_by_id_statistics(
             id=authenticated_user.id
         )
         if user is None:
             # only happens for system users
             raise BadRequestException()
-        return UserWithSummaryResponse.from_model(
-            user_with_summary=user,
+        return UserStatisticsResponse.from_model(
+            user_statistics=user,
             self_base_hyperlink=f"{V3_API_PREFIX}/users",
         )

--- a/src/maasapiserver/v3/api/public/handlers/users.py
+++ b/src/maasapiserver/v3/api/public/handlers/users.py
@@ -419,7 +419,7 @@ class UsersHandler(Handler):
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 
     @handler(
-        path="/users/statistics",
+        path="/users:statistics",
         methods=["GET"],
         tags=TAGS,
         responses={
@@ -468,7 +468,7 @@ class UsersHandler(Handler):
         )
 
     @handler(
-        path="/users/me/statistics",
+        path="/users/me:statistics",
         methods=["GET"],
         tags=TAGS,
         responses={200: {"model": UserStatisticsResponse}},

--- a/src/maasapiserver/v3/api/public/handlers/users.py
+++ b/src/maasapiserver/v3/api/public/handlers/users.py
@@ -457,7 +457,7 @@ class UsersHandler(Handler):
             ],
             total=users.total,
             next=(
-                f"{V3_API_PREFIX}/users_statistics?"
+                f"{V3_API_PREFIX}/users:statistics?"
                 f"{pagination_params.to_next_href_format()}"
                 f"{filters.to_href_format()}"
                 if users.has_next(

--- a/src/maasapiserver/v3/api/public/models/requests/users.py
+++ b/src/maasapiserver/v3/api/public/models/requests/users.py
@@ -20,11 +20,14 @@ class UsersFiltersParams(BaseModel):
             description="Filter by User ID",
         )
     )
+
     username_or_email: str | None = Field(
         Query(default=None, title="Filter by username or email")
     )
 
     def to_clause(self) -> Clause | None:
+        if self.ids:
+            return UserClauseFactory.with_ids(self.ids)
         if self.username_or_email:
             return UserClauseFactory.with_username_or_email_like(
                 self.username_or_email

--- a/src/maasapiserver/v3/api/public/models/requests/users.py
+++ b/src/maasapiserver/v3/api/public/models/requests/users.py
@@ -13,6 +13,13 @@ from maasservicelayer.models.base import UNSET
 
 
 class UsersFiltersParams(BaseModel):
+    ids: list[int] | None = Field(
+        Query(
+            default=None,
+            alias="id",
+            description="Filter by User ID",
+        )
+    )
     username_or_email: str | None = Field(
         Query(default=None, title="Filter by username or email")
     )

--- a/src/maasapiserver/v3/api/public/models/responses/users.py
+++ b/src/maasapiserver/v3/api/public/models/responses/users.py
@@ -12,7 +12,7 @@ from maasapiserver.v3.api.public.models.responses.base import (
     HalResponse,
     PaginatedResponse,
 )
-from maasservicelayer.models.users import User, UserWithSummary
+from maasservicelayer.models.users import User, UserStatistics
 
 
 class UserInfoResponse(BaseModel):
@@ -55,41 +55,31 @@ class UsersListResponse(PaginatedResponse[UserResponse]):
     kind: str = Field(default="UsersList")
 
 
-class UserWithSummaryResponse(HalResponse[BaseHal]):
-    kind: str = Field(default="UserWithSummary")
+class UserStatisticsResponse(HalResponse[BaseHal]):
+    kind: str = Field(default="UserStatistics")
     id: int
     completed_intro: bool
-    email: str | None = None
     is_local: bool
-    is_superuser: bool
-    last_name: str | None = None
-    last_login: datetime | None = None
     machines_count: int
     sshkeys_count: int
-    username: str
 
     @classmethod
     def from_model(
-        cls, user_with_summary: UserWithSummary, self_base_hyperlink: str
+        cls, user_statistics: UserStatistics, self_base_hyperlink: str
     ) -> Self:
         return cls(
-            id=user_with_summary.id,
-            completed_intro=user_with_summary.completed_intro,
-            email=user_with_summary.email,
-            is_local=user_with_summary.is_local,
-            is_superuser=user_with_summary.is_superuser,
-            last_name=user_with_summary.last_name,
-            last_login=user_with_summary.last_login,
-            machines_count=user_with_summary.machines_count,
-            sshkeys_count=user_with_summary.sshkeys_count,
-            username=user_with_summary.username,
+            id=user_statistics.id,
+            completed_intro=user_statistics.completed_intro,
+            is_local=user_statistics.is_local,
+            machines_count=user_statistics.machines_count,
+            sshkeys_count=user_statistics.sshkeys_count,
             hal_links=BaseHal(  # pyright: ignore [reportCallIssue]
                 self=BaseHref(
-                    href=f"{self_base_hyperlink.rstrip('/')}/{user_with_summary.id}"
+                    href=f"{self_base_hyperlink.rstrip('/')}/{user_statistics.id}"
                 )
             ),
         )
 
 
-class UsersWithSummaryListResponse(PaginatedResponse[UserWithSummaryResponse]):
-    kind: str = Field(default="UserWithSummaryList")
+class UsersStatisticsListResponse(PaginatedResponse[UserStatisticsResponse]):
+    kind: str = Field(default="UserStatisticsList")

--- a/src/maasserver/testing/initial.maas_test.sql
+++ b/src/maasserver/testing/initial.maas_test.sql
@@ -4919,21 +4919,6 @@ ALTER SEQUENCE public.django_site_id_seq OWNED BY public.django_site.id;
 
 
 --
--- Name: maasserver_sshkey; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.maasserver_sshkey (
-    id bigint NOT NULL,
-    created timestamp with time zone NOT NULL,
-    updated timestamp with time zone NOT NULL,
-    key text NOT NULL,
-    user_id integer NOT NULL,
-    auth_id character varying(255),
-    protocol character varying(64)
-);
-
-
---
 -- Name: maasserver_agent; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -5394,7 +5379,7 @@ CREATE VIEW public.maasserver_bootsourceselectionstatus_view AS
          SELECT res.id AS resource_id,
             cache.latest_version
            FROM (public.maasserver_bootsourcecache cache
-             JOIN public.maasserver_bootresource res ON ((((res.name)::text = (((cache.os)::text || '/'::text) || (cache.release)::text)) AND ((res.kflavor)::text = (cache.kflavor)::text) AND ((((res.architecture)::text = (((cache.arch)::text || '/'::text) || (cache.subarch)::text)) OR ((res.architecture)::text = (((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text))) OR ((res.architecture)::text = ((((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text) || '-edge'::text))))))
+             JOIN public.maasserver_bootresource res ON ((((res.name)::text = (((cache.os)::text || '/'::text) || (cache.release)::text)) AND ((res.kflavor)::text = (cache.kflavor)::text) AND (((res.architecture)::text = (((cache.arch)::text || '/'::text) || (cache.subarch)::text)) OR ((res.architecture)::text = (((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text)) OR ((res.architecture)::text = ((((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text) || '-edge'::text))))))
         ), resource_set_counts AS (
          SELECT sync_stats.resource_id,
             count(*) AS set_count
@@ -7854,6 +7839,21 @@ CREATE SEQUENCE public.maasserver_space_id_seq
 --
 
 ALTER SEQUENCE public.maasserver_space_id_seq OWNED BY public.maasserver_space.id;
+
+
+--
+-- Name: maasserver_sshkey; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.maasserver_sshkey (
+    id bigint NOT NULL,
+    created timestamp with time zone NOT NULL,
+    updated timestamp with time zone NOT NULL,
+    key text NOT NULL,
+    user_id integer NOT NULL,
+    auth_id character varying(255),
+    protocol character varying(64)
+);
 
 
 --

--- a/src/maasservicelayer/db/repositories/users.py
+++ b/src/maasservicelayer/db/repositories/users.py
@@ -41,7 +41,7 @@ from maasservicelayer.exceptions.constants import (
     UNEXISTING_RESOURCE_VIOLATION_TYPE,
 )
 from maasservicelayer.models.base import ListResult
-from maasservicelayer.models.users import User, UserProfile, UserWithSummary
+from maasservicelayer.models.users import User, UserProfile, UserStatistics
 from maasservicelayer.utils.date import utcnow
 
 
@@ -249,7 +249,7 @@ class UsersRepository(BaseRepository[User]):
         count = (await self.execute_stmt(stmt)).scalar_one()
         return count
 
-    def _user_with_summary_stmt(self) -> Select:
+    def _user_statistics_stmt(self) -> Select:
         return (
             select(
                 UserTable.c.id,
@@ -297,9 +297,9 @@ class UsersRepository(BaseRepository[User]):
             .order_by(desc(UserTable.c.id))
         )
 
-    async def list_with_summary(
+    async def list_statistics(
         self, page: int, size: int, query: QuerySpec
-    ) -> ListResult[UserWithSummary]:
+    ) -> ListResult[UserStatistics]:
         total_stmt = (
             select(func.count())
             .select_from(UserTable)
@@ -313,24 +313,24 @@ class UsersRepository(BaseRepository[User]):
         total_stmt = query.enrich_stmt(total_stmt)
         total = (await self.execute_stmt(total_stmt)).scalar_one()
         stmt = (
-            self._user_with_summary_stmt()
+            self._user_statistics_stmt()
             .offset((page - 1) * size)
             .limit(size)
         )
         stmt = query.enrich_stmt(stmt)
 
         result = (await self.execute_stmt(stmt)).all()
-        return ListResult[UserWithSummary](
-            items=[UserWithSummary(**row._asdict()) for row in result],
+        return ListResult[UserStatistics](
+            items=[UserStatistics(**row._asdict()) for row in result],
             total=total,
         )
 
-    async def get_by_id_with_summary(self, id: int) -> UserWithSummary | None:
-        stmt = self._user_with_summary_stmt().where(eq(UserTable.c.id, id))
+    async def get_by_id_statistics(self, id: int) -> UserStatistics | None:
+        stmt = self._user_statistics_stmt().where(eq(UserTable.c.id, id))
         result = (await self.execute_stmt(stmt)).one_or_none()
         if not result:
             return None
-        return UserWithSummary(**result._asdict())
+        return UserStatistics(**result._asdict())
 
     async def has_users(self) -> bool:
         stmt = (

--- a/src/maasservicelayer/db/repositories/users.py
+++ b/src/maasservicelayer/db/repositories/users.py
@@ -313,9 +313,7 @@ class UsersRepository(BaseRepository[User]):
         total_stmt = query.enrich_stmt(total_stmt)
         total = (await self.execute_stmt(total_stmt)).scalar_one()
         stmt = (
-            self._user_statistics_stmt()
-            .offset((page - 1) * size)
-            .limit(size)
+            self._user_statistics_stmt().offset((page - 1) * size).limit(size)
         )
         stmt = query.enrich_stmt(stmt)
 

--- a/src/maasservicelayer/db/repositories/users.py
+++ b/src/maasservicelayer/db/repositories/users.py
@@ -257,11 +257,6 @@ class UsersRepository(BaseRepository[User]):
         return (
             select(
                 UserTable.c.id,
-                UserTable.c.username,
-                UserTable.c.email,
-                UserTable.c.is_superuser,
-                UserTable.c.last_name,
-                UserTable.c.last_login,
                 UserProfileTable.c.completed_intro,
                 UserProfileTable.c.is_local,
                 func.count(distinct(NodeTable.c.id)).label("machines_count"),
@@ -290,11 +285,6 @@ class UsersRepository(BaseRepository[User]):
             )
             .group_by(
                 UserTable.c.id,
-                UserTable.c.username,
-                UserTable.c.email,
-                UserTable.c.is_superuser,
-                UserTable.c.last_name,
-                UserTable.c.last_login,
                 UserProfileTable.c.completed_intro,
                 UserProfileTable.c.is_local,
             )

--- a/src/maasservicelayer/db/repositories/users.py
+++ b/src/maasservicelayer/db/repositories/users.py
@@ -51,6 +51,10 @@ class UserClauseFactory(ClauseFactory):
         return Clause(condition=eq(UserTable.c.id, id))
 
     @classmethod
+    def with_ids(cls, ids: list[int]) -> Clause:
+        return Clause(condition=UserTable.c.id.in_(ids))
+
+    @classmethod
     def with_username(cls, username: str) -> Clause:
         return Clause(condition=eq(UserTable.c.username, username))
 

--- a/src/maasservicelayer/models/users.py
+++ b/src/maasservicelayer/models/users.py
@@ -36,14 +36,9 @@ class UserProfile(MaasBaseModel):
     provider_id: int | None = None
 
 
-class UserWithSummary(BaseModel):
+class UserStatistics(BaseModel):
     id: int
     completed_intro: bool
-    email: str | None = None  # it's a string in the UI
     is_local: bool
-    is_superuser: bool
-    last_name: str | None = None  # it's a string in the UI
-    last_login: datetime | None = None
     machines_count: int
     sshkeys_count: int
-    username: str

--- a/src/maasservicelayer/services/users.py
+++ b/src/maasservicelayer/services/users.py
@@ -63,7 +63,7 @@ from maasservicelayer.exceptions.constants import (
     PRECONDITION_FAILED,
 )
 from maasservicelayer.models.base import ListResult
-from maasservicelayer.models.users import User, UserProfile, UserWithSummary
+from maasservicelayer.models.users import User, UserProfile, UserStatistics
 from maasservicelayer.services.base import BaseService
 from maasservicelayer.services.consumers import ConsumersService
 from maasservicelayer.services.filestorage import FileStorageService
@@ -338,18 +338,18 @@ class UsersService(BaseService[User, UsersRepository, UserBuilder]):
             builder=NodeBuilder(owner_id=to_user_id),
         )
 
-    async def get_by_id_with_summary(self, id: int) -> UserWithSummary | None:
-        return await self.repository.get_by_id_with_summary(id=id)
+    async def get_by_id_statistics(self, id: int) -> UserStatistics | None:
+        return await self.repository.get_by_id_statistics(id=id)
 
     async def get_by_username(self, username: str) -> User | None:
         return await self.repository.get_one(
             query=QuerySpec(where=UserClauseFactory.with_username(username))
         )
 
-    async def list_with_summary(
+    async def list_statistics(
         self, page: int, size: int, query: QuerySpec
-    ) -> ListResult[UserWithSummary]:
-        return await self.repository.list_with_summary(
+    ) -> ListResult[UserStatistics]:
+        return await self.repository.list_statistics(
             page=page, size=size, query=query
         )
 

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
@@ -101,7 +101,7 @@ class TestUsersApi(ApiCommonTests):
             ),
             Endpoint(
                 method="GET",
-                path=f"{V3_API_PREFIX}/users_statistics",
+                path=f"{V3_API_PREFIX}/users/statistics",
                 permission=MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
             ),
             Endpoint(
@@ -717,12 +717,8 @@ class TestUsersApi(ApiCommonTests):
             items=[
                 UserStatistics(
                     id=1,
-                    username="foo",
                     completed_intro=True,
-                    email="foo@example.com",
                     is_local=True,
-                    is_superuser=False,
-                    last_name="foo",
                     machines_count=2,
                     sshkeys_count=3,
                 )
@@ -740,11 +736,8 @@ class TestUsersApi(ApiCommonTests):
         assert users_statistics.next is None
         user = users_statistics.items[0]
         assert user.id == 1
-        assert user.username == "foo"
         assert user.completed_intro is True
         assert user.is_local is True
-        assert user.is_superuser is False
-        assert user.last_name == "foo"
         assert user.machines_count == 2
         assert user.sshkeys_count == 3
         services_mock.users.list_statistics.assert_called_once_with(
@@ -766,12 +759,8 @@ class TestUsersApi(ApiCommonTests):
             items=[
                 UserStatistics(
                     id=1,
-                    username="foo",
                     completed_intro=True,
-                    email="foo@example.com",
                     is_local=True,
-                    is_superuser=False,
-                    last_name="foo",
                     machines_count=2,
                     sshkeys_count=3,
                 )
@@ -780,7 +769,7 @@ class TestUsersApi(ApiCommonTests):
         )
 
         response = await client.get(
-            f"{V3_API_PREFIX}/users_statistics?size=1&username_or_email=example",
+            f"{V3_API_PREFIX}/users/statistics?size=1&username_or_email=example",
         )
         assert response.status_code == 200
         users_statistics = UsersStatisticsListResponse(**response.json())
@@ -788,7 +777,7 @@ class TestUsersApi(ApiCommonTests):
         assert len(users_statistics.items) == 1
         assert (
             users_statistics.next
-            == f"{V3_API_PREFIX}/users_statistics?page=2&size=1&username_or_email=example"
+            == f"{V3_API_PREFIX}/users/statistics?page=2&size=1&username_or_email=example"
         )
         services_mock.users.list_statistics.assert_called_once_with(
             page=1,

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
@@ -21,8 +21,8 @@ from maasapiserver.v3.api.public.models.responses.users import (
     UserInfoResponse,
     UserResponse,
     UsersListResponse,
-    UsersWithSummaryListResponse,
-    UserWithSummaryResponse,
+    UsersStatisticsListResponse,
+    UserStatisticsResponse,
 )
 from maasapiserver.v3.constants import V3_API_PREFIX
 from maascommon.openfga.base import MAASResourceEntitlement
@@ -43,7 +43,7 @@ from maasservicelayer.exceptions.constants import (
     UNIQUE_CONSTRAINT_VIOLATION_TYPE,
 )
 from maasservicelayer.models.base import ListResult
-from maasservicelayer.models.users import User, UserProfile, UserWithSummary
+from maasservicelayer.models.users import User, UserProfile, UserStatistics
 from maasservicelayer.services import ServiceCollectionV3
 from maasservicelayer.services.external_auth import ExternalAuthService
 from maasservicelayer.services.users import UsersService
@@ -101,7 +101,7 @@ class TestUsersApi(ApiCommonTests):
             ),
             Endpoint(
                 method="GET",
-                path=f"{V3_API_PREFIX}/users_with_summary",
+                path=f"{V3_API_PREFIX}/users_statistics",
                 permission=MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
             ),
             Endpoint(
@@ -702,7 +702,7 @@ class TestUsersApi(ApiCommonTests):
         assert response.status_code == 400
         services_mock.users.transfer_resources.assert_called_once_with(1, 2)
 
-    async def test_list_with_summary(
+    async def test_list_statistics(
         self,
         services_mock: ServiceCollectionV3,
         mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
@@ -711,11 +711,11 @@ class TestUsersApi(ApiCommonTests):
             MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
         )
         services_mock.users = Mock(UsersService)
-        services_mock.users.list_with_summary.return_value = ListResult[
-            UserWithSummary
+        services_mock.users.list_statistics.return_value = ListResult[
+            UserStatistics
         ](
             items=[
-                UserWithSummary(
+                UserStatistics(
                     id=1,
                     username="foo",
                     completed_intro=True,
@@ -731,14 +731,14 @@ class TestUsersApi(ApiCommonTests):
         )
 
         response = await client.get(
-            f"{V3_API_PREFIX}/users_with_summary?size=1",
+            f"{V3_API_PREFIX}/users_statistics?size=1",
         )
         assert response.status_code == 200
-        users_with_summary = UsersWithSummaryListResponse(**response.json())
-        assert users_with_summary.total == 1
-        assert len(users_with_summary.items) == 1
-        assert users_with_summary.next is None
-        user = users_with_summary.items[0]
+        users_statistics = UsersStatisticsListResponse(**response.json())
+        assert users_statistics.total == 1
+        assert len(users_statistics.items) == 1
+        assert users_statistics.next is None
+        user = users_statistics.items[0]
         assert user.id == 1
         assert user.username == "foo"
         assert user.completed_intro is True
@@ -747,11 +747,11 @@ class TestUsersApi(ApiCommonTests):
         assert user.last_name == "foo"
         assert user.machines_count == 2
         assert user.sshkeys_count == 3
-        services_mock.users.list_with_summary.assert_called_once_with(
+        services_mock.users.list_statistics.assert_called_once_with(
             page=1, size=1, query=QuerySpec(where=None)
         )
 
-    async def test_list_with_summary_filters(
+    async def test_list_statistics_filters(
         self,
         services_mock: ServiceCollectionV3,
         mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
@@ -760,11 +760,11 @@ class TestUsersApi(ApiCommonTests):
             MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
         )
         services_mock.users = Mock(UsersService)
-        services_mock.users.list_with_summary.return_value = ListResult[
-            UserWithSummary
+        services_mock.users.list_statistics.return_value = ListResult[
+            UserStatistics
         ](
             items=[
-                UserWithSummary(
+                UserStatistics(
                     id=1,
                     username="foo",
                     completed_intro=True,
@@ -780,17 +780,17 @@ class TestUsersApi(ApiCommonTests):
         )
 
         response = await client.get(
-            f"{V3_API_PREFIX}/users_with_summary?size=1&username_or_email=example",
+            f"{V3_API_PREFIX}/users_statistics?size=1&username_or_email=example",
         )
         assert response.status_code == 200
-        users_with_summary = UsersWithSummaryListResponse(**response.json())
-        assert users_with_summary.total == 2
-        assert len(users_with_summary.items) == 1
+        users_statistics = UsersStatisticsListResponse(**response.json())
+        assert users_statistics.total == 2
+        assert len(users_statistics.items) == 1
         assert (
-            users_with_summary.next
-            == f"{V3_API_PREFIX}/users_with_summary?page=2&size=1&username_or_email=example"
+            users_statistics.next
+            == f"{V3_API_PREFIX}/users_statistics?page=2&size=1&username_or_email=example"
         )
-        services_mock.users.list_with_summary.assert_called_once_with(
+        services_mock.users.list_statistics.assert_called_once_with(
             page=1,
             size=1,
             query=QuerySpec(
@@ -852,31 +852,27 @@ class TestUsersApi(ApiCommonTests):
             user_id=1, password="foo"
         )
 
-    async def test_user_with_summary(
+    async def test_user_statistics(
         self, services_mock: ServiceCollectionV3, mocked_api_client_user
     ) -> None:
         services_mock.users = Mock(UsersService)
-        services_mock.users.get_by_id_with_summary.return_value = (
-            UserWithSummary(
+        services_mock.users.get_by_id_statistics.return_value = (
+            UserStatistics(
                 id=0,
-                username="foo",
                 completed_intro=True,
-                email="foo@example.com",
                 is_local=True,
-                is_superuser=False,
-                last_name="foo",
                 machines_count=2,
                 sshkeys_count=3,
             )
         )
 
         response = await mocked_api_client_user.get(
-            f"{V3_API_PREFIX}/users/me_with_summary"
+            f"{V3_API_PREFIX}/users/me/statistics"
         )
         assert response.status_code == 200
-        user_with_summary = UserWithSummaryResponse(**response.json())
-        assert user_with_summary.id == 0
-        assert user_with_summary.username == "foo"
-        services_mock.users.get_by_id_with_summary.assert_called_once_with(
+        user_statistics = UserStatisticsResponse(**response.json())
+        assert user_statistics.id == 0
+        assert user_statistics.machines_count == 2
+        services_mock.users.get_by_id_statistics.assert_called_once_with(
             id=0
         )

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
@@ -845,14 +845,12 @@ class TestUsersApi(ApiCommonTests):
         self, services_mock: ServiceCollectionV3, mocked_api_client_user
     ) -> None:
         services_mock.users = Mock(UsersService)
-        services_mock.users.get_by_id_statistics.return_value = (
-            UserStatistics(
-                id=0,
-                completed_intro=True,
-                is_local=True,
-                machines_count=2,
-                sshkeys_count=3,
-            )
+        services_mock.users.get_by_id_statistics.return_value = UserStatistics(
+            id=0,
+            completed_intro=True,
+            is_local=True,
+            machines_count=2,
+            sshkeys_count=3,
         )
 
         response = await mocked_api_client_user.get(
@@ -862,6 +860,4 @@ class TestUsersApi(ApiCommonTests):
         user_statistics = UserStatisticsResponse(**response.json())
         assert user_statistics.id == 0
         assert user_statistics.machines_count == 2
-        services_mock.users.get_by_id_statistics.assert_called_once_with(
-            id=0
-        )
+        services_mock.users.get_by_id_statistics.assert_called_once_with(id=0)

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
@@ -101,7 +101,7 @@ class TestUsersApi(ApiCommonTests):
             ),
             Endpoint(
                 method="GET",
-                path=f"{V3_API_PREFIX}/users/statistics",
+                path=f"{V3_API_PREFIX}/users:statistics",
                 permission=MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
             ),
             Endpoint(
@@ -727,7 +727,7 @@ class TestUsersApi(ApiCommonTests):
         )
 
         response = await client.get(
-            f"{V3_API_PREFIX}/users_statistics?size=1",
+            f"{V3_API_PREFIX}/users:statistics?size=1",
         )
         assert response.status_code == 200
         users_statistics = UsersStatisticsListResponse(**response.json())
@@ -769,7 +769,7 @@ class TestUsersApi(ApiCommonTests):
         )
 
         response = await client.get(
-            f"{V3_API_PREFIX}/users/statistics?size=1&username_or_email=example",
+            f"{V3_API_PREFIX}/users:statistics?size=1&username_or_email=example",
         )
         assert response.status_code == 200
         users_statistics = UsersStatisticsListResponse(**response.json())
@@ -777,7 +777,7 @@ class TestUsersApi(ApiCommonTests):
         assert len(users_statistics.items) == 1
         assert (
             users_statistics.next
-            == f"{V3_API_PREFIX}/users/statistics?page=2&size=1&username_or_email=example"
+            == f"{V3_API_PREFIX}/users:statistics?page=2&size=1&username_or_email=example"
         )
         services_mock.users.list_statistics.assert_called_once_with(
             page=1,
@@ -854,7 +854,7 @@ class TestUsersApi(ApiCommonTests):
         )
 
         response = await mocked_api_client_user.get(
-            f"{V3_API_PREFIX}/users/me/statistics"
+            f"{V3_API_PREFIX}/users/me:statistics"
         )
         assert response.status_code == 200
         user_statistics = UserStatisticsResponse(**response.json())

--- a/src/tests/maasapiserver/v3/api/public/models/responses/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/models/responses/test_users.py
@@ -3,10 +3,10 @@
 
 from maasapiserver.v3.api.public.models.responses.users import (
     UserResponse,
-    UserWithSummaryResponse,
+    UserStatisticsResponse,
 )
 from maasapiserver.v3.constants import V3_API_PREFIX
-from maasservicelayer.models.users import User, UserWithSummary
+from maasservicelayer.models.users import User, UserStatistics
 from maasservicelayer.utils.date import utcnow
 
 
@@ -44,10 +44,10 @@ class TestUserResponse:
         )
 
 
-class TestUserWithSummaryResponse:
+class TestUserStatisticsResponse:
     def test_from_model(self) -> None:
         now = utcnow()
-        user = UserWithSummary(
+        user = UserStatistics(
             id=1,
             completed_intro=False,
             email="email@example.com",
@@ -59,7 +59,7 @@ class TestUserWithSummaryResponse:
             sshkeys_count=20,
             username="test_username",
         )
-        user_response = UserWithSummaryResponse.from_model(
+        user_response = UserStatisticsResponse.from_model(
             user, self_base_hyperlink=f"{V3_API_PREFIX}/users"
         )
         assert user_response.id == user.id

--- a/src/tests/maasapiserver/v3/api/public/models/responses/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/models/responses/test_users.py
@@ -46,7 +46,6 @@ class TestUserResponse:
 
 class TestUserStatisticsResponse:
     def test_from_model(self) -> None:
-        now = utcnow()
         user = UserStatistics(
             id=1,
             completed_intro=False,

--- a/src/tests/maasapiserver/v3/api/public/models/responses/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/models/responses/test_users.py
@@ -50,29 +50,18 @@ class TestUserStatisticsResponse:
         user = UserStatistics(
             id=1,
             completed_intro=False,
-            email="email@example.com",
             is_local=True,
-            is_superuser=False,
-            last_name="test_last_name",
-            last_login=now,
             machines_count=10,
             sshkeys_count=20,
-            username="test_username",
         )
         user_response = UserStatisticsResponse.from_model(
             user, self_base_hyperlink=f"{V3_API_PREFIX}/users"
         )
         assert user_response.id == user.id
         assert user_response.completed_intro == user.completed_intro
-        assert user_response.email == user.email
         assert user_response.is_local == user.is_local
-        assert user_response.is_superuser == user.is_superuser
-        assert user_response.is_superuser == user.is_superuser
-        assert user_response.last_name == user.last_name
-        assert user_response.last_login == user.last_login
         assert user_response.machines_count == user.machines_count
         assert user_response.sshkeys_count == user.sshkeys_count
-        assert user_response.username == user.username
         assert user_response.hal_links is not None
         assert (
             user_response.hal_links.self.href

--- a/src/tests/maasservicelayer/db/repositories/test_users.py
+++ b/src/tests/maasservicelayer/db/repositories/test_users.py
@@ -326,14 +326,12 @@ class TestUsersRepository:
 
         users_repository = UsersRepository(Context(connection=db_connection))
 
-        query = QuerySpec(
-            where=UserClauseFactory.with_ids([user1.id, user3.id])
-        )
-
         users_statistics = await users_repository.list_statistics(
             page=1,
             size=1000,
-            query=query,
+            query=QuerySpec(
+                where=UserClauseFactory.with_ids([user1.id, user3.id])
+            ),
         )
 
         assert len(users_statistics.items) == 2
@@ -341,18 +339,18 @@ class TestUsersRepository:
         assert users_statistics.items[0].id == user1.id
         assert users_statistics.items[1].id == user3.id
 
-        query = QuerySpec(
-            where=UserClauseFactory.with_ids([user1.id, user2.id, user3.id])
-        )
-
         users_statistics = await users_repository.list_statistics(
             page=1,
             size=1000,
-            query=query,
+            query=QuerySpec(
+                where=UserClauseFactory.with_ids(
+                    [user1.id, user2.id, user3.id]
+                )
+            ),
         )
 
-        assert len(users_statistics.items) == 2
-        assert users_statistics.total == 2
+        assert len(users_statistics.items) == 3
+        assert users_statistics.total == 3
 
     async def test_get_by_id_statistics(
         self, db_connection: AsyncConnection, fixture: Fixture

--- a/src/tests/maasservicelayer/db/repositories/test_users.py
+++ b/src/tests/maasservicelayer/db/repositories/test_users.py
@@ -48,7 +48,7 @@ class TestUserClauseFactory:
                     compile_kwargs={"literal_binds": True}
                 )
             )
-            == "maasserver_user.id IN (1, 2)"
+            == "auth_user.id IN (1, 2)"
         )
 
 
@@ -313,7 +313,6 @@ class TestUsersRepository:
         self,
         db_connection: AsyncConnection,
         fixture: Fixture,
-        num_results: int,
     ) -> None:
         user1 = await create_test_user(
             fixture, username="johnmarston", email="foo@example.com"

--- a/src/tests/maasservicelayer/db/repositories/test_users.py
+++ b/src/tests/maasservicelayer/db/repositories/test_users.py
@@ -203,7 +203,7 @@ class TestUsersRepository:
         assert users_list.total == 0
         assert users_list.items == []
 
-    async def test_list_with_summary(
+    async def test_list_statistics(
         self, db_connection: AsyncConnection, fixture: Fixture
     ) -> None:
         user1 = await create_test_user(
@@ -235,7 +235,7 @@ class TestUsersRepository:
         await create_test_user_profile(fixture, user_id=user4.id)
 
         users_repository = UsersRepository(Context(connection=db_connection))
-        users_list = await users_repository.list_with_summary(
+        users_list = await users_repository.list_statistics(
             page=1, size=1000, query=QuerySpec(where=None)
         )
         # only active users should be listed
@@ -248,14 +248,14 @@ class TestUsersRepository:
         assert users_list.items[2].machines_count == 3
         assert users_list.items[2].sshkeys_count == 0
 
-    async def test_list_with_summary_special_users(
+    async def test_list_statistics_special_users(
         self, db_connection: AsyncConnection, fixture: Fixture
     ) -> None:
         await create_test_user(fixture, username="MAAS")
         await create_test_user(fixture, username="maas-init-node")
 
         users_repository = UsersRepository(Context(connection=db_connection))
-        users_list = await users_repository.list_with_summary(
+        users_list = await users_repository.list_statistics(
             page=1, size=1000, query=QuerySpec(where=None)
         )
         assert users_list.total == 0
@@ -271,7 +271,7 @@ class TestUsersRepository:
             ("example", 3),
         ],
     )
-    async def test_list_with_summary_filters(
+    async def test_list_statistics_filters(
         self,
         db_connection: AsyncConnection,
         fixture: Fixture,
@@ -289,7 +289,7 @@ class TestUsersRepository:
         )
 
         users_repository = UsersRepository(Context(connection=db_connection))
-        users_list = await users_repository.list_with_summary(
+        users_list = await users_repository.list_statistics(
             page=1,
             size=1000,
             query=QuerySpec(
@@ -298,7 +298,7 @@ class TestUsersRepository:
         )
         assert users_list.total == num_results
 
-    async def test_get_by_id_with_summary(
+    async def test_get_by_id_statistics(
         self, db_connection: AsyncConnection, fixture: Fixture
     ) -> None:
         user = await create_test_user(fixture, username="user", is_active=True)
@@ -308,23 +308,19 @@ class TestUsersRepository:
         await create_test_user_sshkey(fixture, key="bar", user_id=user.id)
         users_repository = UsersRepository(Context(connection=db_connection))
 
-        user_with_summary = await users_repository.get_by_id_with_summary(
-            user.id
-        )
-        assert user_with_summary.username == "user"
-        assert user_with_summary.machines_count == 1
-        assert user_with_summary.sshkeys_count == 2
+        user_statistics = await users_repository.get_by_id_statistics(user.id)
+        assert user_statistics
+        assert user_statistics.machines_count == 1
+        assert user_statistics.sshkeys_count == 2
 
-    async def test_get_by_id_with_summary_system_user(
+    async def test_get_by_id_statistics_system_user(
         self, db_connection: AsyncConnection, fixture: Fixture
     ) -> None:
         user = await create_test_user(fixture, username="MAAS")
         users_repository = UsersRepository(Context(connection=db_connection))
 
-        user_with_summary = await users_repository.get_by_id_with_summary(
-            user.id
-        )
-        assert user_with_summary is None
+        user_statistics = await users_repository.get_by_id_statistics(user.id)
+        assert user_statistics is None
 
     async def test_count_by_provider(
         self, db_connection: AsyncConnection, fixture: Fixture

--- a/src/tests/maasservicelayer/db/repositories/test_users.py
+++ b/src/tests/maasservicelayer/db/repositories/test_users.py
@@ -289,15 +289,19 @@ class TestUsersRepository:
         query: str,
         num_results: int,
     ) -> None:
-        await create_test_user(
+        user1 = await create_test_user(
             fixture, username="foo", email="foo@example.com"
         )
-        await create_test_user(
+        user2 = await create_test_user(
             fixture, username="FOOOOO!", email="hello@example.com"
         )
-        await create_test_user(
+        user3 = await create_test_user(
             fixture, username="bar!", email="bar@example.com"
         )
+
+        await create_test_user_profile(fixture, user_id=user1.id)
+        await create_test_user_profile(fixture, user_id=user2.id)
+        await create_test_user_profile(fixture, user_id=user3.id)
 
         users_repository = UsersRepository(Context(connection=db_connection))
         users_list = await users_repository.list_statistics(
@@ -308,6 +312,7 @@ class TestUsersRepository:
             ),
         )
         assert users_list.total == num_results
+        assert len(users_list.items) == num_results
 
     async def test_list_statistics_filter_by_ids(
         self,
@@ -315,14 +320,18 @@ class TestUsersRepository:
         fixture: Fixture,
     ) -> None:
         user1 = await create_test_user(
-            fixture, username="johnmarston", email="foo@example.com"
+            fixture, username="arthurmorgan", email="arthur.morgan@example.com"
         )
         user2 = await create_test_user(
-            fixture, username="arthurmorgan", email="hello@example.com"
+            fixture, username="hoseamatthews", email="hosea.matthews@example.com"
         )
         user3 = await create_test_user(
-            fixture, username="hoseamatthews", email="bar@example.com"
+            fixture, username="johnmarston", email="john.marston@example.com"
         )
+
+        await create_test_user_profile(fixture, user_id=user1.id)
+        await create_test_user_profile(fixture, user_id=user2.id)
+        await create_test_user_profile(fixture, user_id=user3.id)
 
         users_repository = UsersRepository(Context(connection=db_connection))
 
@@ -336,8 +345,8 @@ class TestUsersRepository:
 
         assert len(users_statistics.items) == 2
         assert users_statistics.total == 2
-        assert users_statistics.items[0].id == user1.id
-        assert users_statistics.items[1].id == user3.id
+        assert users_statistics.items[0].id == user3.id
+        assert users_statistics.items[1].id == user1.id
 
         users_statistics = await users_repository.list_statistics(
             page=1,

--- a/src/tests/maasservicelayer/db/repositories/test_users.py
+++ b/src/tests/maasservicelayer/db/repositories/test_users.py
@@ -323,7 +323,9 @@ class TestUsersRepository:
             fixture, username="arthurmorgan", email="arthur.morgan@example.com"
         )
         user2 = await create_test_user(
-            fixture, username="hoseamatthews", email="hosea.matthews@example.com"
+            fixture,
+            username="hoseamatthews",
+            email="hosea.matthews@example.com",
         )
         user3 = await create_test_user(
             fixture, username="johnmarston", email="john.marston@example.com"

--- a/src/tests/maasservicelayer/db/repositories/test_users.py
+++ b/src/tests/maasservicelayer/db/repositories/test_users.py
@@ -40,6 +40,17 @@ class TestUserClauseFactory:
             "lower(auth_user.username) LIKE lower('%foo%') OR lower(auth_user.email) LIKE lower('%foo%')"
         )
 
+    def test_with_ids(self):
+        clause = UserClauseFactory.with_ids([1, 2])
+        assert (
+            str(
+                clause.condition.compile(
+                    compile_kwargs={"literal_binds": True}
+                )
+            )
+            == "maasserver_user.id IN (1, 2)"
+        )
+
 
 @pytest.mark.usefixtures("ensuremaasdb")
 @pytest.mark.asyncio
@@ -297,6 +308,52 @@ class TestUsersRepository:
             ),
         )
         assert users_list.total == num_results
+
+    async def test_list_statistics_filter_by_ids(
+        self,
+        db_connection: AsyncConnection,
+        fixture: Fixture,
+        num_results: int,
+    ) -> None:
+        user1 = await create_test_user(
+            fixture, username="johnmarston", email="foo@example.com"
+        )
+        user2 = await create_test_user(
+            fixture, username="arthurmorgan", email="hello@example.com"
+        )
+        user3 = await create_test_user(
+            fixture, username="hoseamatthews", email="bar@example.com"
+        )
+
+        users_repository = UsersRepository(Context(connection=db_connection))
+
+        query = QuerySpec(
+            where=UserClauseFactory.with_ids([user1.id, user3.id])
+        )
+
+        users_statistics = await users_repository.list_statistics(
+            page=1,
+            size=1000,
+            query=query,
+        )
+
+        assert len(users_statistics.items) == 2
+        assert users_statistics.total == 2
+        assert users_statistics.items[0].id == user1.id
+        assert users_statistics.items[1].id == user3.id
+
+        query = QuerySpec(
+            where=UserClauseFactory.with_ids([user1.id, user2.id, user3.id])
+        )
+
+        users_statistics = await users_repository.list_statistics(
+            page=1,
+            size=1000,
+            query=query,
+        )
+
+        assert len(users_statistics.items) == 2
+        assert users_statistics.total == 2
 
     async def test_get_by_id_statistics(
         self, db_connection: AsyncConnection, fixture: Fixture

--- a/src/tests/maasservicelayer/services/test_users.py
+++ b/src/tests/maasservicelayer/services/test_users.py
@@ -615,21 +615,21 @@ class TestUsersService:
         with pytest.raises(BadRequestException):
             await users_service.transfer_resources(1, 2)
 
-    async def test_list_with_summary(
+    async def test_list_statistics(
         self, users_service: UsersService, users_repository: Mock
     ) -> None:
-        await users_service.list_with_summary(
+        await users_service.list_statistics(
             page=1, size=1000, query=QuerySpec(where=None)
         )
-        users_repository.list_with_summary.assert_called_once_with(
+        users_repository.list_statistics.assert_called_once_with(
             page=1, size=1000, query=QuerySpec(where=None)
         )
 
-    async def test_get_by_id_with_summary(
+    async def test_get_by_id_statistics(
         self, users_service: UsersService, users_repository: Mock
     ) -> None:
-        await users_service.get_by_id_with_summary(id=1)
-        users_repository.get_by_id_with_summary.assert_called_once_with(id=1)
+        await users_service.get_by_id_statistics(id=1)
+        users_repository.get_by_id_statistics.assert_called_once_with(id=1)
 
     async def test_get_by_username(
         self, users_service: UsersService, users_repository: Mock


### PR DESCRIPTION
## Done
- /users_with_summary changed to /users/statistics
- /me_with_summary changed to /me/with/statistics
- removed duplicate information in endpoints (except for ID)