### PR TITLE
fix(maasserver): avoid sources_list when >=24.04 (#45)

### DIFF
--- a/src/maascommon/utils/images.py
+++ b/src/maascommon/utils/images.py
@@ -1,0 +1,26 @@
+#  Copyright 2025 Canonical Ltd.  This software is licensed under the
+#  GNU Affero General Public License version 3 (see the file LICENSE).
+
+from distro_info import UbuntuDistroInfo
+
+
+def get_distro_series_info_row(series):
+    """Returns the distro series row information from python-distro-info."""
+    info = UbuntuDistroInfo()
+    for row in info._avail(info._date):
+        # LP: #1711191 - distro-info 0.16+ no longer returns dictionaries or
+        # lists, and it now returns objects instead. As such, we need to
+        # handle both cases for backwards compatibility.
+        if not isinstance(row, dict):
+            row = row.__dict__
+        if row["series"] == series:
+            return row
+    return None
+
+
+def format_ubuntu_distro_series(series):
+    """Formats the Ubuntu distro series into a version name."""
+    row = get_distro_series_info_row(series)
+    if row is None:
+        return series
+    return row["version"]

--- a/src/maasserver/compose_preseed.py
+++ b/src/maasserver/compose_preseed.py
@@ -8,6 +8,7 @@ from ipaddress import ip_address
 from urllib.parse import urlencode, urlparse
 
 from django.urls import reverse
+from packaging.version import InvalidVersion, parse, Version
 import yaml
 
 from maascommon.osystem import (
@@ -16,10 +17,12 @@ from maascommon.osystem import (
     OperatingSystemRegistry,
     Token,
 )
+from maascommon.utils.images import format_ubuntu_distro_series
 from maasserver.dns.config import get_resource_name_for_subnet
 from maasserver.enum import NODE_STATUS, PRESEED_TYPE
 from maasserver.models import PackageRepository
 from maasserver.models.config import Config
+from maasserver.models.node import Node as NodeModel
 from maasserver.models.subnet import get_boot_rackcontroller_ips, Subnet
 from maasserver.node_status import COMMISSIONING_LIKE_STATUSES
 from maasserver.server_address import get_maas_facing_server_host
@@ -157,27 +160,27 @@ def get_cloud_init_legacy_apt_config_to_inject_key_to_archive(node):
     return apt_sources
 
 
-def get_archive_config(request, node, preserve_sources=False):
-    arch = node.split_arch()[0]
-    archive = PackageRepository.objects.get_default_archive(arch)
-    repositories = PackageRepository.objects.get_additional_repositories(arch)
-    apt_proxy = get_apt_proxy(request, node.get_boot_rack_controller(), node)
-
-    # Process the default Ubuntu Archives or Mirror.
-    archives = {}
-    archives["apt"] = {}
-    archives["apt"]["preserve_sources_list"] = preserve_sources
+def generate_urls_for_sources_list(archive: PackageRepository) -> str:
     # Always generate a custom list of repositories. deb-src is enabled in the
     # ephemeral environment due to the cloud-init template having it enabled.
     # It is disabled in a deployed environment due to the Curtin template
     # having it enabled.
     urls = ""
-    components = set(archive.KNOWN_COMPONENTS)
 
-    if archive.disabled_components:
-        for comp in archive.COMPONENTS_TO_DISABLE:
-            if comp in archive.disabled_components:
-                components.remove(comp)
+    disabled_components = (
+        archive.disabled_components
+        if archive.disabled_components is not None
+        else ""
+    )
+
+    components = [
+        component
+        for component in archive.KNOWN_COMPONENTS
+        if not (
+            component in disabled_components
+            and component in archive.COMPONENTS_TO_DISABLE
+        )
+    ]
 
     urls += "deb {} $RELEASE {}\n".format(archive.url, " ".join(components))
     if archive.disable_sources:
@@ -204,7 +207,100 @@ def get_archive_config(request, node, preserve_sources=False):
                 " ".join(components),
             )
 
-    archives["apt"]["sources_list"] = urls
+    return urls
+
+
+def generate_deb822_for_sources(archive: PackageRepository) -> str:
+    disabled_components = (
+        archive.disabled_components
+        if archive.disabled_components is not None
+        else []
+    )
+
+    components = [
+        component
+        for component in archive.KNOWN_COMPONENTS
+        if not (
+            component in disabled_components
+            and component in archive.COMPONENTS_TO_DISABLE
+        )
+    ]
+
+    types = "deb" if archive.disable_sources else "deb deb-src"
+
+    suites = ["$RELEASE"]
+    for pocket in archive.POCKETS_TO_DISABLE:
+        if (
+            not archive.disabled_pockets
+            or pocket not in archive.disabled_pockets
+        ):
+            suites.append(f"$RELEASE-{pocket}")
+
+    content = f"Types: {types}\n"
+    content += f"URIs: {archive.url}\n"
+    content += f"Suites: {' '.join(suites)}\n"
+    content += f"Components: {' '.join(components)}\n"
+    if not archive.key:
+        content += (
+            "Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg\n"
+        )
+    return content
+
+
+def get_ubuntu_version(series: str) -> Version:
+    version = format_ubuntu_distro_series(series)
+
+    # This avoids issues with things like "24.04 LTS".
+    version, _, _ = version.partition(" ")
+
+    try:
+        parsed_version = parse(version)
+    except InvalidVersion:
+        # If version cannot be parsed, we assume a version that
+        # matches the deb822 format behavior since it is most recent.
+        parsed_version = parse("24.04")
+
+    return parsed_version
+
+
+def get_archive_config(
+    request, node: NodeModel, preserve_sources=False
+) -> dict:
+    arch = node.split_arch()[0]
+    archive: PackageRepository = PackageRepository.objects.get_default_archive(
+        arch
+    )
+    repositories = PackageRepository.objects.get_additional_repositories(arch)
+    apt_proxy = get_apt_proxy(request, node.get_boot_rack_controller(), node)
+
+    # Process the default Ubuntu Archives or Mirror.
+    archives = {}
+    archives["apt"] = {}
+    archives["apt"]["preserve_sources_list"] = preserve_sources
+
+    if "sources" not in archives["apt"]:
+        archives["apt"]["sources"] = {}
+
+    osystem = node.get_osystem()
+    series = node.get_distro_series()
+
+    is_ubuntu_and_later_than_or_equal_to_24_04 = (
+        osystem == "ubuntu" and get_ubuntu_version(series) >= parse("24.04")
+    )
+
+    if is_ubuntu_and_later_than_or_equal_to_24_04:
+        # From 24.04 on, Ubuntu uses as default the deb822 format for APT repositories.
+        # If providing both, this creates duplicate repositories entries that confuses
+        # apt update. See https://bugs.launchpad.net/maas/+bug/2093303 for more details.
+        #
+        # Furthermore, sources_list plays a "double role" for cloud-init. If provided
+        # with something that follows the deb822 format as below, it will populate
+        # ubuntu.sources. If not, it will populate sources.list.
+        archives["apt"]["sources_list"] = generate_deb822_for_sources(archive)
+    else:
+        archives["apt"]["sources_list"] = generate_urls_for_sources_list(
+            archive
+        )
 
     if apt_proxy:
         archives["apt"]["proxy"] = apt_proxy
@@ -232,9 +328,6 @@ def get_archive_config(request, node, preserve_sources=False):
                 url = ""
                 for dist in repo.distributions:
                     url += f"deb {repo.url} {dist} {components}\n"
-
-        if "sources" not in archives["apt"].keys():
-            archives["apt"]["sources"] = {}
 
         repo_name = make_clean_repo_name(repo)
 
@@ -410,6 +503,12 @@ def get_base_preseed(node=None):
         # to JuJu deploy in an ephemeral environment.
         "manage_etc_hosts": True
     }
+
+    if node is not None and node.status == NODE_STATUS.DEPLOYING:
+        # python3-packaging is a dependency of curtin which might or might not
+        # be included in the images. For instance, it is not included in the
+        # image we use of bionic.
+        cloud_config["packages"] = ["python3-packaging"]
 
     if node is None or node.status in COMMISSIONING_LIKE_STATUSES:
         # All other ephemeral environments use the MAAS script runner or

--- a/src/maasserver/tests/test_compose_preseed.py
+++ b/src/maasserver/tests/test_compose_preseed.py
@@ -5,6 +5,7 @@ from ipaddress import ip_address
 import random
 
 from django.urls import reverse
+from packaging.version import parse
 import yaml
 
 from maascommon.osystem import BOOT_IMAGE_PURPOSE, NoSuchOperatingSystem
@@ -13,11 +14,15 @@ from maasserver.compose_preseed import (
     build_metadata_url,
     compose_enlistment_preseed,
     compose_preseed,
+    generate_deb822_for_sources,
+    generate_urls_for_sources_list,
     get_apt_proxy,
+    get_ubuntu_version,
 )
 from maasserver.enum import NODE_STATUS, NODE_STATUS_CHOICES, PRESEED_TYPE
 from maasserver.models import NodeKey, PackageRepository
 from maasserver.models.config import Config
+from maasserver.models.node import Node
 from maasserver.rpc.testing.fixtures import RunningClusterRPCFixture
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
@@ -388,43 +393,25 @@ class TestComposePreseed(MAASServerTestCase):
             expected_package_mirrors,
         )
 
-    def assertAptConfig(self, config, apt_proxy):
+    def assertAptConfig(self, config, apt_proxy, node: Node | None = None):
         archive = PackageRepository.objects.get_default_archive("amd64")
-        components = set(archive.KNOWN_COMPONENTS)
 
-        if archive.disabled_components:
-            for comp in archive.COMPONENTS_TO_DISABLE:
-                if comp in archive.disabled_components:
-                    components.remove(comp)
-
-        components = " ".join(components)
-        sources_list = f"deb {archive.url} $RELEASE {components}\n"
-        if archive.disable_sources:
-            sources_list += "# "
-        sources_list += f"deb-src {archive.url} $RELEASE {components}\n"
-
-        for pocket in archive.POCKETS_TO_DISABLE:
-            if pocket in archive.disabled_pockets:
-                continue
-            sources_list += "deb {} $RELEASE-{} {}\n".format(
-                archive.url,
-                pocket,
-                components,
-            )
-            if archive.disable_sources:
-                sources_list += "# "
-            sources_list += "deb-src {} $RELEASE-{} {}\n".format(
-                archive.url,
-                pocket,
-                components,
-            )
+        if (
+            node is not None
+            and node.get_osystem() == "ubuntu"
+            and get_ubuntu_version(node.get_distro_series()) >= parse("24.04")
+        ):
+            expected_sources_list = generate_deb822_for_sources(archive)
+        else:
+            expected_sources_list = generate_urls_for_sources_list(archive)
 
         self.assertEqual(
             config.get("apt", {}),
             {
                 "preserve_sources_list": False,
                 "proxy": apt_proxy,
-                "sources_list": sources_list,
+                "sources_list": expected_sources_list,
+                "sources": {},
             },
         )
         self.assertEqual(
@@ -435,6 +422,13 @@ class TestComposePreseed(MAASServerTestCase):
                 ],
             },
         )
+
+    def test_get_ubuntu_version(self):
+        self.assertEqual(get_ubuntu_version("precise"), parse("12.04"))
+        self.assertEqual(get_ubuntu_version("jammy"), parse("22.04"))
+        self.assertEqual(get_ubuntu_version("noble"), parse("24.04"))
+        self.assertEqual(get_ubuntu_version("oracular"), parse("24.10"))
+        self.assertEqual(get_ubuntu_version("resolute"), parse("26.04"))
 
     def test_compose_preseed_for_commissioning_node_skips_apt_proxy(self):
         rack_controller = factory.make_RackController()
@@ -481,7 +475,7 @@ class TestComposePreseed(MAASServerTestCase):
             {"consumer_key", "endpoint", "token_key", "token_secret", "type"},
         )
         self.assertEqual(preseed["rsyslog"]["remotes"].keys(), {"maas"})
-        self.assertAptConfig(preseed, apt_proxy)
+        self.assertAptConfig(preseed, apt_proxy, node)
         self.assertEqual(
             preseed["snap"],
             {
@@ -874,7 +868,7 @@ class TestComposePreseed(MAASServerTestCase):
             f"{request.scheme}://{rack_controller.fqdn}:5248{reverse('curtin-metadata')}",
             preseed["datasource"]["MAAS"]["metadata_url"],
         )
-        self.assertAptConfig(preseed, expected_apt_proxy)
+        self.assertAptConfig(preseed, expected_apt_proxy, node)
         self.assertEqual(
             preseed["snap"],
             {
@@ -957,7 +951,7 @@ class TestComposePreseed(MAASServerTestCase):
 
         self.assertNotIn("apt_sources", preseed)
 
-    def test_compose_preseed_for_curtin_not_packages(self):
+    def test_compose_preseed_for_curtin_packages_python3_packaging_only(self):
         rack_controller = factory.make_RackController()
         node = factory.make_Node(
             interface=True,
@@ -978,7 +972,10 @@ class TestComposePreseed(MAASServerTestCase):
             compose_preseed(request, PRESEED_TYPE.CURTIN, node)
         )
 
-        self.assertNotIn("packages", preseed)
+        self.assertIn("packages", preseed)
+        # This is a dependency from curtin, and should be the only one.
+        # It comes by default in some ubuntu images, but not all.
+        self.assertEqual(preseed["packages"], ["python3-packaging"])
 
     def test_compose_preseed_with_osystem_compose_preseed(self):
         os_name = factory.make_name("os")

--- a/src/maasserver/tests/test_preseed.py
+++ b/src/maasserver/tests/test_preseed.py
@@ -15,13 +15,20 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.urls import reverse
+from packaging.version import parse
 import yaml
 
 from maascommon.osystem import BOOT_IMAGE_PURPOSE, OperatingSystemRegistry
 from maascommon.osystem.custom import CustomOS
 from maascommon.osystem.ubuntu import UbuntuOS
 from maasserver import preseed as preseed_module
-from maasserver.compose_preseed import get_archive_config, make_clean_repo_name
+from maasserver.compose_preseed import (
+    generate_deb822_for_sources,
+    generate_urls_for_sources_list,
+    get_archive_config,
+    get_ubuntu_version,
+    make_clean_repo_name,
+)
 from maasserver.enum import (
     BOOT_RESOURCE_FILE_TYPE,
     BOOT_RESOURCE_TYPE,
@@ -30,7 +37,13 @@ from maasserver.enum import (
     PRESEED_TYPE,
 )
 from maasserver.exceptions import MissingBootImage
-from maasserver.models import BootResource, Config, NodeKey, PackageRepository
+from maasserver.models import (
+    BootResource,
+    Config,
+    Node,
+    NodeKey,
+    PackageRepository,
+)
 from maasserver.models import dnspublication as dnspublications_module
 from maasserver.models.bootresource import LINUX_OSYSTEMS
 from maasserver.preseed import (
@@ -1446,38 +1459,23 @@ class TestCurtinUtilities(BootImageHelperMixin, MAASServerTestCase):
         super().setUp()
         self.patch(dnspublications_module, "post_commit_do")
 
-    def assertAptConfig(self, config, archive=None):
+    def assertAptConfig(self, config, archive=None, node: Node | None = None):
         if archive is None:
             archive = PackageRepository.objects.get_default_archive("amd64")
-        components = set(archive.KNOWN_COMPONENTS)
 
-        if archive.disabled_components:
-            for comp in archive.COMPONENTS_TO_DISABLE:
-                if comp in archive.disabled_components:
-                    components.remove(comp)
-
-        components = " ".join(components)
-        sources_list = f"deb {archive.url} $RELEASE {components}\n"
-        if archive.disable_sources:
-            sources_list += "# "
-        sources_list += f"deb-src {archive.url} $RELEASE {components}\n"
-
-        for pocket in archive.POCKETS_TO_DISABLE:
-            if archive.disabled_pockets and pocket in archive.disabled_pockets:
-                continue
-            sources_list += (
-                f"deb {archive.url} $RELEASE-{pocket} {components}\n"
-            )
-            if archive.disable_sources:
-                sources_list += "# "
-            sources_list += (
-                f"deb-src {archive.url} $RELEASE-{pocket} {components}\n"
-            )
+        if (
+            node is not None
+            and node.get_osystem() == "ubuntu"
+            and get_ubuntu_version(node.get_distro_series()) >= parse("24.04")
+        ):
+            expected_sources_list = generate_deb822_for_sources(archive)
+        else:
+            expected_sources_list = generate_urls_for_sources_list(archive)
 
         apt_config = config.get("apt")
         self.assertFalse(apt_config.get("preserve_sources_list"))
         self.assertIn("proxy", apt_config)
-        self.assertEqual(apt_config.get("sources_list"), sources_list)
+        self.assertEqual(apt_config.get("sources_list"), expected_sources_list)
 
     def test_get_curtin_config(self):
         node = factory.make_Node_with_Interface_on_Subnet(
@@ -1705,30 +1703,40 @@ class TestCurtinUtilities(BootImageHelperMixin, MAASServerTestCase):
         return parsed_result.netloc, parsed_result.path.strip("/")
 
     def test_compose_curtin_archive_config_uses_main_archive_for_i386(self):
-        PackageRepository.objects.all().delete()
-        node = self.make_fastpath_node("i386")
-        node.osystem = "ubuntu"
-        main_url = "http://us.archive.ubuntu.com/ubuntu"
-        factory.make_PackageRepository(
-            url=main_url, default=True, arches=["i386", "amd64"]
-        )
-        self.make_boot_image_for_node(node, "xinstall")
-        # compose_curtin_archive_config returns a list.
-        userdata = compose_curtin_archive_config(make_HttpRequest(), node)
-        self.assertAptConfig(yaml.safe_load(userdata[0]))
+        for distro_series in ("focal", "noble"):
+            with self.subTest(distro_series=distro_series):
+                PackageRepository.objects.all().delete()
+                node = self.make_fastpath_node("i386")
+                node.osystem = "ubuntu"
+                node.distro_series = distro_series
+                main_url = "http://us.archive.ubuntu.com/ubuntu"
+                factory.make_PackageRepository(
+                    url=main_url, default=True, arches=["i386", "amd64"]
+                )
+                self.make_boot_image_for_node(node, "xinstall")
+                # compose_curtin_archive_config returns a list.
+                userdata = compose_curtin_archive_config(
+                    make_HttpRequest(), node
+                )
+                self.assertAptConfig(yaml.safe_load(userdata[0]), node=node)
 
     def test_compose_curtin_archive_config_uses_main_archive_for_amd64(self):
-        PackageRepository.objects.all().delete()
-        node = self.make_fastpath_node("amd64")
-        node.osystem = "ubuntu"
-        main_url = "http://us.archive.ubuntu.com/ubuntu"
-        factory.make_PackageRepository(
-            url=main_url, default=True, arches=["i386", "amd64"]
-        )
-        self.make_boot_image_for_node(node, "xinstall")
-        # compose_curtin_archive_config returns a list.
-        userdata = compose_curtin_archive_config(make_HttpRequest(), node)
-        self.assertAptConfig(yaml.safe_load(userdata[0]))
+        for distro_series in ("focal", "noble"):
+            with self.subTest(distro_series=distro_series):
+                PackageRepository.objects.all().delete()
+                node = self.make_fastpath_node("amd64")
+                node.osystem = "ubuntu"
+                node.distro_series = distro_series
+                main_url = "http://us.archive.ubuntu.com/ubuntu"
+                factory.make_PackageRepository(
+                    url=main_url, default=True, arches=["i386", "amd64"]
+                )
+                self.make_boot_image_for_node(node, "xinstall")
+                # compose_curtin_archive_config returns a list.
+                userdata = compose_curtin_archive_config(
+                    make_HttpRequest(), node
+                )
+                self.assertAptConfig(yaml.safe_load(userdata[0]), node=node)
 
     def test_compose_curtin_archive_config_uses_main_archive_key(self):
         PackageRepository.objects.all().delete()
@@ -1776,24 +1784,29 @@ XJzKwRUEuJlIkVEZ72OtuoUMoBrjuADRlJQUW0ZbcmpOxjK1c6w08nhSvA==
         )
 
     def test_compose_curtin_archive_config_disables_pockets(self):
-        PackageRepository.objects.all().delete()
-        node = self.make_fastpath_node("amd64")
-        node.osystem = "ubuntu"
-        main_url = "http://us.archive.ubuntu.com/ubuntu"
-        archive = factory.make_PackageRepository(
-            url=main_url,
-            default=True,
-            arches=["i386", "amd64"],
-            disabled_pockets=["updates", "backports"],
-        )
-        self.make_boot_image_for_node(node, "xinstall")
-        # compose_curtin_archive_config returns a list.
-        userdata = compose_curtin_archive_config(make_HttpRequest(), node)
-        preseed = yaml.safe_load(userdata[0])
-        archive = PackageRepository.objects.get_default_archive(
-            node.split_arch()[0]
-        )
-        self.assertAptConfig(preseed, archive)
+        for distro_series in ("focal", "noble"):
+            with self.subTest(distro_series=distro_series):
+                PackageRepository.objects.all().delete()
+                node = self.make_fastpath_node("amd64")
+                node.osystem = "ubuntu"
+                node.distro_series = distro_series
+                main_url = "http://us.archive.ubuntu.com/ubuntu"
+                archive = factory.make_PackageRepository(
+                    url=main_url,
+                    default=True,
+                    arches=["i386", "amd64"],
+                    disabled_pockets=["updates", "backports"],
+                )
+                self.make_boot_image_for_node(node, "xinstall")
+                # compose_curtin_archive_config returns a list.
+                userdata = compose_curtin_archive_config(
+                    make_HttpRequest(), node
+                )
+                preseed = yaml.safe_load(userdata[0])
+                archive = PackageRepository.objects.get_default_archive(
+                    node.split_arch()[0]
+                )
+                self.assertAptConfig(preseed, archive, node)
 
     def test_compose_curtin_archive_config_with_disabled_pockets(self):
         """Test that main archive has a configuration that includes
@@ -1816,27 +1829,31 @@ XJzKwRUEuJlIkVEZ72OtuoUMoBrjuADRlJQUW0ZbcmpOxjK1c6w08nhSvA==
         # compose_curtin_archive_config returns a list.
         userdata = compose_curtin_archive_config(make_HttpRequest(), node)
         preseed = yaml.safe_load(userdata[0])
-        self.assertAptConfig(preseed, archive)
+        self.assertAptConfig(preseed, archive, node)
 
     def test_compose_curtin_archive_config_with_deb_src(self):
-        PackageRepository.objects.all().delete()
-        node = self.make_fastpath_node("amd64")
-        node.osystem = "ubuntu"
-        main_url = "http://us.archive.ubuntu.com/ubuntu"
-        archive = factory.make_PackageRepository(
-            url=main_url,
-            default=True,
-            arches=["i386", "amd64"],
-            disable_sources=False,
-        )
-        self.make_boot_image_for_node(node, "xinstall")
-        # compose_curtin_archive_config returns a list.
-        userdata = compose_curtin_archive_config(make_HttpRequest(), node)
-        preseed = yaml.safe_load(userdata[0])
-        archive = PackageRepository.objects.get_default_archive(
-            node.split_arch()[0]
-        )
-        self.assertAptConfig(preseed, archive)
+        for distro_series in ("focal", "noble"):
+            with self.subTest(distro_series=distro_series):
+                PackageRepository.objects.all().delete()
+                node = self.make_fastpath_node("amd64")
+                node.osystem = "ubuntu"
+                main_url = "http://us.archive.ubuntu.com/ubuntu"
+                archive = factory.make_PackageRepository(
+                    url=main_url,
+                    default=True,
+                    arches=["i386", "amd64"],
+                    disable_sources=False,
+                )
+                self.make_boot_image_for_node(node, "xinstall")
+                # compose_curtin_archive_config returns a list.
+                userdata = compose_curtin_archive_config(
+                    make_HttpRequest(), node
+                )
+                preseed = yaml.safe_load(userdata[0])
+                archive = PackageRepository.objects.get_default_archive(
+                    node.split_arch()[0]
+                )
+                self.assertAptConfig(preseed, archive, node)
 
     def test_compose_curtin_archive_config_has_ppa(self):
         node = self.make_fastpath_node("i386")
@@ -2007,19 +2024,26 @@ XJzKwRUEuJlIkVEZ72OtuoUMoBrjuADRlJQUW0ZbcmpOxjK1c6w08nhSvA==
         )
 
     def test_compose_curtin_archive_config_ports_archive_for_other_arch(self):
-        node = self.make_fastpath_node("ppc64el")
-        node.osystem = "ubuntu"
-        main_url = PackageRepository.get_ports_archive().url
-        factory.make_PackageRepository(
-            url=main_url, default=True, arches=["ppc64el", "arm64"]
-        )
-        self.make_boot_image_for_node(node, "xinstall")
-        # compose_curtin_archive_config returns a list.
-        userdata = compose_curtin_archive_config(make_HttpRequest(), node)
-        archive = PackageRepository.objects.get_default_archive(
-            node.split_arch()[0]
-        )
-        self.assertAptConfig(yaml.safe_load(userdata[0]), archive)
+        for distro_series in ("focal", "noble"):
+            with self.subTest(distro_series=distro_series):
+                node = self.make_fastpath_node("ppc64el")
+                node.osystem = "ubuntu"
+                node.distro_series = distro_series
+                main_url = PackageRepository.get_ports_archive().url
+                factory.make_PackageRepository(
+                    url=main_url, default=True, arches=["ppc64el", "arm64"]
+                )
+                self.make_boot_image_for_node(node, "xinstall")
+                # compose_curtin_archive_config returns a list.
+                userdata = compose_curtin_archive_config(
+                    make_HttpRequest(), node
+                )
+                archive = PackageRepository.objects.get_default_archive(
+                    node.split_arch()[0]
+                )
+                self.assertAptConfig(
+                    yaml.safe_load(userdata[0]), archive, node
+                )
 
     def test_compose_curtin_archive_config_main_archive_for_custom_os(self):
         node = self.make_fastpath_node("amd64")


### PR DESCRIPTION
From Ubuntu 24.04 forward, the apt repository is now stored by default following the deb822 format. See here for a reference: https://repolib.readthedocs.io/en/latest/deb822-format.html

Before this change, machines would end up having both the old one-line format on top of the deb822, generating two repository sources as described in https://bugs.launchpad.net/maas/+bug/2093303.

This PR empties the old one in case we are deploying a machine with Ubuntu >=24.04.

Resolves LP:2093303