### PR TITLE
feat: add filtering to custom_images endpoint based ID and file type

### DIFF
--- a/src/maasapiserver/v3/api/public/handlers/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/handlers/boot_resources.py
@@ -329,7 +329,9 @@ class CustomImagesHandler(Handler):
                 ]
             )
             if filter_clause
-            else BootResourceClauseFactory.with_rtype(BootResourceType.UPLOADED)
+            else BootResourceClauseFactory.with_rtype(
+                BootResourceType.UPLOADED
+            )
         )
 
         boot_resources = await services.boot_resources.list(

--- a/src/maasapiserver/v3/api/public/handlers/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/handlers/boot_resources.py
@@ -314,18 +314,41 @@ class CustomImagesHandler(Handler):
     )
     async def list_custom_images(
         self,
+        filters: CustomImageFilterParams = Depends(),  # noqa: B008
         pagination_params: PaginationParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> ImageListResponse:
+        filter_clause = filters.to_clause()
+        where_clause = (
+            BootResourceClauseFactory.and_clauses(
+                [
+                    BootResourceClauseFactory.with_rtype(
+                        BootResourceType.UPLOADED
+                    ),
+                    filter_clause,
+                ]
+            )
+            if filter_clause
+            else BootResourceClauseFactory.with_rtype(BootResourceType.UPLOADED)
+        )
+
         boot_resources = await services.boot_resources.list(
             page=pagination_params.page,
             size=pagination_params.size,
-            query=QuerySpec(
-                where=BootResourceClauseFactory.with_rtype(
-                    BootResourceType.UPLOADED
-                )
-            ),
+            query=QuerySpec(where=where_clause),
         )
+
+        next_link = None
+        if boot_resources.has_next(
+            pagination_params.page, pagination_params.size
+        ):
+            next_link = (
+                f"{V3_API_PREFIX}/custom_images?"
+                f"{pagination_params.to_next_href_format()}"
+            )
+            if query_filters := filters.to_href_format():
+                next_link += f"&{query_filters}"
+
         return ImageListResponse(
             items=[
                 ImageResponse.from_boot_resource(
@@ -335,14 +358,7 @@ class CustomImagesHandler(Handler):
                 for boot_resource in boot_resources.items
             ],
             total=boot_resources.total,
-            next=(
-                f"{V3_API_PREFIX}/custom_images?"
-                + f"{pagination_params.to_next_href_format()}"
-                if boot_resources.has_next(
-                    pagination_params.page, pagination_params.size
-                )
-                else None
-            ),
+            next=next_link,
         )
 
     @handler(

--- a/src/maasapiserver/v3/api/public/handlers/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/handlers/boot_resources.py
@@ -318,20 +318,13 @@ class CustomImagesHandler(Handler):
         pagination_params: PaginationParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> ImageListResponse:
-        filter_clause = filters.to_clause()
-        where_clause = (
-            BootResourceClauseFactory.and_clauses(
-                [
-                    BootResourceClauseFactory.with_rtype(
-                        BootResourceType.UPLOADED
-                    ),
-                    filter_clause,
-                ]
-            )
-            if filter_clause
-            else BootResourceClauseFactory.with_rtype(
-                BootResourceType.UPLOADED
-            )
+        where_clause = BootResourceClauseFactory.and_clauses(
+            [
+                BootResourceClauseFactory.with_rtype(
+                    BootResourceType.UPLOADED
+                ),
+                filters.to_clause(),
+            ]
         )
 
         boot_resources = await services.boot_resources.list(

--- a/src/maasapiserver/v3/api/public/handlers/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/handlers/boot_resources.py
@@ -318,14 +318,10 @@ class CustomImagesHandler(Handler):
         pagination_params: PaginationParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> ImageListResponse:
-        where_clause = BootResourceClauseFactory.and_clauses(
-            [
-                BootResourceClauseFactory.with_rtype(
-                    BootResourceType.UPLOADED
-                ),
-                filters.to_clause(),
-            ]
-        )
+        clauses = [BootResourceClauseFactory.with_rtype(BootResourceType.UPLOADED)]
+        if filter_clause := filters.to_clause():
+            clauses.append(filter_clause)
+        where_clause = BootResourceClauseFactory.and_clauses(clauses)
 
         boot_resources = await services.boot_resources.list(
             page=pagination_params.page,

--- a/src/maasapiserver/v3/api/public/handlers/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/handlers/boot_resources.py
@@ -318,7 +318,9 @@ class CustomImagesHandler(Handler):
         pagination_params: PaginationParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> ImageListResponse:
-        clauses = [BootResourceClauseFactory.with_rtype(BootResourceType.UPLOADED)]
+        clauses = [
+            BootResourceClauseFactory.with_rtype(BootResourceType.UPLOADED)
+        ]
         if filter_clause := filters.to_clause():
             clauses.append(filter_clause)
         where_clause = BootResourceClauseFactory.and_clauses(clauses)

--- a/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
@@ -323,7 +323,9 @@ class CustomImageFilterParams(BaseModel):
         if self.file_type is not None:
             clauses.append(
                 BootResourceClauseFactory.with_filetype(
-                    BootResourceFileTypeChoice.get_resource_filetype(self.file_type)
+                    BootResourceFileTypeChoice.get_resource_filetype(
+                        self.file_type
+                    )
                 )
             )
 

--- a/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
@@ -322,7 +322,9 @@ class CustomImageFilterParams(BaseModel):
             clauses.append(BootResourceClauseFactory.with_ids(self.ids))
         if self.file_type is not None:
             clauses.append(
-                BootResourceClauseFactory.with_filetype(self.file_type)
+                BootResourceClauseFactory.with_filetype(
+                    BootResourceFileTypeChoice.get_resource_filetype(self.file_type)
+                )
             )
 
         if len(clauses) == 0:

--- a/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
@@ -309,13 +309,31 @@ class CustomImageFilterParams(BaseModel):
             description="Filter by Custom Image ID",
         )
     )
+    file_type: BootResourceFileType | None = Field(
+        Query(
+            default=None,
+            description="Filter by file type (e.g., self-extracting for switch images)",
+        )
+    )
 
     def to_clause(self) -> Clause | None:
+        clauses = []
         if self.ids is not None:
-            return BootResourceClauseFactory.with_ids(self.ids)
-        return None
+            clauses.append(BootResourceClauseFactory.with_ids(self.ids))
+        if self.file_type is not None:
+            clauses.append(BootResourceClauseFactory.with_filetype(self.file_type))
+
+        if len(clauses) == 0:
+            return None
+        elif len(clauses) == 1:
+            return clauses[0]
+        else:
+            return BootResourceClauseFactory.and_clauses(clauses)
 
     def to_href_format(self) -> str | None:
+        parts = []
         if self.ids is not None:
-            return "&".join([f"id={id}" for id in self.ids])
-        return None
+            parts.extend([f"id={id}" for id in self.ids])
+        if self.file_type is not None:
+            parts.append(f"file_type={self.file_type}")
+        return "&".join(parts) if parts else None

--- a/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
@@ -321,7 +321,9 @@ class CustomImageFilterParams(BaseModel):
         if self.ids is not None:
             clauses.append(BootResourceClauseFactory.with_ids(self.ids))
         if self.file_type is not None:
-            clauses.append(BootResourceClauseFactory.with_filetype(self.file_type))
+            clauses.append(
+                BootResourceClauseFactory.with_filetype(self.file_type)
+            )
 
         if len(clauses) == 0:
             return None

--- a/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
+++ b/src/maasapiserver/v3/api/public/models/requests/boot_resources.py
@@ -309,7 +309,7 @@ class CustomImageFilterParams(BaseModel):
             description="Filter by Custom Image ID",
         )
     )
-    file_type: BootResourceFileType | None = Field(
+    file_type: BootResourceFileTypeChoice | None = Field(
         Query(
             default=None,
             description="Filter by file type (e.g., self-extracting for switch images)",

--- a/src/maasservicelayer/db/repositories/bootresources.py
+++ b/src/maasservicelayer/db/repositories/bootresources.py
@@ -109,6 +109,26 @@ class BootResourceClauseFactory(ClauseFactory):
             ],
         )
 
+    @classmethod
+    def with_filetype(cls, filetype: BootResourceFileType) -> Clause:
+        subquery = (
+            select(BootResourceSetTable.c.resource_id)
+            .distinct()
+            .select_from(BootResourceSetTable)
+            .join(
+                BootResourceFileTable,
+                eq(
+                    BootResourceFileTable.c.resource_set_id,
+                    BootResourceSetTable.c.id,
+                ),
+            )
+            .where(eq(BootResourceFileTable.c.filetype, filetype))
+            .scalar_subquery()
+        )
+        return Clause(
+            condition=BootResourceTable.c.id.in_(subquery),
+        )
+
 
 class BootResourceOrderByClauses(OrderByClauseFactory):
     @staticmethod

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_boot_resources.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_boot_resources.py
@@ -497,6 +497,66 @@ class TestCustomImagesApi(ApiCommonTests):
             boot_resources_response.next == f"{self.BASE_PATH}?page=2&size=1"
         )
 
+    async def test_list_custom_images_filter_by_file_type(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_VIEW_BOOT_ENTITIES,
+        )
+        services_mock.boot_resources = Mock(BootResourceService)
+        services_mock.boot_resources.list.return_value = ListResult[
+            BootResource
+        ](items=[TEST_BOOT_RESOURCE_1], total=1)
+
+        response = await client.get(
+            f"{self.BASE_PATH}?file_type=self-extracting"
+        )
+
+        assert response.status_code == 200
+
+        boot_resources_response = ImageListResponse(**response.json())
+
+        assert len(boot_resources_response.items) == 1
+        assert boot_resources_response.total == 1
+        assert boot_resources_response.next is None
+
+        services_mock.boot_resources.list.assert_called_once()
+        call_args = services_mock.boot_resources.list.call_args
+        query_spec = call_args.kwargs["query"]
+        assert query_spec is not None
+        assert query_spec.where is not None
+
+    async def test_list_custom_images_filter_combined(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_VIEW_BOOT_ENTITIES,
+        )
+        services_mock.boot_resources = Mock(BootResourceService)
+        services_mock.boot_resources.list.return_value = ListResult[
+            BootResource
+        ](items=[TEST_BOOT_RESOURCE_1], total=2)
+
+        response = await client.get(
+            f"{self.BASE_PATH}?size=1&id=1&id=2&file_type=self-extracting"
+        )
+
+        assert response.status_code == 200
+
+        boot_resources_response = ImageListResponse(**response.json())
+
+        assert len(boot_resources_response.items) == 1
+        assert boot_resources_response.total == 2
+        assert boot_resources_response.next is not None
+        assert (
+            boot_resources_response.next
+            == f"{self.BASE_PATH}?page=2&size=1&id=1&id=2&file_type=self-extracting"
+        )
+
     async def test_get_custom_image_by_id_200(
         self,
         services_mock: ServiceCollectionV3,

--- a/src/tests/maasapiserver/v3/api/public/models/requests/test_boot_resources.py
+++ b/src/tests/maasapiserver/v3/api/public/models/requests/test_boot_resources.py
@@ -9,7 +9,10 @@ from maasapiserver.v3.api.public.models.requests.boot_resources import (
     BootResourceFileTypeChoice,
     CustomImageFilterParams,
 )
-from maascommon.enums.boot_resources import BootResourceType
+from maascommon.enums.boot_resources import (
+    BootResourceFileType,
+    BootResourceType,
+)
 from maasservicelayer.builders.bootresources import BootResourceBuilder
 from maasservicelayer.db.repositories.bootresources import (
     BootResourceClauseFactory,
@@ -558,16 +561,80 @@ class TestCustomImageFilterParams:
             ([1, 2, 3], BootResourceClauseFactory.with_ids([1, 2, 3])),
         ],
     )
-    def test_to_clause(self, ids, expected):
-        filters = CustomImageFilterParams(ids=ids)
+    def test_to_clause_ids(self, ids, expected):
+        filters = CustomImageFilterParams(ids=ids, file_type=None)
         clause = filters.to_clause()
+        assert clause == expected
+
+    @pytest.mark.parametrize(
+        "file_type,expected",
+        [
+            (None, None),
+            (
+                BootResourceFileType.SELF_EXTRACTING,
+                BootResourceClauseFactory.with_filetype(
+                    BootResourceFileType.SELF_EXTRACTING
+                ),
+            ),
+            (
+                BootResourceFileType.ROOT_TGZ,
+                BootResourceClauseFactory.with_filetype(
+                    BootResourceFileType.ROOT_TGZ
+                ),
+            ),
+        ],
+    )
+    def test_to_clause_file_type(self, file_type, expected):
+        filters = CustomImageFilterParams(ids=None, file_type=file_type)
+        clause = filters.to_clause()
+        assert clause == expected
+
+    def test_to_clause_combined_filters(self):
+        filters = CustomImageFilterParams(
+            ids=[1, 2], file_type=BootResourceFileType.SELF_EXTRACTING
+        )
+        clause = filters.to_clause()
+        # Should return an and_clauses with both filters
+        assert clause is not None
+        # The clause should be a combination of both filters
+        expected = BootResourceClauseFactory.and_clauses(
+            [
+                BootResourceClauseFactory.with_ids([1, 2]),
+                BootResourceClauseFactory.with_filetype(
+                    BootResourceFileType.SELF_EXTRACTING
+                ),
+            ]
+        )
         assert clause == expected
 
     @pytest.mark.parametrize(
         "ids,expected",
         [(None, None), ([1], "id=1"), ([1, 2, 3], "id=1&id=2&id=3")],
     )
-    def test_to_href_format(self, ids, expected):
-        filters = CustomImageFilterParams(ids=ids)
+    def test_to_href_format_ids(self, ids, expected):
+        filters = CustomImageFilterParams(ids=ids, file_type=None)
         href = filters.to_href_format()
         assert href == expected
+
+    @pytest.mark.parametrize(
+        "file_type,expected",
+        [
+            (None, None),
+            (
+                BootResourceFileType.SELF_EXTRACTING,
+                "file_type=self-extracting",
+            ),
+            (BootResourceFileType.ROOT_TGZ, "file_type=root-tgz"),
+        ],
+    )
+    def test_to_href_format_file_type(self, file_type, expected):
+        filters = CustomImageFilterParams(ids=None, file_type=file_type)
+        href = filters.to_href_format()
+        assert href == expected
+
+    def test_to_href_format_combined_filters(self):
+        filters = CustomImageFilterParams(
+            ids=[1, 2], file_type=BootResourceFileType.SELF_EXTRACTING
+        )
+        href = filters.to_href_format()
+        assert href == "id=1&id=2&file_type=self-extracting"

--- a/src/tests/maasapiserver/v3/api/public/models/requests/test_boot_resources.py
+++ b/src/tests/maasapiserver/v3/api/public/models/requests/test_boot_resources.py
@@ -571,13 +571,13 @@ class TestCustomImageFilterParams:
         [
             (None, None),
             (
-                BootResourceFileType.SELF_EXTRACTING,
+                BootResourceFileTypeChoice.SELF_EXTRACTING,
                 BootResourceClauseFactory.with_filetype(
                     BootResourceFileType.SELF_EXTRACTING
                 ),
             ),
             (
-                BootResourceFileType.ROOT_TGZ,
+                BootResourceFileTypeChoice.TGZ,
                 BootResourceClauseFactory.with_filetype(
                     BootResourceFileType.ROOT_TGZ
                 ),
@@ -621,10 +621,10 @@ class TestCustomImageFilterParams:
         [
             (None, None),
             (
-                BootResourceFileType.SELF_EXTRACTING,
+                BootResourceFileTypeChoice.SELF_EXTRACTING,
                 "file_type=self-extracting",
             ),
-            (BootResourceFileType.ROOT_TGZ, "file_type=root-tgz"),
+            (BootResourceFileTypeChoice.TGZ, "file_type=tgz"),
         ],
     )
     def test_to_href_format_file_type(self, file_type, expected):

--- a/src/tests/maasapiserver/v3/api/public/models/requests/test_boot_resources.py
+++ b/src/tests/maasapiserver/v3/api/public/models/requests/test_boot_resources.py
@@ -591,7 +591,7 @@ class TestCustomImageFilterParams:
 
     def test_to_clause_combined_filters(self):
         filters = CustomImageFilterParams(
-            ids=[1, 2], file_type=BootResourceFileType.SELF_EXTRACTING
+            ids=[1, 2], file_type=BootResourceFileTypeChoice.SELF_EXTRACTING
         )
         clause = filters.to_clause()
         # Should return an and_clauses with both filters
@@ -634,7 +634,7 @@ class TestCustomImageFilterParams:
 
     def test_to_href_format_combined_filters(self):
         filters = CustomImageFilterParams(
-            ids=[1, 2], file_type=BootResourceFileType.SELF_EXTRACTING
+            ids=[1, 2], file_type=BootResourceFileTypeChoice.SELF_EXTRACTING
         )
         href = filters.to_href_format()
         assert href == "id=1&id=2&file_type=self-extracting"

--- a/src/tests/maasservicelayer/db/repositories/test_bootresources.py
+++ b/src/tests/maasservicelayer/db/repositories/test_bootresources.py
@@ -457,7 +457,7 @@ class TestBootResourceRepository:
         assert result_tgz.total == 1
         assert len(result_tgz.items) == 1
         assert result_tgz.items[0].id == regular_resource.id
-        assert result_tgz.items[0].name == "ubuntu/focal"
+        assert result_tgz.items[0].name == "custom/noble"
 
     async def test_list_with_filetype_filter_no_duplicates(
         self,

--- a/src/tests/maasservicelayer/db/repositories/test_bootresources.py
+++ b/src/tests/maasservicelayer/db/repositories/test_bootresources.py
@@ -109,14 +109,10 @@ class TestBootResourceClauseFactory:
         compiled = str(
             clause.condition.compile(compile_kwargs={"literal_binds": True})
         )
-        assert "maasserver_bootresource.id IN" in compiled
-        assert "SELECT DISTINCT" in compiled
-        assert "maasserver_bootresourceset.resource_id" in compiled
         assert (
-            "maasserver_bootresourcefile.filetype = 'self-extracting'"
-            in compiled
+            compiled
+            == "maasserver_bootresource.id IN (SELECT DISTINCT maasserver_bootresourceset.resource_id \nFROM maasserver_bootresourceset JOIN maasserver_bootresourcefile ON maasserver_bootresourcefile.resource_set_id = maasserver_bootresourceset.id \nWHERE maasserver_bootresourcefile.filetype = 'self-extracting')"
         )
-        assert len(clause.joins) == 0
 
 
 class TestCommonBootResourceRepository(RepositoryCommonTests[BootResource]):

--- a/src/tests/maasservicelayer/db/repositories/test_bootresources.py
+++ b/src/tests/maasservicelayer/db/repositories/test_bootresources.py
@@ -13,14 +13,21 @@ from maascommon.enums.boot_resources import (
 from maascommon.enums.node import NodeStatus
 from maasservicelayer.builders.bootresources import BootResourceBuilder
 from maasservicelayer.context import Context
+from maasservicelayer.db.filters import QuerySpec
 from maasservicelayer.db.repositories.bootresources import (
     BootResourceClauseFactory,
     BootResourcesRepository,
 )
 from maasservicelayer.models.bootresources import BootResource
+from tests.fixtures.factories.bootresourcefiles import (
+    create_test_bootresourcefile_entry,
+)
 from tests.fixtures.factories.bootresources import (
     create_test_bootresource_entry,
     create_test_custom_bootresource_status_entry,
+)
+from tests.fixtures.factories.bootresourcesets import (
+    create_test_bootresourceset_entry,
 )
 from tests.fixtures.factories.node import (
     create_test_machine_entry,
@@ -361,13 +368,6 @@ class TestBootResourceRepository:
         fixture: Fixture,
     ):
         """Test filtering boot resources by file type."""
-        from maasservicelayer.db.filters import QuerySpec
-        from tests.fixtures.factories.bootresourcefiles import (
-            create_test_bootresourcefile_entry,
-        )
-        from tests.fixtures.factories.bootresourcesets import (
-            create_test_bootresourceset_entry,
-        )
 
         # Create boot resource with self-extracting file (switch image)
         switch_resource = await create_test_bootresource_entry(

--- a/src/tests/maasservicelayer/db/repositories/test_bootresources.py
+++ b/src/tests/maasservicelayer/db/repositories/test_bootresources.py
@@ -5,6 +5,7 @@ import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
 
 from maascommon.enums.boot_resources import (
+    BootResourceFileType,
     BootResourceType,
     ImageStatus,
     ImageUpdateStatus,
@@ -100,6 +101,22 @@ class TestBootResourceClauseFactory:
             "maasserver_bootsourceselection JOIN maasserver_bootresource ON maasserver_bootsourceselection.id = maasserver_bootresource.selection_id"
             in compiled_joins
         )
+
+    def test_with_filetype(self) -> None:
+        clause = BootResourceClauseFactory.with_filetype(
+            BootResourceFileType.SELF_EXTRACTING
+        )
+        compiled = str(
+            clause.condition.compile(compile_kwargs={"literal_binds": True})
+        )
+        assert "maasserver_bootresource.id IN" in compiled
+        assert "SELECT DISTINCT" in compiled
+        assert "maasserver_bootresourceset.resource_id" in compiled
+        assert (
+            "maasserver_bootresourcefile.filetype = 'self-extracting'"
+            in compiled
+        )
+        assert len(clause.joins) == 0
 
 
 class TestCommonBootResourceRepository(RepositoryCommonTests[BootResource]):
@@ -341,3 +358,247 @@ class TestBootResourceRepository:
         )
         assert len(stats_list.items) == 1
         assert stats_list.total == 1
+
+    async def test_list_with_filetype_filter(
+        self,
+        repository: BootResourcesRepository,
+        fixture: Fixture,
+    ):
+        """Test filtering boot resources by file type."""
+        from maasservicelayer.db.filters import QuerySpec
+        from tests.fixtures.factories.bootresourcefiles import (
+            create_test_bootresourcefile_entry,
+        )
+        from tests.fixtures.factories.bootresourcesets import (
+            create_test_bootresourceset_entry,
+        )
+
+        # Create boot resource with self-extracting file (switch image)
+        switch_resource = await create_test_bootresource_entry(
+            fixture,
+            rtype=BootResourceType.UPLOADED,
+            name="onie/cumulus",
+            architecture="amd64/generic",
+        )
+        switch_set = await create_test_bootresourceset_entry(
+            fixture,
+            version="1.0",
+            label="release",
+            resource_id=switch_resource.id,
+        )
+        await create_test_bootresourcefile_entry(
+            fixture,
+            filename="installer.bin",
+            filetype=BootResourceFileType.SELF_EXTRACTING,
+            sha256="switch123",
+            size=2048,
+            filename_on_disk="installer.bin",
+            resource_set_id=switch_set.id,
+        )
+
+        # Create boot resource with tgz file (regular image)
+        regular_resource = await create_test_bootresource_entry(
+            fixture,
+            rtype=BootResourceType.UPLOADED,
+            name="ubuntu/focal",
+            architecture="amd64/generic",
+        )
+        regular_set = await create_test_bootresourceset_entry(
+            fixture,
+            version="20.04",
+            label="release",
+            resource_id=regular_resource.id,
+        )
+        await create_test_bootresourcefile_entry(
+            fixture,
+            filename="root.tgz",
+            filetype=BootResourceFileType.ROOT_TGZ,
+            sha256="ubuntu123",
+            size=1024,
+            filename_on_disk="root.tgz",
+            resource_set_id=regular_set.id,
+        )
+
+        result = await repository.list(
+            page=1,
+            size=10,
+            query=QuerySpec(
+                where=BootResourceClauseFactory.and_clauses(
+                    [
+                        BootResourceClauseFactory.with_rtype(
+                            BootResourceType.UPLOADED
+                        ),
+                        BootResourceClauseFactory.with_filetype(
+                            BootResourceFileType.SELF_EXTRACTING
+                        ),
+                    ]
+                )
+            ),
+        )
+
+        assert result.total == 1
+        assert len(result.items) == 1
+        assert result.items[0].id == switch_resource.id
+        assert result.items[0].name == "onie/cumulus"
+
+        result_tgz = await repository.list(
+            page=1,
+            size=10,
+            query=QuerySpec(
+                where=BootResourceClauseFactory.and_clauses(
+                    [
+                        BootResourceClauseFactory.with_rtype(
+                            BootResourceType.UPLOADED
+                        ),
+                        BootResourceClauseFactory.with_filetype(
+                            BootResourceFileType.ROOT_TGZ
+                        ),
+                    ]
+                )
+            ),
+        )
+
+        assert result_tgz.total == 1
+        assert len(result_tgz.items) == 1
+        assert result_tgz.items[0].id == regular_resource.id
+        assert result_tgz.items[0].name == "ubuntu/focal"
+
+    async def test_list_with_filetype_filter_no_duplicates(
+        self,
+        repository: BootResourcesRepository,
+        fixture: Fixture,
+    ):
+        """Test that filtering by file type doesn't return duplicates when a resource has multiple sets."""
+        from maasservicelayer.db.filters import QuerySpec
+        from tests.fixtures.factories.bootresourcefiles import (
+            create_test_bootresourcefile_entry,
+        )
+        from tests.fixtures.factories.bootresourcesets import (
+            create_test_bootresourceset_entry,
+        )
+
+        multi_version_resource = await create_test_bootresource_entry(
+            fixture,
+            rtype=BootResourceType.UPLOADED,
+            name="onie/cumulus",
+            architecture="amd64/generic",
+        )
+
+        set_v1 = await create_test_bootresourceset_entry(
+            fixture,
+            version="1.0",
+            label="release",
+            resource_id=multi_version_resource.id,
+        )
+        await create_test_bootresourcefile_entry(
+            fixture,
+            filename="installer_v1.bin",
+            filetype=BootResourceFileType.SELF_EXTRACTING,
+            sha256="sonic123v1",
+            size=2048,
+            filename_on_disk="installer_v1.bin",
+            resource_set_id=set_v1.id,
+        )
+
+        set_v2 = await create_test_bootresourceset_entry(
+            fixture,
+            version="2.0",
+            label="release",
+            resource_id=multi_version_resource.id,
+        )
+        await create_test_bootresourcefile_entry(
+            fixture,
+            filename="installer_v2.bin",
+            filetype=BootResourceFileType.SELF_EXTRACTING,
+            sha256="sonic123v2",
+            size=3072,
+            filename_on_disk="installer_v2.bin",
+            resource_set_id=set_v2.id,
+        )
+
+        result = await repository.list(
+            page=1,
+            size=10,
+            query=QuerySpec(
+                where=BootResourceClauseFactory.and_clauses(
+                    [
+                        BootResourceClauseFactory.with_rtype(
+                            BootResourceType.UPLOADED
+                        ),
+                        BootResourceClauseFactory.with_filetype(
+                            BootResourceFileType.SELF_EXTRACTING
+                        ),
+                    ]
+                )
+            ),
+        )
+
+        assert result.total == 1
+        assert len(result.items) == 1
+        assert result.items[0].id == multi_version_resource.id
+        assert result.items[0].name == "onie/cumulus"
+
+    async def test_list_with_combined_filters(
+        self,
+        repository: BootResourcesRepository,
+        fixture: Fixture,
+    ):
+        """Test combining file type filter with other filters."""
+        from maasservicelayer.db.filters import QuerySpec
+        from tests.fixtures.factories.bootresourcefiles import (
+            create_test_bootresourcefile_entry,
+        )
+        from tests.fixtures.factories.bootresourcesets import (
+            create_test_bootresourceset_entry,
+        )
+
+        resources = []
+        for i in range(3):
+            resource = await create_test_bootresource_entry(
+                fixture,
+                rtype=BootResourceType.UPLOADED,
+                name=f"onie/image-{i}",
+                architecture="amd64/generic",
+            )
+            resource_set = await create_test_bootresourceset_entry(
+                fixture,
+                version=f"{i}.0",
+                label="release",
+                resource_id=resource.id,
+            )
+            await create_test_bootresourcefile_entry(
+                fixture,
+                filename=f"installer-{i}.bin",
+                filetype=BootResourceFileType.SELF_EXTRACTING,
+                sha256=f"hash{i}",
+                size=1024 * (i + 1),
+                filename_on_disk=f"installer-{i}.bin",
+                resource_set_id=resource_set.id,
+            )
+            resources.append(resource)
+
+        # Filter by IDs and file type
+        target_ids = [resources[0].id, resources[2].id]
+        result = await repository.list(
+            page=1,
+            size=10,
+            query=QuerySpec(
+                where=BootResourceClauseFactory.and_clauses(
+                    [
+                        BootResourceClauseFactory.with_rtype(
+                            BootResourceType.UPLOADED
+                        ),
+                        BootResourceClauseFactory.with_ids(target_ids),
+                        BootResourceClauseFactory.with_filetype(
+                            BootResourceFileType.SELF_EXTRACTING
+                        ),
+                    ]
+                )
+            ),
+        )
+
+        # Should return only resources 0 and 2
+        assert result.total == 2
+        assert len(result.items) == 2
+        returned_ids = {item.id for item in result.items}
+        assert returned_ids == set(target_ids)

--- a/src/tests/maasservicelayer/db/repositories/test_bootresources.py
+++ b/src/tests/maasservicelayer/db/repositories/test_bootresources.py
@@ -465,14 +465,6 @@ class TestBootResourceRepository:
         fixture: Fixture,
     ):
         """Test that filtering by file type doesn't return duplicates when a resource has multiple sets."""
-        from maasservicelayer.db.filters import QuerySpec
-        from tests.fixtures.factories.bootresourcefiles import (
-            create_test_bootresourcefile_entry,
-        )
-        from tests.fixtures.factories.bootresourcesets import (
-            create_test_bootresourceset_entry,
-        )
-
         multi_version_resource = await create_test_bootresource_entry(
             fixture,
             rtype=BootResourceType.UPLOADED,
@@ -540,13 +532,6 @@ class TestBootResourceRepository:
         fixture: Fixture,
     ):
         """Test combining file type filter with other filters."""
-        from maasservicelayer.db.filters import QuerySpec
-        from tests.fixtures.factories.bootresourcefiles import (
-            create_test_bootresourcefile_entry,
-        )
-        from tests.fixtures.factories.bootresourcesets import (
-            create_test_bootresourceset_entry,
-        )
 
         resources = []
         for i in range(3):

--- a/src/tests/maasservicelayer/db/repositories/test_bootresources.py
+++ b/src/tests/maasservicelayer/db/repositories/test_bootresources.py
@@ -396,7 +396,7 @@ class TestBootResourceRepository:
         regular_resource = await create_test_bootresource_entry(
             fixture,
             rtype=BootResourceType.UPLOADED,
-            name="ubuntu/focal",
+            name="custom/noble",
             architecture="amd64/generic",
         )
         regular_set = await create_test_bootresourceset_entry(


### PR DESCRIPTION
Extends the CustomImageFilterParams to include file type, such that filtering for specific file types like 'self-extracting' is possible. Adds the CustomImageFilterParams to the custom_images GET endpoint. The primary use-case is getting a list of images to be used for switch provisioning based on the 'self-extracting' image type.