### PR TITLE
fix: dedupe script results when filters match the same row twice

### DIFF
--- a/src/maasserver/api/scriptresults.py
+++ b/src/maasserver/api/scriptresults.py
@@ -59,6 +59,7 @@ def filter_script_results(script_set, filters, hardware_type=None):
                     or (f.isdigit() and int(f) == script_result.id)
                 ):
                     script_results.append(script_result)
+                    break
     if hardware_type is not None:
         script_results = [
             script_result

--- a/src/maasserver/api/tests/test_scriptresults.py
+++ b/src/maasserver/api/tests/test_scriptresults.py
@@ -500,6 +500,26 @@ class TestNodeScriptResultAPI(APITestCase.ForUser):
                 result,
             )
 
+    def test_GET_filters_no_duplicates_when_multiple_tokens_match(self):
+        script = factory.make_Script()
+        script_set = self.make_scriptset()
+        script_result = factory.make_ScriptResult(
+            script_set=script_set, script=script
+        )
+        tag = random.choice([tag for tag in script.tags if "tag" in tag])
+
+        response = self.client.get(
+            self.get_script_result_uri(script_set),
+            {"filters": "%s,%s" % (script_result.name, tag)},
+        )
+        self.assertEqual(response.status_code, http.client.OK)
+        parsed_result = json_load_bytes(response.content)
+        results = parsed_result["results"]
+        self.assertEqual(
+            1,
+            len([r for r in results if r["id"] == script_result.id]),
+        )
+
     def test_GET_filters_by_hardware_type(self):
         script_set = self.make_scriptset()
         hardware_type = factory.pick_choice(HARDWARE_TYPE_CHOICES)


### PR DESCRIPTION
filter_script_results appended once per matching filter token, so a single script result could appear multiple times when several tokens matched it for example same name twice, or name plus tag. We should stop after the first match per script result so combined filters stay. Also added a regression test that passes both script name and a tag that apply to the same result.