### PR TITLE
fix: pin twisted version in docs reqs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -59,6 +59,7 @@ SQLAlchemy==2.0.49
 structlog==25.5.0
 Tempita==0.6.0
 temporalio==1.24.0
+twisted==25.5.0
 
 # Other dependencies, possibly dependencies of the above
 # due to this being an output of pip freeze.


### PR DESCRIPTION
[Twisted 26.0.4](https://github.com/twisted/twisted/releases/tag/twisted-26.4.0) breaks our CI.