### PR TITLE
fix: explicitly configure dhcp in ip= kernel command line

### DIFF
--- a/src/metadataserver/builtin_scripts/tests/test_hooks.py
+++ b/src/metadataserver/builtin_scripts/tests/test_hooks.py
@@ -1238,7 +1238,7 @@ KERNEL_CMDLINE_OUTPUT = (
     "BOOT_IMAGE=http://10.245.136.6:5248/images/ubuntu/amd64/generic/bionic/"
     "daily/boot-kernel nomodeset ro root=squash:http://10.245.136.6:5248/"
     "images/ubuntu/amd64/generic/bionic/daily/squashfs "
-    "ip=::::flying-marmot:BOOTIF ip6=off overlayroot=tmpfs "
+    "ip=::::flying-marmot:BOOTIF:dhcp ip6=off overlayroot=tmpfs "
     "overlayroot_cfgdisk=disabled cc:{{'datasource_list': ['MAAS']}}"
     "end_cc cloud-config-url=http://10-245-136-0--21.maas-internal:5248/MAAS/"
     "metadata/latest/by-id/m3e8ks/?op=get_preseed apparmor=0 "

--- a/src/provisioningserver/kernel_opts.py
+++ b/src/provisioningserver/kernel_opts.py
@@ -85,11 +85,12 @@ def compose_purpose_opts(params: KernelParameters):
 
     kernel_params = [
         f"root={image_type}:http://{server_addr}:5248/images/{image_filename}",
-        # Read by cloud-initramfs-dyn-netconf initramfs-tools networking
-        # configuration in the initramfs.  Choose IPv4 or IPv6 based on the
-        # family of fs_host.  If BOOTIF is set, IPv6 config uses that
+        # Read by initramfs for networking configuration. This is handled by dracut and
+        # systemd-network-generator as of Ubuntu 26.04 LTS, and is handled by
+        # cloud-initramfs-dyn-netconf initramfs-tools on prior releases. Choose IPv4 or
+        # IPv6 based on the family of fs_host. If BOOTIF is set, IPv6 config uses that
         # exclusively.
-        (f"ip=::::{params.hostname}:BOOTIF" if not is_v6 else "ip=off"),
+        (f"ip=::::{params.hostname}:BOOTIF:dhcp" if not is_v6 else "ip=off"),
         ("ip6=dhcp" if is_v6 else "ip6=off"),
         # Select the MAAS datasource by default.
         "cc:{'datasource_list': ['MAAS']}end_cc",

--- a/src/provisioningserver/tests/test_kernel_opts.py
+++ b/src/provisioningserver/tests/test_kernel_opts.py
@@ -135,7 +135,7 @@ class TestKernelOpts(MAASTestCase):
             "root=squash:http://",
             "overlayroot=tmpfs",
             "ip6=off",
-            f"ip=::::{params.hostname}:BOOTIF",
+            f"ip=::::{params.hostname}:BOOTIF:dhcp",
         ]:
             self.assertIn(needle, cmdline)
 
@@ -163,7 +163,7 @@ class TestKernelOpts(MAASTestCase):
         for needle in [
             f"root=tar:http://10.0.2.254:5248/images/{params.xinstall_path}",
             "ip6=off",
-            f"ip=::::{params.hostname}:BOOTIF",
+            f"ip=::::{params.hostname}:BOOTIF:dhcp",
             "nvme-core.multipath=0",
         ]:
             self.assertIn(needle, cmdline)
@@ -214,7 +214,7 @@ class TestKernelOpts(MAASTestCase):
             "root=squash:http://",
             "overlayroot=tmpfs",
             "ip6=off",
-            f"ip=::::{params.hostname}:BOOTIF",
+            f"ip=::::{params.hostname}:BOOTIF:dhcp",
         ]:
             self.assertIn(needle, cmdline)
 
@@ -257,7 +257,7 @@ class TestKernelOpts(MAASTestCase):
             "root=squash:http://",
             "overlayroot=tmpfs",
             "ip6=off",
-            "ip=::::%s:BOOTIF" % params.hostname,
+            "ip=::::%s:BOOTIF:dhcp" % params.hostname,
         ]:
             self.assertIn(needle, cmdline)
 


### PR DESCRIPTION
The ip= kernel command line option is implemented slightly differently across dracut, initramfs-tools, systemd-network-generator, etc.

Dracut now lets systemd-network-generator handle ip= parsing, and systemd-network-generator requires that the DHCP type is set when the interface name is. E.g.,

 ip=::::bibarel:BOOTIF:dhcp BOOTIF=01-ec:b1:d7:7f:2a:6c

is valid but

 ip=::::bibarel:BOOTIF BOOTIF=01-ec:b1:d7:7f:2a:6c

is not. Ubuntu currently carries a downstream patch to allow for easier migration from initramfs-tools, but going forward the DHCP type should be set explicitly. Hence, set it to "dhcp", which is the behavior when unspecified in initramfs-tools.

Resolves: LP#2141588