### PR TITLE
feat(api): add username_or_email filter to user list endpoint

### DIFF
--- a/src/maasapiserver/v3/api/public/handlers/users.py
+++ b/src/maasapiserver/v3/api/public/handlers/users.py
@@ -201,6 +201,11 @@ class UsersHandler(Handler):
             size=pagination_params.size,
             query=QuerySpec(where=filters.to_clause()),
         )
+        next_link = None
+        if users.has_next(pagination_params.page, pagination_params.size):
+            next_link = f"{V3_API_PREFIX}/users?{pagination_params.to_next_href_format()}"
+            if query_filters := filters.to_href_format():
+                next_link += f"&{query_filters}"
         return UsersListResponse(
             items=[
                 UserResponse.from_model(
@@ -210,15 +215,7 @@ class UsersHandler(Handler):
                 for user in users.items
             ],
             total=users.total,
-            next=(
-                f"{V3_API_PREFIX}/users?"
-                f"{pagination_params.to_next_href_format()}"
-                f"{filters.to_href_format()}"
-                if users.has_next(
-                    pagination_params.page, pagination_params.size
-                )
-                else None
-            ),
+            next=next_link,
         )
 
     @handler(

--- a/src/maasapiserver/v3/api/public/handlers/users.py
+++ b/src/maasapiserver/v3/api/public/handlers/users.py
@@ -193,11 +193,13 @@ class UsersHandler(Handler):
     async def list_users(
         self,
         pagination_params: PaginationParams = Depends(),  # noqa: B008
+        filters: UsersFiltersParams = Depends(),  # noqa: B008
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> UsersListResponse:
         users = await services.users.list(
             page=pagination_params.page,
             size=pagination_params.size,
+            query=QuerySpec(where=filters.to_clause()),
         )
         return UsersListResponse(
             items=[
@@ -211,6 +213,7 @@ class UsersHandler(Handler):
             next=(
                 f"{V3_API_PREFIX}/users?"
                 f"{pagination_params.to_next_href_format()}"
+                f"{filters.to_href_format()}"
                 if users.has_next(
                     pagination_params.page, pagination_params.size
                 )

--- a/src/maasapiserver/v3/api/public/handlers/users.py
+++ b/src/maasapiserver/v3/api/public/handlers/users.py
@@ -447,24 +447,21 @@ class UsersHandler(Handler):
             size=pagination_params.size,
             query=QuerySpec(where=filters.to_clause()),
         )
+        next_link = None
+        if users.has_next(pagination_params.page, pagination_params.size):
+            next_link = f"{V3_API_PREFIX}/users:statistics?{pagination_params.to_next_href_format()}"
+            if query_filters := filters.to_href_format():
+                next_link += f"&{query_filters}"
         return UsersStatisticsListResponse(
             items=[
                 UserStatisticsResponse.from_model(
                     user_statistics=user,
-                    self_base_hyperlink=f"{V3_API_PREFIX}/users",
+                    self_base_hyperlink=f"{V3_API_PREFIX}/users:statistics",
                 )
                 for user in users.items
             ],
             total=users.total,
-            next=(
-                f"{V3_API_PREFIX}/users:statistics?"
-                f"{pagination_params.to_next_href_format()}"
-                f"{filters.to_href_format()}"
-                if users.has_next(
-                    pagination_params.page, pagination_params.size
-                )
-                else None
-            ),
+            next=next_link,
         )
 
     @handler(

--- a/src/maasapiserver/v3/api/public/models/requests/users.py
+++ b/src/maasapiserver/v3/api/public/models/requests/users.py
@@ -40,7 +40,7 @@ class UsersFiltersParams(BaseModel):
             parts.extend([f"id={id}" for id in self.ids])
         if self.username_or_email:
             parts.append(f"username_or_email={self.username_or_email}")
-        return '&'.join(parts) if parts else ""
+        return "&".join(parts) if parts else ""
 
 
 class BaseUserRequest(BaseModel):

--- a/src/maasapiserver/v3/api/public/models/requests/users.py
+++ b/src/maasapiserver/v3/api/public/models/requests/users.py
@@ -35,11 +35,12 @@ class UsersFiltersParams(BaseModel):
         return None
 
     def to_href_format(self) -> str:
-        return (
-            f"&username_or_email={self.username_or_email}"
-            if self.username_or_email
-            else ""
-        )
+        parts = []
+        if self.ids:
+            parts.extend([f"id={id}" for id in self.ids])
+        if self.username_or_email:
+            parts.append(f"username_or_email={self.username_or_email}")
+        return f"&{'&'.join(parts)}" if parts else ""
 
 
 class BaseUserRequest(BaseModel):

--- a/src/maasapiserver/v3/api/public/models/requests/users.py
+++ b/src/maasapiserver/v3/api/public/models/requests/users.py
@@ -40,7 +40,7 @@ class UsersFiltersParams(BaseModel):
             parts.extend([f"id={id}" for id in self.ids])
         if self.username_or_email:
             parts.append(f"username_or_email={self.username_or_email}")
-        return f"&{'&'.join(parts)}" if parts else ""
+        return '&'.join(parts) if parts else ""
 
 
 class BaseUserRequest(BaseModel):

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_users.py
@@ -250,6 +250,38 @@ class TestUsersApi(ApiCommonTests):
         assert users_response.total == 2
         assert users_response.next is None
 
+    async def test_list_users_with_username_or_email_filter(
+        self,
+        services_mock: ServiceCollectionV3,
+        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
+    ) -> None:
+        client = mocked_api_client_user_with_permissions(
+            MAASResourceEntitlement.CAN_VIEW_IDENTITIES,
+        )
+        services_mock.users = Mock(UsersService)
+        services_mock.users.list.return_value = ListResult[User](
+            items=[USER_1], total=2
+        )
+
+        response = await client.get(
+            f"{self.BASE_PATH}?size=1&username_or_email=example",
+        )
+        assert response.status_code == 200
+        users_response = UsersListResponse(**response.json())
+        assert users_response.total == 2
+        assert len(users_response.items) == 1
+        assert (
+            users_response.next
+            == f"{self.BASE_PATH}?page=2&size=1&username_or_email=example"
+        )
+        services_mock.users.list.assert_called_once_with(
+            page=1,
+            size=1,
+            query=QuerySpec(
+                where=UserClauseFactory.with_username_or_email_like("example")
+            ),
+        )
+
     # GET /users/{user_id}
     async def test_get_user(
         self,


### PR DESCRIPTION
- added `username_or_email` parameter to base user list endpoint
- created test for this parameter
- serialized ids parameter in `to_href_format`