### PR TITLE
spec: extract power drivers to independent repositories

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,1 @@
+{"feature_directory": "specs/6690-power-drivers-extract"}

--- a/specs/6690-power-drivers-extract/checklists/requirements.md
+++ b/specs/6690-power-drivers-extract/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Extract Power Drivers to Independent Repositories
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2025-01-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All checklist items pass validation
+- Specification is ready for planning phase (`/speckit.plan`)
+- Key design decisions (entry point group name, driver grouping strategy) are documented as entities, not implementation details
+- Non-goals clearly bound the scope to avoid scope creep

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -3,65 +3,67 @@
 **Feature Branch**: `6690-power-drivers-extract`  
 **Created**: 2025-01-13  
 **Status**: Draft  
-**Input**: Move power drivers to their own repositories with snap plug/slot discovery mechanism, language-agnostic interface via JSON metadata, and snap distribution.
+**Input**: Move power drivers to their own repositories as snap services communicating over UNIX sockets, with rack-to-region driver lifecycle notifications.
 
 ## Clarifications
 
-- **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is a JSON-based protocol, not a language-specific API.
-- **Snap plug/slot discovery**: Drivers are distributed as separate snaps. When a driver snap connects to the MAAS snap (via a content plug and slot), it exposes driver metadata as a JSON file at a known path. MAAS discovers drivers by scanning these JSON files at runtime.
+- **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is a JSON-based protocol over UNIX sockets, not a language-specific API.
+- **Driver services**: Each power driver runs as a long-running snap service. The rack controller (`rackd`) communicates with driver services over UNIX domain sockets exposed through the snap interface.
+- **No metadata JSON**: Driver capabilities are discovered by querying the live service at its UNIX socket. There is no static metadata file.
 - **`maas-power` CLI deprecated**: The `maas-power` command (currently in `provisioningserver/power_driver_command.py`) is deprecated. Driver snaps provide their own CLI tools for testing and direct invocation. MAAS no longer ships a unified power CLI.
 - **Independent repositories**: Each driver group lives in its own git repository. Driver code, tests, documentation, and snapcraft configuration are all maintained in the driver's repository — not in the MAAS monorepo.
+- **Rack-to-region driver lifecycle**: When drivers appear or disappear (snap connect/disconnect), the rack controller notifies the region controller so the region's view of available power types stays in sync.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - MAAS discovers power drivers via snap plug/slot connections (Priority: P1)
+### User Story 1 - Rack controller discovers driver services via UNIX sockets (Priority: P1)
 
-**Description**: When a power driver snap is installed and connected to the MAAS snap, MAAS automatically discovers the driver by reading a JSON metadata file exposed through the snap's content interface. No MAAS core changes are required to add new drivers — installing and connecting a driver snap is sufficient.
+**Description**: When a power driver snap is installed, connected, and its service is running, the rack controller (`rackd`) discovers the driver by connecting to its UNIX domain socket through the snap interface. The rack queries the service to learn the driver's name, capabilities, and parameter schema. No MAAS core changes are required to add new drivers — installing, connecting, and starting a driver snap is sufficient.
 
-**Why this priority**: This is the foundational capability. Without snap-based discovery, the entire separation architecture cannot function. All other stories depend on this working correctly.
+**Why this priority**: This is the foundational capability. Without service-based discovery, the entire separation architecture cannot function. All other stories depend on this working correctly.
 
-**Independent Test**: Can be fully tested by building a minimal driver snap with a valid metadata JSON, installing it, connecting it to the MAAS snap, and verifying that `PowerDriverRegistry` contains the driver after MAAS reloads its driver list.
-
-**Acceptance Scenarios**:
-
-1. **Given** a fresh MAAS installation with no driver snaps connected, **When** the rack controller starts, **Then** only builtin drivers (e.g., `manual`) are available in `PowerDriverRegistry`
-2. **Given** a driver snap `maas-power-driver-ipmi` is installed and connected to MAAS, **When** MAAS reloads its driver list, **Then** the `ipmi` driver is discoverable via `PowerDriverRegistry.get_item("ipmi")`
-3. **Given** multiple driver snaps are connected, **When** MAAS reloads its driver list, **Then** all drivers from all connected snaps are registered and available
-4. **Given** a driver snap is disconnected, **When** MAAS reloads its driver list, **Then** that driver is no longer available in the registry
-5. **Given** a driver snap's metadata JSON is malformed, **When** MAAS attempts to discover it, **Then** MAAS logs a warning and skips that driver but continues discovering others
-6. **Given** a driver snap is connected while MAAS is running, **When** MAAS detects the new connection (via snap change notification or periodic scan), **Then** the new driver becomes available without a full MAAS restart
-
-### User Story 2 - Driver snaps expose metadata via JSON at the snap interface (Priority: P1)
-
-**Description**: Each power driver snap exposes a JSON metadata file at a known path through its content interface. This file describes the driver's capabilities, parameters, and how MAAS should invoke it. The JSON schema is defined by the MAAS power driver interface contract.
-
-**Why this priority**: This defines the contract between MAAS and driver snaps. Without a standardized metadata format, discovery and invocation cannot work.
-
-**Independent Test**: Can be tested by creating a minimal driver snap that exposes a metadata JSON file, connecting it to MAAS, and verifying that MAAS can read and validate the metadata.
+**Independent Test**: Can be fully tested by building a minimal driver snap that runs a service listening on a UNIX socket, connecting it to the MAAS snap, and verifying that `rackd` discovers the driver and populates `PowerDriverRegistry`.
 
 **Acceptance Scenarios**:
 
-1. **Given** a driver snap connected to MAAS, **When** MAAS reads the metadata JSON at the interface path, **Then** the JSON is valid against the power driver metadata schema
-2. **Given** a metadata JSON file, **When** validated, **Then** it contains: driver `name`, `description`, `version`, `settings` (parameter schema), `executable` path, and supported `actions`
-3. **Given** a metadata JSON with invalid or missing required fields, **When** MAAS validates it, **Then** MAAS rejects the driver and logs the validation error
-4. **Given** a driver snap is updated (new version), **When** the metadata JSON changes, **Then** MAAS detects the change and reloads the driver metadata
-5. **Given** the metadata JSON, **When** inspected, **Then** it contains no language-specific information — the format is identical regardless of whether the driver is written in Python, Go, Rust, or any other language
+1. **Given** a fresh MAAS installation with no driver snaps connected, **When** `rackd` starts, **Then** only builtin drivers (e.g., `manual`) are available in `PowerDriverRegistry`
+2. **Given** a driver snap `maas-power-driver-ipmi` is installed, connected, and its service is running, **When** `rackd` discovers available sockets, **Then** the `ipmi` driver is discoverable via `PowerDriverRegistry.get_item("ipmi")`
+3. **Given** multiple driver snaps are connected and running, **When** `rackd` discovers available sockets, **Then** all drivers are registered and available
+4. **Given** a driver snap is disconnected or its service stops, **When** `rackd` detects the socket is unavailable, **Then** that driver is removed from the registry
+5. **Given** a driver service is unresponsive, **When** `rackd` attempts to query it, **Then** `rackd` logs a warning and marks the driver as unavailable but continues operating with other drivers
+6. **Given** a driver snap is connected and its service starts while `rackd` is running, **When** `rackd` detects the new socket, **Then** the new driver becomes available without a `rackd` restart
 
-### User Story 3 - MAAS invokes power drivers via a language-agnostic protocol (Priority: P1)
+### User Story 2 - Rack controller queries driver services for capabilities (Priority: P1)
 
-**Description**: MAAS communicates with power drivers through a language-agnostic protocol (subprocess with JSON on stdin/stdout, or a local HTTP endpoint). MAAS core code never imports or links against driver code directly. Power actions (on, off, query, cycle, reset) are sent as structured requests and receive structured responses.
+**Description**: When `rackd` connects to a driver service's UNIX socket, it sends a capabilities request. The service responds with its driver name, description, version, supported actions, parameter schema, and capability flags. This replaces any static metadata file — the live service is the source of truth.
 
-**Why this priority**: This ensures true decoupling. Drivers can be written in any language and updated independently of MAAS. The protocol is the only contract between MAAS and drivers.
+**Why this priority**: This defines the contract between `rackd` and driver services. Without a standardized capabilities query, `rackd` cannot know what a driver supports.
 
-**Independent Test**: Can be tested by implementing a minimal driver in a non-Python language (e.g., a shell script or Go binary) that speaks the protocol, connecting it via a test snap, and verifying that MAAS can execute power actions through it.
+**Independent Test**: Can be tested by implementing a minimal driver service that responds to a capabilities query on its UNIX socket, connecting it to MAAS, and verifying that `rackd` receives and registers the driver's capabilities.
 
 **Acceptance Scenarios**:
 
-1. **Given** a machine with power type `ipmi`, **When** a power query is requested via RPC, **Then** MAAS invokes the driver through the protocol and receives the power state
-2. **Given** a driver implemented in Go, **When** connected via snap, **Then** MAAS can execute all supported power actions through it
-3. **Given** a driver implemented in Python, **When** connected via snap, **Then** MAAS can execute all supported power actions through it
-4. **Given** a driver crashes or becomes unresponsive, **When** MAAS attempts to invoke it, **Then** MAAS receives a clear error and reports it to the user
-5. **Given** `provisioningserver` source code, **When** searched for direct driver imports, **Then** no import of specific power driver implementations exists (only the protocol client and registry)
+1. **Given** a driver service is running and accessible via its UNIX socket, **When** `rackd` sends a capabilities request, **Then** the service responds with: driver `name`, `description`, `version`, `actions`, `settings` (parameter schema), and `capabilities` (flags)
+2. **Given** a capabilities response, **When** validated by `rackd`, **Then** all required fields are present and well-formed
+3. **Given** a driver service responds with an invalid or incomplete capabilities message, **When** `rackd` processes it, **Then** `rackd` rejects the driver and logs the validation error
+4. **Given** a driver service is updated (new version), **When** `rackd` queries it again, **Then** `rackd` receives the updated capabilities and version
+5. **Given** the capabilities response, **When** inspected, **Then** it contains no language-specific information — the format is identical regardless of whether the driver is written in Python, Go, Rust, or any other language
+
+### User Story 3 - Rack controller invokes power drivers over UNIX sockets (Priority: P1)
+
+**Description**: `rackd` communicates with power driver services over UNIX domain sockets. Power actions (on, off, query, cycle, reset, set-boot-order) are sent as structured JSON requests and receive structured JSON responses. The driver service is long-running — `rackd` does not start or stop it.
+
+**Why this priority**: This ensures true decoupling. Drivers can be written in any language and updated independently of MAAS. The UNIX socket protocol is the only contract between `rackd` and drivers.
+
+**Independent Test**: Can be tested by implementing a minimal driver service in any language that listens on a UNIX socket and responds to power action requests, connecting it via snap, and verifying that `rackd` can execute power actions through it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a machine with power type `ipmi`, **When** a power query is requested via RPC, **Then** `rackd` sends a query request to the ipmi driver's UNIX socket and receives the power state
+2. **Given** a driver implemented in Go, **When** connected via snap and running as a service, **Then** `rackd` can execute all supported power actions through its UNIX socket
+3. **Given** a driver implemented in Python, **When** connected via snap and running as a service, **Then** `rackd` can execute all supported power actions through its UNIX socket
+4. **Given** a driver service crashes or becomes unresponsive, **When** `rackd` attempts to send a request, **Then** `rackd` receives a clear error and reports it to the user
+5. **Given** `provisioningserver` source code, **When** searched for direct driver imports, **Then** no import of specific power driver implementations exists (only the socket client and registry)
 
 ### User Story 4 - Power drivers live in independent repositories (Priority: P1)
 
@@ -79,39 +81,55 @@
 4. **Given** a driver repository, **When** its version is bumped and released, **Then** the new driver snap can be released without touching the MAAS repository
 5. **Given** the MAAS monorepo after extraction, **When** searched for driver implementation code, **Then** no driver implementation files exist (only the protocol client, registry, and builtin `manual` driver remain)
 
-### User Story 5 - Power drivers are distributed as standalone snaps (Priority: P2)
+### User Story 5 - Driver snaps run as long-running services (Priority: P1)
 
-**Description**: Each power driver (or group of related drivers) is packaged as a standalone snap. The snap includes the driver executable, its metadata JSON, and any system-level dependencies. Installing a driver is `snap install` + `snap connect`.
+**Description**: Each power driver snap declares a snap service that starts automatically when the snap is installed. The service listens on a UNIX domain socket at a known path within the snap's interface directory. The snap includes the driver binary, any system-level dependencies, and the snapcraft configuration. Installing a driver is `snap install` + `snap connect`.
 
-**Why this priority**: This enables the operational model where drivers can be installed, updated, and uninstalled independently of MAAS core and independently of each other.
+**Why this priority**: Long-running services eliminate per-action startup overhead and allow drivers to maintain state (e.g., connection pools, session caches) between power operations.
 
-**Independent Test**: Can be tested by building a driver snap with `snapcraft`, installing it locally, connecting it to MAAS, and verifying that the driver is discovered and functional.
+**Independent Test**: Can be tested by building a driver snap with `snapcraft` that declares a service, installing it, connecting it to MAAS, and verifying that the service is running and listening on its UNIX socket.
 
 **Acceptance Scenarios**:
 
-1. **Given** a driver snap, **When** `snap install --dangerous driver.snap` is run, **Then** the snap installs successfully
-2. **Given** a driver snap is installed, **When** `snap connect maas:power-drivers driver:power-drivers` is run, **Then** the driver's metadata becomes visible to MAAS
-3. **Given** a driver snap is removed, **When** `snap remove driver` is run, **Then** the driver is no longer available to MAAS
-4. **Given** a driver snap is updated, **When** `snap refresh driver` is run, **Then** MAAS picks up the updated driver metadata and version
+1. **Given** a driver snap, **When** `snap install --dangerous driver.snap` is run, **Then** the snap installs and its service starts automatically
+2. **Given** a driver snap is installed and connected, **When** `snap services driver` is run, **Then** the driver service is listed as active
+3. **Given** a driver snap is removed, **When** `snap remove driver` is run, **Then** the service stops and the UNIX socket is removed
+4. **Given** a driver snap is updated, **When** `snap refresh driver` is run, **Then** the service restarts with the updated version and `rackd` picks up the new capabilities
 
-### User Story 6 - The MAAS snap exposes a content slot for driver discovery (Priority: P1)
+### User Story 6 - The MAAS snap exposes a UNIX socket directory for driver services (Priority: P1)
 
-**Description**: The MAAS snap declares a content slot (`power-drivers`) that driver snaps connect to via a content plug. When connected, the slot provides MAAS with access to driver metadata JSON files. The slot path is a directory that driver snaps populate with their metadata.
+**Description**: The MAAS snap declares a content slot (`power-drivers`) that provides a shared directory where driver snaps place their UNIX domain sockets. When a driver snap connects its plug to MAAS's slot, its service writes a UNIX socket into that shared directory. `rackd` scans this directory to discover available driver services.
 
-**Why this priority**: This is the mechanism that makes discovery work. Without the snap content interface, MAAS cannot find or read driver metadata.
+**Why this priority**: This is the mechanism that makes discovery work. Without the shared socket directory, `rackd` cannot find or connect to driver services.
 
-**Independent Test**: Can be tested by verifying that the MAAS snap declares the content slot, that a test driver snap can connect to it, and that MAAS can read the metadata JSON from the connected path.
+**Independent Test**: Can be tested by verifying that the MAAS snap declares the content slot, that a test driver snap can connect to it, and that the driver's UNIX socket appears in the shared directory.
 
 **Acceptance Scenarios**:
 
 1. **Given** the MAAS snap, **When** `snap info maas` is run, **Then** a `power-drivers` content slot is declared
-2. **Given** a driver snap with a `power-drivers` content plug, **When** `snap connect maas:power-drivers driver:power-drivers` is run, **Then** the connection succeeds and the driver's metadata JSON is accessible at the slot path
-3. **Given** multiple driver snaps connected, **When** MAAS scans the slot path, **Then** each driver's metadata JSON is found and loaded
-4. **Given** a driver snap is disconnected, **When** MAAS scans the slot path, **Then** the disconnected driver's metadata is no longer present
+2. **Given** a driver snap with a `power-drivers` content plug, **When** `snap connect maas:power-drivers driver:power-drivers` is run, **Then** the connection succeeds and the driver's UNIX socket is accessible in the shared directory
+3. **Given** multiple driver snaps connected, **When** `rackd` scans the shared directory, **Then** each driver's UNIX socket is found and connected to
+4. **Given** a driver snap is disconnected, **When** `rackd` scans the shared directory, **Then** the disconnected driver's socket is no longer present
 
-### User Story 7 - Existing power functionality is preserved after extraction (Priority: P1)
+### User Story 7 - Rack controller notifies region of driver lifecycle changes (Priority: P1)
 
-**Description**: After moving drivers to separate snaps, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. RPC power commands and UI power controls function identically. The `maas-power` CLI is deprecated — driver snaps provide their own CLI tools for testing and direct invocation.
+**Description**: When drivers appear or disappear on a rack (due to snap connect/disconnect/service start/stop), `rackd` notifies the region controller of the change. The region updates its view of available power types for that rack. This ensures the region's power type list stays in sync with what each rack actually supports.
+
+**Why this priority**: The region controller needs to know which power types each rack supports (for form generation, validation, documentation). Without lifecycle notifications, the region's view becomes stale when drivers are added or removed.
+
+**Independent Test**: Can be tested by connecting a driver snap to a rack controller and verifying that the region controller receives a notification and updates its power type list for that rack.
+
+**Acceptance Scenarios**:
+
+1. **Given** a driver snap is connected to a rack controller, **When** `rackd` discovers the new driver, **Then** `rackd` sends a notification to the region controller with the driver's capabilities
+2. **Given** a driver snap is disconnected from a rack controller, **When** `rackd` detects the driver is gone, **Then** `rackd` sends a removal notification to the region controller
+3. **Given** the region controller receives a driver addition notification, **When** it processes the notification, **Then** the new power type appears in the rack's available power types
+4. **Given** the region controller receives a driver removal notification, **When** it processes the notification, **Then** the removed power type no longer appears in the rack's available power types
+5. **Given** `rackd` starts and discovers existing driver services, **When** it communicates with the region, **Then** the region receives the complete set of available power types for that rack
+
+### User Story 8 - Existing power functionality is preserved after extraction (Priority: P1)
+
+**Description**: After moving drivers to separate snap services, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. RPC power commands and UI power controls function identically. The `maas-power` CLI is deprecated — driver snaps provide their own CLI tools for testing and direct invocation.
 
 **Why this priority**: This is a refactoring feature. If existing functionality breaks, the extraction has failed. Must be verified for all 21 existing driver types.
 
@@ -119,16 +137,18 @@
 
 **Acceptance Scenarios**:
 
-1. **Given** the refactored code with drivers in separate snaps, **When** the existing test suite `bin/test.rack` is run for power drivers, **Then** all tests pass
+1. **Given** the refactored code with drivers as snap services, **When** the existing test suite `bin/test.rack` is run for power drivers, **Then** all tests pass
 2. **Given** the refactored code, **When** the region controller requests power types from the rack controller via `DescribePowerTypes` RPC, **Then** all connected drivers are returned in the schema
 3. **Given** the refactored code, **When** a BMC's power parameters are sanitized, **Then** secret parameters are correctly separated from non-secret parameters using `sanitise_power_parameters()`
 4. **Given** the `maas-power` command is invoked, **When** it runs, **Then** it prints a deprecation warning directing users to the driver snap's own CLI tool
+5. **Given** a driver snap is connected to a rack, **When** the region queries that rack for available power types, **Then** the new driver appears in the rack's power type list
 
 ## Assumptions
 
 - Power drivers may be written in any programming language (Python, Go, Rust, C, shell, etc.)
-- The communication protocol between MAAS and drivers is language-agnostic (JSON over subprocess stdin/stdout or local HTTP)
-- Snap content interfaces (plug/slot) are the discovery mechanism — not Python entry points, shared libraries, or other language-specific mechanisms
+- Each driver runs as a long-running service communicating over UNIX domain sockets
+- Driver capabilities are discovered by querying the live service — there is no static metadata JSON file
+- Snap content interfaces (plug/slot) provide a shared directory for UNIX sockets
 - Driver snaps run with `strict` confinement (same as MAAS)
 - System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) are included in the driver snap, not the MAAS snap
 - The `manual` power driver remains builtin in MAAS core (no external dependencies, always available)
@@ -136,52 +156,49 @@
 - Driver code, tests, and documentation are maintained in driver repositories, not the MAAS monorepo
 - Third-party power drivers are a valid use case (anyone can build a driver snap)
 - Each driver repository has its own CI pipeline for testing and snap building
+- The rack controller is responsible for driver discovery and for notifying the region of driver lifecycle changes
 
 ## Key Entities
 
-### Power Driver Metadata JSON
-- **Purpose**: Describes a driver's capabilities, parameters, and invocation details to MAAS
-- **Location**: Exposed at the snap content interface path when the driver snap is connected
-- **Schema** (key fields):
-  - `name`: Unique driver identifier (e.g., `ipmi`, `redfish`)
-  - `description`: Human-readable description
-  - `version`: Driver version string
-  - `actions`: List of supported actions (`on`, `off`, `query`, `cycle`, `reset`, `set-boot-order`)
-  - `settings`: Array of parameter definitions (name, label, type, required, choices, scope, secret)
-  - `ip_extractor`: Field name and regex pattern for extracting IP address from parameters
-  - `executable`: Path to the driver binary/script within the snap
-  - `protocol`: Communication method (`subprocess` or `http`)
-  - `capabilities`: Flags (`queryable`, `chassis`, `can_probe`, `can_set_boot_order`)
-- **Validation**: MAAS validates metadata against a JSON Schema before accepting the driver
-
-### Power Driver Protocol
-- **Purpose**: Language-agnostic communication between MAAS and driver processes
-- **Transport**: Subprocess with JSON lines on stdin/stdout (primary), or local HTTP (alternative)
-- **Request format**: JSON object with `action`, `system_id`, `hostname`, `context` (power parameters)
-- **Response format**: JSON object with `state` (for query) or `status`/`error` (for actions)
-- **Error format**: JSON object with `error_type` and `error_message`
-- **Lifecycle**: Driver process is started per-action (subprocess) or long-running (HTTP)
+### Driver Service Protocol (UNIX Socket)
+- **Purpose**: Language-agnostic communication between `rackd` and driver services
+- **Transport**: UNIX domain socket in the shared snap content directory
+- **Messages**: JSON objects, length-prefixed (4-byte big-endian length + JSON payload)
+- **Request types**:
+  - `capabilities` — returns driver name, description, version, actions, settings, capability flags
+  - `power_query` — returns current power state (`on`, `off`, `unknown`)
+  - `power_on`, `power_off`, `power_cycle`, `power_reset` — performs action, returns status
+  - `set_boot_order` — configures boot order, returns status
+- **Response format**: JSON object with `status` (`ok`/`error`), optional `state` (for queries), optional `error_type` and `error_message`
+- **Lifecycle**: Driver is a long-running service; `rackd` connects as needed, does not manage the service lifecycle
 
 ### Power Driver Registry
-- **Purpose**: Runtime registry of all discovered power drivers
+- **Purpose**: Runtime registry of all discovered power drivers on a rack
 - **Operations**: `register_item()`, `get_item()`, `get_schema()`, iteration over registered drivers
-- **Discovery**: Populated by scanning the snap content slot path for metadata JSON files
-- **Reload**: Supports hot-reload when snaps are connected/disconnected/updated
+- **Discovery**: Populated by `rackd` scanning the shared socket directory and querying each service for capabilities
+- **Reload**: Supports hot-reload when driver services appear or disappear
 
 ### Snap Content Interface
-- **Purpose**: The snap plug/slot mechanism that exposes driver metadata to MAAS
-- **Slot** (MAAS snap): `power-drivers` — a directory where driver metadata JSON files appear
-- **Plug** (driver snap): `power-drivers` — connects to MAAS's slot, provides metadata JSON
-- **Path convention**: Each driver writes a single metadata JSON file named `<driver-name>.json`
+- **Purpose**: The snap plug/slot mechanism that provides a shared directory for UNIX sockets
+- **Slot** (MAAS snap): `power-drivers` — a directory where driver services place their UNIX sockets
+- **Plug** (driver snap): `power-drivers` — connects to MAAS's slot, driver service writes its socket here
+- **Socket naming**: Each driver writes a UNIX socket named `<driver-name>.sock`
+
+### Rack-to-Region Driver Lifecycle Notification
+- **Purpose**: Keeps the region's view of available power types in sync with each rack
+- **Trigger**: Driver service appears (snap connect + service start) or disappears (snap disconnect / service stop)
+- **Direction**: Rack controller → Region controller (via existing RPC channel)
+- **Payload**: Driver capabilities (same as the capabilities query response) for additions; driver name for removals
+- **On rack startup**: `rackd` sends the complete set of available drivers to the region during registration
 
 ### Driver Repository Structure
 - **Purpose**: Standard layout for each driver's git repository
 - **Contents**:
-  - Driver implementation source code
+  - Driver implementation source code (service binary)
   - Test suite (unit tests, integration tests against real or mocked BMCs)
   - Documentation (driver-specific README, supported hardware, configuration guide)
-  - `snap/snapcraft.yaml` (snap build configuration)
-  - Metadata JSON template (processed during snap build to include version, executable path, etc.)
+  - `snap/snapcraft.yaml` (snap build configuration, declares the service and content plug)
+  - Protocol client library (for testing: a small client that speaks the UNIX socket protocol)
 - **Independence**: Each repository builds, tests, and releases without requiring the MAAS monorepo
 
 ### Driver Grouping
@@ -199,15 +216,17 @@
 
 ## Success Criteria
 
-- MAAS rack controller discovers all connected driver snaps within 1 second of snap connection
+- MAAS rack controller discovers all connected driver services within 1 second of service start
 - Zero power driver tests fail after extraction (100% test pass rate preserved)
 - All 21 existing power driver types remain functional after extraction
 - The `maas-power` command prints a deprecation warning and exits (driver snaps provide their own CLI tools)
 - A new power driver can be added by building and connecting a driver snap (no MAAS core changes required)
-- A power driver written in a non-Python language (e.g., Go) can be discovered and invoked by MAAS
-- The metadata JSON schema is published and versioned for third-party driver authors
+- A power driver written in a non-Python language (e.g., Go) can be discovered and invoked by `rackd`
+- The UNIX socket protocol specification is published for third-party driver authors
 - No breaking changes to existing MAAS APIs or RPC interfaces
 - The MAAS snap declares a `power-drivers` content slot that driver snaps can connect to
+- The region controller receives timely notifications when drivers are added or removed from a rack
+- Each driver repository is self-contained (code, tests, docs, snapcraft config) and builds independently
 
 ## Non-Goals
 
@@ -219,3 +238,4 @@
 - This feature does not publish driver snaps to the Snap Store (that is a follow-up)
 - This feature does not define a driver SDK or CLI tooling for driver authors (that is a follow-up)
 - This feature does not preserve the `maas-power` CLI — it is deprecated in favor of per-driver CLI tools
+- This feature does not define a driver SDK or language bindings for the UNIX socket protocol (that is a follow-up)

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -10,11 +10,11 @@
 - **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is HTTP over UNIX domain sockets, not a language-specific API.
 - **Driver services**: Each power driver runs as a long-running snap service. The rack controller (`rackd`) communicates with driver services over HTTP on UNIX domain sockets exposed through the snap interface.
 - **No metadata JSON**: Driver capabilities are discovered by querying the live service at its UNIX socket. There is no static metadata file.
-- **`maas-power` CLI deprecated**: The `maas-power` command (currently in `provisioningserver/power_driver_command.py`) is deprecated. Driver snaps provide their own CLI tools for testing and direct invocation. MAAS no longer ships a unified power CLI.
+- **`maas-power` removed entirely**: The `maas-power` command (currently in `provisioningserver/power_driver_command.py`) is removed. It is not deprecated — it simply no longer exists. Driver snaps provide their own CLI tools for testing and direct invocation.
 - **Independent repositories**: Each power driver lives in its own git repository as an independent project. No driver grouping — one driver per repo, one driver per snap.
 - **`webhook` builtin**: The `webhook` power driver remains builtin in MAAS core (no external dependencies, useful for testing and custom integrations). All other drivers are external snaps.
 - **No `manual` driver**: The `manual` power driver is dropped entirely. It has no value in a service-based architecture.
-- **Rack-to-region driver lifecycle**: When drivers appear or disappear (snap connect/disconnect), the rack controller notifies the region controller so the region's view of available power types stays in sync.
+- **Rack-to-region driver lifecycle (v3 internal API)**: When drivers appear or disappear (snap connect/disconnect), the rack controller notifies the region controller via the v3 internal API so the region's view of available power types stays in sync. This is not the legacy RPC channel.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -113,9 +113,9 @@
 3. **Given** multiple driver snaps connected, **When** `rackd` scans the shared directory, **Then** each driver's UNIX socket is found and connected to
 4. **Given** a driver snap is disconnected, **When** `rackd` scans the shared directory, **Then** the disconnected driver's socket is no longer present
 
-### User Story 7 - Rack controller notifies region of driver lifecycle changes (Priority: P1)
+### User Story 7 - Rack controller notifies region of driver lifecycle changes via v3 internal API (Priority: P1)
 
-**Description**: When drivers appear or disappear on a rack (due to snap connect/disconnect/service start/stop), `rackd` notifies the region controller of the change. The region updates its view of available power types for that rack. This ensures the region's power type list stays in sync with what each rack actually supports.
+**Description**: When drivers appear or disappear on a rack (due to snap connect/disconnect/service start/stop), `rackd` notifies the region controller of the change via the v3 internal API. The region updates its view of available power types for that rack. This ensures the region's power type list stays in sync with what each rack actually supports. This notification does not use the legacy RPC channel.
 
 **Why this priority**: The region controller needs to know which power types each rack supports (for form generation, validation, documentation). Without lifecycle notifications, the region's view becomes stale when drivers are added or removed.
 
@@ -123,15 +123,15 @@
 
 **Acceptance Scenarios**:
 
-1. **Given** a driver snap is connected to a rack controller, **When** `rackd` discovers the new driver, **Then** `rackd` sends a notification to the region controller with the driver's capabilities
-2. **Given** a driver snap is disconnected from a rack controller, **When** `rackd` detects the driver is gone, **Then** `rackd` sends a removal notification to the region controller
-3. **Given** the region controller receives a driver addition notification, **When** it processes the notification, **Then** the new power type appears in the rack's available power types
-4. **Given** the region controller receives a driver removal notification, **When** it processes the notification, **Then** the removed power type no longer appears in the rack's available power types
-5. **Given** `rackd` starts and discovers existing driver services, **When** it communicates with the region, **Then** the region receives the complete set of available power types for that rack
+1. **Given** a driver snap is connected to a rack controller, **When** `rackd` discovers the new driver, **Then** `rackd` calls the v3 internal API to register the driver's capabilities with the region controller
+2. **Given** a driver snap is disconnected from a rack controller, **When** `rackd` detects the driver is gone, **Then** `rackd` calls the v3 internal API to remove the driver from the region controller
+3. **Given** the region controller receives a driver addition via the v3 internal API, **When** it processes the notification, **Then** the new power type appears in the rack's available power types
+4. **Given** the region controller receives a driver removal via the v3 internal API, **When** it processes the notification, **Then** the removed power type no longer appears in the rack's available power types
+5. **Given** `rackd` starts and discovers existing driver services, **When** it communicates with the region, **Then** the region receives the complete set of available power types for that rack via the v3 internal API
 
 ### User Story 8 - Existing power functionality is preserved after extraction (Priority: P1)
 
-**Description**: After moving drivers to separate snap services, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. RPC power commands and UI power controls function identically. The `maas-power` CLI is deprecated — driver snaps provide their own CLI tools for testing and direct invocation.
+**Description**: After moving drivers to separate snap services, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. RPC power commands and UI power controls function identically. The `maas-power` command no longer exists.
 
 **Why this priority**: This is a refactoring feature. If existing functionality breaks, the extraction has failed. Must be verified for all 21 existing driver types.
 
@@ -142,8 +142,8 @@
 1. **Given** the refactored code with drivers as snap services, **When** the existing test suite `bin/test.rack` is run for power drivers, **Then** all tests pass
 2. **Given** the refactored code, **When** the region controller requests power types from the rack controller via `DescribePowerTypes` RPC, **Then** all connected drivers are returned in the schema
 3. **Given** the refactored code, **When** a BMC's power parameters are sanitized, **Then** secret parameters are correctly separated from non-secret parameters using `sanitise_power_parameters()`
-4. **Given** the `maas-power` command is invoked, **When** it runs, **Then** it prints a deprecation warning directing users to the driver snap's own CLI tool
-5. **Given** a driver snap is connected to a rack, **When** the region queries that rack for available power types, **Then** the new driver appears in the rack's power type list
+4. **Given** a driver snap is connected to a rack, **When** the region queries that rack for available power types, **Then** the new driver appears in the rack's power type list
+5. **Given** the MAAS monorepo after extraction, **When** searched for `maas-power` or `power_driver_command`, **Then** no traces of the command remain
 
 ## Assumptions
 
@@ -160,7 +160,7 @@
 - Driver code, tests, and documentation are maintained in driver repositories, not the MAAS monorepo
 - Third-party power drivers are a valid use case (anyone can build a driver snap)
 - Each driver repository has its own CI pipeline for testing and snap building
-- The rack controller is responsible for driver discovery and for notifying the region of driver lifecycle changes
+- The rack controller is responsible for driver discovery and for notifying the region of driver lifecycle changes via the v3 internal API
 
 ## Key Entities
 
@@ -169,14 +169,14 @@
 - **Transport**: HTTP over UNIX domain socket in the shared snap content directory
 - **Wire format**: Standard HTTP requests/responses with JSON bodies
 - **Endpoints**:
-  - `GET /` — returns driver capabilities (name, description, version, actions, settings, capability flags)
+  - `GET /metadata` — returns driver metadata (name, description, version, actions, settings, capability flags)
   - `POST /query` — returns current power state (`on`, `off`, `unknown`)
   - `POST /on` — powers on the node
   - `POST /off` — powers off the node
   - `POST /cycle` — cycles power
   - `POST /reset` — resets power
   - `POST /set-boot-order` — configures boot order
-- **Request body**: JSON object with `system_id`, `hostname`, `context` (power parameters)
+- **Request body**: JSON object with `system_id` and `context` (power parameters). `system_id` alone is sufficient to identify the target system.
 - **Response format**: JSON object with `status` (`ok`/`error`), optional `state` (for queries), optional `error_type` and `error_message`
 - **HTTP status codes**: 200 for success, 503 for unavailable, 400 for invalid parameters, 500 for driver errors
 - **Lifecycle**: Driver is a long-running service; `rackd` connects as needed, does not manage the service lifecycle
@@ -196,9 +196,9 @@
 ### Rack-to-Region Driver Lifecycle Notification
 - **Purpose**: Keeps the region's view of available power types in sync with each rack
 - **Trigger**: Driver service appears (snap connect + service start) or disappears (snap disconnect / service stop)
-- **Direction**: Rack controller → Region controller (via existing RPC channel)
-- **Payload**: Driver capabilities (same as the capabilities query response) for additions; driver name for removals
-- **On rack startup**: `rackd` sends the complete set of available drivers to the region during registration
+- **Direction**: Rack controller → Region controller (via v3 internal API, not legacy RPC)
+- **Payload**: Driver metadata (same as the `/metadata` endpoint response) for additions; driver name for removals
+- **On rack startup**: `rackd` registers the complete set of available drivers with the region via the v3 internal API
 
 ### Driver Repository Structure
 - **Purpose**: Standard layout for each driver's git repository
@@ -239,13 +239,13 @@
 - MAAS rack controller discovers all connected driver services within 1 second of service start
 - Zero power driver tests fail after extraction (100% test pass rate preserved)
 - All 20 external power driver types remain functional after extraction (webhook stays builtin)
-- The `maas-power` command prints a deprecation warning and exits (driver snaps provide their own CLI tools)
 - A new power driver can be added by building and connecting a driver snap (no MAAS core changes required)
 - A power driver written in a non-Python language (e.g., Go) can be discovered and invoked by `rackd`
 - The HTTP-over-UNIX-socket protocol specification is published for third-party driver authors
 - No breaking changes to existing MAAS APIs or RPC interfaces
 - The MAAS snap declares a `power-drivers` content slot that driver snaps can connect to
-- The region controller receives timely notifications when drivers are added or removed from a rack
+- The region controller receives timely notifications via the v3 internal API when drivers are added or removed from a rack
+- The `maas-power` command and `power_driver_command.py` are completely removed from the MAAS codebase
 - Each driver repository is self-contained (code, tests, docs, snapcraft config) and builds independently
 
 ## Non-Goals
@@ -257,5 +257,5 @@
 - This feature does not require changes to the MAAS UI
 - This feature does not publish driver snaps to the Snap Store (that is a follow-up)
 - This feature does not define a driver SDK or CLI tooling for driver authors (that is a follow-up)
-- This feature does not preserve the `maas-power` CLI — it is deprecated in favor of per-driver CLI tools
 - This feature does not define a driver SDK or language bindings for the HTTP-over-UNIX-socket protocol (that is a follow-up)
+- This feature does not preserve the `maas-power` command — it is removed entirely

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -153,9 +153,9 @@
 - Driver snaps run with `strict` confinement (same as MAAS)
 - System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) are included in the driver snap, not the MAAS snap
 - The `webhook` and `manual` power drivers remain builtin in MAAS core (no external dependencies)
-- Each driver is an independent project — no driver grouping, one driver per repo and per snap
+- Each driver is an independent project — no driver grouping, one driver per repo and per snap, with the exception of built-in power drivers.
 - Pod drivers (LXD, Virsh) follow a similar but separate extraction path (out of scope for this feature)
-- Driver code, tests, and documentation are maintained in driver repositories, not the MAAS monorepo
+- Driver code, tests, and documentation are maintained in driver repositories, not the MAAS monorepo, with the exception of built-in power drivers.
 - Third-party power drivers are a valid use case (anyone can build a driver snap)
 - Each driver repository has its own CI pipeline for testing and snap building
 - The rack controller is responsible for driver discovery and for notifying the region of driver lifecycle changes via the v3 internal API

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -1,0 +1,159 @@
+# Feature Specification: Extract Power Drivers to Independent Repositories
+
+**Feature Branch**: `6690-power-drivers-extract`  
+**Created**: 2025-01-13  
+**Status**: Draft  
+**Input**: Move power drivers to their own repositories with entry point discovery mechanism, common interface, and snap distribution.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - MAAS discovers installed power drivers at startup (Priority: P1)
+
+**Description**: When MAAS region or rack controller starts, it automatically discovers all installed power driver packages through Python entry points. Administrators install power driver packages separately, and MAAS recognizes them without requiring changes to MAAS core.
+
+**Why this priority**: This is the foundational capability. Without runtime discovery, the entire separation architecture cannot function. All other stories depend on this working correctly.
+
+**Independent Test**: Can be fully tested by installing a mock power driver package with an entry point, starting the rack controller, and verifying that `PowerDriverRegistry` contains the driver. Delivers a working plugin architecture.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh MAAS installation with no external power drivers, **When** the rack controller starts, **Then** only builtin drivers (e.g., `manual`) are available in `PowerDriverRegistry`
+2. **Given** a MAAS installation with `maas-power-driver-ipmi` package installed, **When** the rack controller starts, **Then** the `ipmi` driver is discoverable via `PowerDriverRegistry.get_item("ipmi")`
+3. **Given** multiple power driver packages are installed, **When** the rack controller starts, **Then** all drivers from all packages are registered and available
+4. **Given** a power driver package is uninstalled, **When** the rack controller restarts, **Then** that driver is no longer available in the registry
+5. **Given** a power driver package fails to load (import error), **When** the rack controller starts, **Then** MAAS logs a warning but continues startup with remaining drivers
+
+### User Story 2 - Power driver packages declare themselves via standard entry point (Priority: P1)
+
+**Description**: Power driver package authors implement the `PowerDriverBase` interface and register their driver under the `maas.power_drivers` entry point group. The package declares its dependency on `maas-power-driver-interface`.
+
+**Why this priority**: This defines the contract between MAAS and driver packages. Without a standardized registration mechanism, discovery cannot work.
+
+**Independent Test**: Can be tested by creating a minimal Python package with an entry point that loads a driver class, verifying that `importlib.metadata.entry_points(group="maas.power_drivers")` returns it, and that the loaded class implements the required interface.
+
+**Acceptance Scenarios**:
+
+1. **Given** a driver package with `maas.power_drivers` entry point, **When** `importlib.metadata.entry_points(group="maas.power_drivers")` is called, **Then** the entry point is returned with the driver's name and import path
+2. **Given** an entry point loads successfully, **When** instantiated, **Then** the driver class implements all required properties (`name`, `description`, `settings`, `ip_extractor`, `queryable`, `chassis`, `can_probe`, `can_set_boot_order`)
+3. **Given** an entry point loads successfully, **When** instantiated, **Then** the driver class implements all required methods (`on`, `off`, `query`, `cycle`, `reset`)
+4. **Given** a driver package depends on `maas-power-driver-interface`, **When** the package is installed, **Then** the interface package is installed as a dependency
+
+### User Story 3 - MAAS core uses power drivers without importing them directly (Priority: P1)
+
+**Description**: MAAS region and rack controllers interact with power drivers exclusively through `PowerDriverRegistry`. MAAS core code never imports a specific power driver implementation. Power actions (on, off, query, cycle, reset) flow through the registry.
+
+**Why this priority**: This ensures true decoupling. If MAAS core imports specific drivers, the separation is incomplete and drivers cannot be moved to separate repositories.
+
+**Independent Test**: Can be tested by running the existing power action test suite with all driver imports removed from MAAS core, verifying that power actions still succeed through registry lookups.
+
+**Acceptance Scenarios**:
+
+1. **Given** a machine with power type `ipmi`, **When** a power query is requested via RPC, **Then** the rack controller looks up the driver via `PowerDriverRegistry.get_item("ipmi")` and executes the query
+2. **Given** a machine with power type `redfish`, **When** a power-on action is requested, **Then** the action succeeds without MAAS core importing the redfish driver directly
+3. **Given** `provisioningserver` source code, **When** searched for direct driver imports, **Then** no import of `provisioningserver.drivers.power.ipmi`, `provisioningserver.drivers.power.redfish`, etc. exists (only registry imports)
+4. **Given** `maasserver` source code, **When** searched for direct driver imports, **Then** no import of specific power driver implementations exists
+
+### User Story 4 - Power drivers are distributed as installable packages (Priority: P2)
+
+**Description**: Power drivers are packaged as Python packages that can be installed via pip or included in snap builds. Each driver package includes its system-level dependencies (e.g., `freeipmi-tools` for IPMI).
+
+**Why this priority**: This enables the operational model where drivers can be installed/uninstalled independently of MAAS core. Lower priority than discovery because it's about distribution, not functionality.
+
+**Independent Test**: Can be tested by building a driver package with `build`, installing it with `pip install`, and verifying that the driver is discovered by MAAS.
+
+**Acceptance Scenarios**:
+
+1. **Given** a power driver package repository, **When** `pip install .` is run, **Then** the package installs with its entry point registered
+2. **Given** a power driver package, **When** `python -m build` is run, **Then** a wheel and sdist are produced
+3. **Given** a power driver package with system dependencies, **When** the package metadata is inspected, **Then** the system dependencies are documented (via package metadata or documentation)
+
+### User Story 5 - Power drivers are available in the MAAS snap (Priority: P2)
+
+**Description**: Power driver packages are included in the MAAS snap alongside the core MAAS installation. The snap declares system-level dependencies for each included driver.
+
+**Why this priority**: This is the primary distribution channel for MAAS. Drivers must be available in the snap for production use. Lower priority because the snap configuration depends on the package structure being finalized.
+
+**Independent Test**: Can be tested by building the MAAS snap with driver packages included, installing the snap, and verifying that `maas-power` CLI shows all expected drivers.
+
+**Acceptance Scenarios**:
+
+1. **Given** the MAAS snap with power driver packages included, **When** the snap is installed, **Then** `maas-power --help` lists all included driver types as subcommands
+2. **Given** the MAAS snap, **When** a power driver's system dependency is missing, **Then** the driver reports missing packages via `detect_missing_packages()` rather than failing at import
+3. **Given** the MAAS snap with drivers, **When** `snap list` is run, **Then** the snap includes the driver packages
+
+### User Story 6 - Existing power functionality is preserved after extraction (Priority: P1)
+
+**Description**: After moving drivers to separate packages, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. The `maas-power` CLI, RPC power commands, and UI power controls function identically.
+
+**Why this priority**: This is a refactoring feature. If existing functionality breaks, the extraction has failed. Must be verified for all 21 existing driver types.
+
+**Independent Test**: Can be tested by running the full existing power driver test suite against the refactored code, verifying all tests pass.
+
+**Acceptance Scenarios**:
+
+1. **Given** the refactored code with drivers in separate packages, **When** the existing test suite `bin/test.rack` is run for power drivers, **Then** all tests pass
+2. **Given** the refactored code, **When** `maas-power ipmi status --power-address 10.0.0.1 --power-user admin --power-pass secret` is run, **Then** the command executes and returns power status
+3. **Given** the refactored code, **When** the region controller requests power types from the rack controller via `DescribePowerTypes` RPC, **Then** all installed drivers are returned in the schema
+4. **Given** the refactored code, **When** a BMC's power parameters are sanitized, **Then** secret parameters are correctly separated from non-secret parameters using `sanitise_power_parameters()`
+
+## Assumptions
+
+- Python 3.14+ is available (MAAS already requires this)
+- `importlib.metadata.entry_points()` with `group` parameter is available (Python 3.10+)
+- The existing `PowerDriverBase` ABC is sufficient as the interface contract
+- Driver packages target the same Python version as MAAS core
+- System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) remain as snap stage-packages, not Python packages
+- The `manual` power driver remains builtin in MAAS core (no external dependencies, always available)
+- Pod drivers (LXD, Virsh) follow a similar but separate extraction path (out of scope for this feature)
+- Third-party power drivers are a valid use case (hence the public interface package)
+
+## Key Entities
+
+### Power Driver Interface
+- **Purpose**: Defines the contract that all power drivers must implement
+- **Properties**: `name`, `description`, `settings`, `ip_extractor`, `queryable`, `chassis`, `can_probe`, `can_set_boot_order`
+- **Methods**: `on()`, `off()`, `query()`, `cycle()`, `reset()`, `set_boot_order()`, `detect_missing_packages()`, `get_schema()`
+
+### Power Driver Registry
+- **Purpose**: Runtime registry of all discovered power drivers
+- **Operations**: `register_item()`, `get_item()`, `get_schema()`, iteration over registered drivers
+- **Discovery**: Populated via `importlib.metadata.entry_points(group="maas.power_drivers")` at startup
+
+### Power Driver Package
+- **Purpose**: A Python package containing one or more power driver implementations
+- **Structure**: Standard Python package with `pyproject.toml` declaring entry points and dependencies
+- **Entry Point Group**: `maas.power_drivers`
+- **Dependency**: `maas-power-driver-interface`
+
+### Driver Grouping
+- **Purpose**: Logical grouping of related drivers into shared packages
+- **Groups**:
+  - `maas-power-drivers-core`: `manual` (builtin)
+  - `maas-power-driver-ipmi`: `ipmi`, `moonshot`
+  - `maas-power-driver-redfish`: `redfish`, `openbmc`
+  - `maas-power-driver-ibm`: `hmc`, `hmcz`, `mscm`
+  - `maas-power-driver-amt`: `amt`
+  - `maas-power-driver-apc`: `apc`
+  - `maas-power-driver-vmware`: `vmware`, `proxmox`
+  - `maas-power-driver-webhook`: `webhook`
+  - `maas-power-drivers-legacy`: `dli`, `eaton`, `raritan`, `recs`, `seamicro`, `ucsm`, `wedge`
+
+## Success Criteria
+
+- MAAS rack controller discovers all installed power drivers within 1 second of startup
+- Zero power driver tests fail after extraction (100% test pass rate preserved)
+- All 21 existing power driver types remain functional after extraction
+- The `maas-power` CLI works with all installed drivers without modification
+- A new power driver can be added by creating a Python package (no MAAS core changes required)
+- Power driver interface package can be published to PyPI for third-party consumption
+- No breaking changes to existing MAAS APIs or RPC interfaces
+- The MAAS snap builds and installs successfully with driver packages included
+
+## Non-Goals
+
+- This feature does not extract pod drivers (LXD, Virsh) — they are out of scope
+- This feature does not create a new API for power management — existing APIs are preserved
+- This feature does not change how power parameters are stored in the database
+- This feature does not introduce a new authentication or authorization model for drivers
+- This feature does not require changes to the MAAS UI
+- This feature does not publish packages to PyPI (that is a follow-up)

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -9,6 +9,7 @@
 
 - **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is a JSON-based protocol, not a language-specific API.
 - **Snap plug/slot discovery**: Drivers are distributed as separate snaps. When a driver snap connects to the MAAS snap (via a content plug and slot), it exposes driver metadata as a JSON file at a known path. MAAS discovers drivers by scanning these JSON files at runtime.
+- **`maas-power` CLI deprecated**: The `maas-power` command (currently in `provisioningserver/power_driver_command.py`) is deprecated. Driver snaps provide their own CLI tools for testing and direct invocation. MAAS no longer ships a unified power CLI.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -93,7 +94,7 @@
 
 ### User Story 6 - Existing power functionality is preserved after extraction (Priority: P1)
 
-**Description**: After moving drivers to separate packages, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. The `maas-power` CLI, RPC power commands, and UI power controls function identically.
+**Description**: After moving drivers to separate snaps, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. RPC power commands and UI power controls function identically. The `maas-power` CLI is deprecated — driver snaps provide their own CLI tools for testing and direct invocation.
 
 **Why this priority**: This is a refactoring feature. If existing functionality breaks, the extraction has failed. Must be verified for all 21 existing driver types.
 
@@ -101,10 +102,10 @@
 
 **Acceptance Scenarios**:
 
-1. **Given** the refactored code with drivers in separate packages, **When** the existing test suite `bin/test.rack` is run for power drivers, **Then** all tests pass
-2. **Given** the refactored code, **When** `maas-power ipmi status --power-address 10.0.0.1 --power-user admin --power-pass secret` is run, **Then** the command executes and returns power status
-3. **Given** the refactored code, **When** the region controller requests power types from the rack controller via `DescribePowerTypes` RPC, **Then** all installed drivers are returned in the schema
-4. **Given** the refactored code, **When** a BMC's power parameters are sanitized, **Then** secret parameters are correctly separated from non-secret parameters using `sanitise_power_parameters()`
+1. **Given** the refactored code with drivers in separate snaps, **When** the existing test suite `bin/test.rack` is run for power drivers, **Then** all tests pass
+2. **Given** the refactored code, **When** the region controller requests power types from the rack controller via `DescribePowerTypes` RPC, **Then** all connected drivers are returned in the schema
+3. **Given** the refactored code, **When** a BMC's power parameters are sanitized, **Then** secret parameters are correctly separated from non-secret parameters using `sanitise_power_parameters()`
+4. **Given** the `maas-power` command is invoked, **When** it runs, **Then** it prints a deprecation warning directing users to the driver snap's own CLI tool
 
 ## Assumptions
 
@@ -173,7 +174,7 @@
 - MAAS rack controller discovers all connected driver snaps within 1 second of snap connection
 - Zero power driver tests fail after extraction (100% test pass rate preserved)
 - All 21 existing power driver types remain functional after extraction
-- The `maas-power` CLI works with all connected drivers without modification
+- The `maas-power` command prints a deprecation warning and exits (driver snaps provide their own CLI tools)
 - A new power driver can be added by building and connecting a driver snap (no MAAS core changes required)
 - A power driver written in a non-Python language (e.g., Go) can be discovered and invoked by MAAS
 - The metadata JSON schema is published and versioned for third-party driver authors
@@ -189,3 +190,4 @@
 - This feature does not require changes to the MAAS UI
 - This feature does not publish driver snaps to the Snap Store (that is a follow-up)
 - This feature does not define a driver SDK or CLI tooling for driver authors (that is a follow-up)
+- This feature does not preserve the `maas-power` CLI — it is deprecated in favor of per-driver CLI tools

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -7,11 +7,13 @@
 
 ## Clarifications
 
-- **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is a JSON-based protocol over UNIX sockets, not a language-specific API.
-- **Driver services**: Each power driver runs as a long-running snap service. The rack controller (`rackd`) communicates with driver services over UNIX domain sockets exposed through the snap interface.
+- **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is HTTP over UNIX domain sockets, not a language-specific API.
+- **Driver services**: Each power driver runs as a long-running snap service. The rack controller (`rackd`) communicates with driver services over HTTP on UNIX domain sockets exposed through the snap interface.
 - **No metadata JSON**: Driver capabilities are discovered by querying the live service at its UNIX socket. There is no static metadata file.
 - **`maas-power` CLI deprecated**: The `maas-power` command (currently in `provisioningserver/power_driver_command.py`) is deprecated. Driver snaps provide their own CLI tools for testing and direct invocation. MAAS no longer ships a unified power CLI.
-- **Independent repositories**: Each driver group lives in its own git repository. Driver code, tests, documentation, and snapcraft configuration are all maintained in the driver's repository — not in the MAAS monorepo.
+- **Independent repositories**: Each power driver lives in its own git repository as an independent project. No driver grouping — one driver per repo, one driver per snap.
+- **`webhook` builtin**: The `webhook` power driver remains builtin in MAAS core (no external dependencies, useful for testing and custom integrations). All other drivers are external snaps.
+- **No `manual` driver**: The `manual` power driver is dropped entirely. It has no value in a service-based architecture.
 - **Rack-to-region driver lifecycle**: When drivers appear or disappear (snap connect/disconnect), the rack controller notifies the region controller so the region's view of available power types stays in sync.
 
 ## User Scenarios & Testing *(mandatory)*
@@ -26,7 +28,7 @@
 
 **Acceptance Scenarios**:
 
-1. **Given** a fresh MAAS installation with no driver snaps connected, **When** `rackd` starts, **Then** only builtin drivers (e.g., `manual`) are available in `PowerDriverRegistry`
+1. **Given** a fresh MAAS installation with no driver snaps connected, **When** `rackd` starts, **Then** only the builtin `webhook` driver is available in `PowerDriverRegistry`
 2. **Given** a driver snap `maas-power-driver-ipmi` is installed, connected, and its service is running, **When** `rackd` discovers available sockets, **Then** the `ipmi` driver is discoverable via `PowerDriverRegistry.get_item("ipmi")`
 3. **Given** multiple driver snaps are connected and running, **When** `rackd` discovers available sockets, **Then** all drivers are registered and available
 4. **Given** a driver snap is disconnected or its service stops, **When** `rackd` detects the socket is unavailable, **Then** that driver is removed from the registry
@@ -65,9 +67,9 @@
 4. **Given** a driver service crashes or becomes unresponsive, **When** `rackd` attempts to send a request, **Then** `rackd` receives a clear error and reports it to the user
 5. **Given** `provisioningserver` source code, **When** searched for direct driver imports, **Then** no import of specific power driver implementations exists (only the socket client and registry)
 
-### User Story 4 - Power drivers live in independent repositories (Priority: P1)
+### User Story 4 - Each power driver is an independent project (Priority: P1)
 
-**Description**: Each power driver (or group of related drivers) is maintained in its own git repository. The repository contains the driver implementation, its test suite, documentation, and snapcraft configuration. Driver teams can develop, version, and release independently of MAAS core.
+**Description**: Each power driver is maintained in its own git repository as a fully independent project. There is no driver grouping — one driver per repository, one driver per snap. Driver teams can develop, version, and release independently of MAAS core and independently of each other.
 
 **Why this priority**: Independent repositories enable independent versioning, separate CI pipelines, and clear ownership. Without this, drivers cannot truly be maintained separately from MAAS.
 
@@ -79,7 +81,7 @@
 2. **Given** a driver repository, **When** inspected, **Then** it contains documentation describing the driver's supported BMC types, configuration parameters, and known limitations
 3. **Given** a driver repository, **When** `snapcraft` is run, **Then** a driver snap is produced that can be installed and connected to MAAS
 4. **Given** a driver repository, **When** its version is bumped and released, **Then** the new driver snap can be released without touching the MAAS repository
-5. **Given** the MAAS monorepo after extraction, **When** searched for driver implementation code, **Then** no driver implementation files exist (only the protocol client, registry, and builtin `manual` driver remain)
+5. **Given** the MAAS monorepo after extraction, **When** searched for driver implementation code, **Then** no driver implementation files exist (only the protocol client, registry, and builtin `webhook` driver remain)
 
 ### User Story 5 - Driver snaps run as long-running services (Priority: P1)
 
@@ -146,12 +148,14 @@
 ## Assumptions
 
 - Power drivers may be written in any programming language (Python, Go, Rust, C, shell, etc.)
-- Each driver runs as a long-running service communicating over UNIX domain sockets
+- Each driver runs as a long-running service communicating over HTTP on UNIX domain sockets
 - Driver capabilities are discovered by querying the live service — there is no static metadata JSON file
 - Snap content interfaces (plug/slot) provide a shared directory for UNIX sockets
 - Driver snaps run with `strict` confinement (same as MAAS)
 - System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) are included in the driver snap, not the MAAS snap
-- The `manual` power driver remains builtin in MAAS core (no external dependencies, always available)
+- The `webhook` power driver remains builtin in MAAS core (no external dependencies, useful for testing)
+- The `manual` power driver is dropped entirely
+- Each driver is an independent project — no driver grouping, one driver per repo and per snap
 - Pod drivers (LXD, Virsh) follow a similar but separate extraction path (out of scope for this feature)
 - Driver code, tests, and documentation are maintained in driver repositories, not the MAAS monorepo
 - Third-party power drivers are a valid use case (anyone can build a driver snap)
@@ -160,16 +164,21 @@
 
 ## Key Entities
 
-### Driver Service Protocol (UNIX Socket)
+### Driver Service Protocol (HTTP over UNIX Socket)
 - **Purpose**: Language-agnostic communication between `rackd` and driver services
-- **Transport**: UNIX domain socket in the shared snap content directory
-- **Messages**: JSON objects, length-prefixed (4-byte big-endian length + JSON payload)
-- **Request types**:
-  - `capabilities` — returns driver name, description, version, actions, settings, capability flags
-  - `power_query` — returns current power state (`on`, `off`, `unknown`)
-  - `power_on`, `power_off`, `power_cycle`, `power_reset` — performs action, returns status
-  - `set_boot_order` — configures boot order, returns status
+- **Transport**: HTTP over UNIX domain socket in the shared snap content directory
+- **Wire format**: Standard HTTP requests/responses with JSON bodies
+- **Endpoints**:
+  - `GET /` — returns driver capabilities (name, description, version, actions, settings, capability flags)
+  - `POST /query` — returns current power state (`on`, `off`, `unknown`)
+  - `POST /on` — powers on the node
+  - `POST /off` — powers off the node
+  - `POST /cycle` — cycles power
+  - `POST /reset` — resets power
+  - `POST /set-boot-order` — configures boot order
+- **Request body**: JSON object with `system_id`, `hostname`, `context` (power parameters)
 - **Response format**: JSON object with `status` (`ok`/`error`), optional `state` (for queries), optional `error_type` and `error_message`
+- **HTTP status codes**: 200 for success, 503 for unavailable, 400 for invalid parameters, 500 for driver errors
 - **Lifecycle**: Driver is a long-running service; `rackd` connects as needed, does not manage the service lifecycle
 
 ### Power Driver Registry
@@ -201,28 +210,39 @@
   - Protocol client library (for testing: a small client that speaks the UNIX socket protocol)
 - **Independence**: Each repository builds, tests, and releases without requiring the MAAS monorepo
 
-### Driver Grouping
-- **Purpose**: Logical grouping of related drivers into shared snaps
-- **Groups**:
-  - `maas-power-drivers-core`: `manual` (builtin in MAAS snap)
-  - `maas-power-driver-ipmi`: `ipmi`, `moonshot`
-  - `maas-power-driver-redfish`: `redfish`, `openbmc`
-  - `maas-power-driver-ibm`: `hmc`, `hmcz`, `mscm`
-  - `maas-power-driver-amt`: `amt`
-  - `maas-power-driver-apc`: `apc`
-  - `maas-power-driver-vmware`: `vmware`, `proxmox`
-  - `maas-power-driver-webhook`: `webhook`
-  - `maas-power-drivers-legacy`: `dli`, `eaton`, `raritan`, `recs`, `seamicro`, `ucsm`, `wedge`
+### Driver Listing
+- **Purpose**: Each driver is an independent project — no grouping
+- **Drivers**:
+  - `webhook` (builtin in MAAS snap)
+  - `ipmi` (independent snap)
+  - `redfish` (independent snap)
+  - `amt` (independent snap)
+  - `apc` (independent snap)
+  - `dli` (independent snap)
+  - `eaton` (independent snap)
+  - `hmc` (independent snap)
+  - `hmcz` (independent snap)
+  - `moonshot` (independent snap)
+  - `mscm` (independent snap)
+  - `msftocs` (independent snap)
+  - `openbmc` (independent snap)
+  - `proxmox` (independent snap)
+  - `raritan` (independent snap)
+  - `recs` (independent snap)
+  - `seamicro` (independent snap)
+  - `ucsm` (independent snap)
+  - `vmware` (independent snap)
+  - `wedge` (independent snap)
 
 ## Success Criteria
 
 - MAAS rack controller discovers all connected driver services within 1 second of service start
 - Zero power driver tests fail after extraction (100% test pass rate preserved)
-- All 21 existing power driver types remain functional after extraction
+- All 20 external power driver types remain functional after extraction (webhook stays builtin)
 - The `maas-power` command prints a deprecation warning and exits (driver snaps provide their own CLI tools)
 - A new power driver can be added by building and connecting a driver snap (no MAAS core changes required)
 - A power driver written in a non-Python language (e.g., Go) can be discovered and invoked by `rackd`
-- The UNIX socket protocol specification is published for third-party driver authors
+- The HTTP-over-UNIX-socket protocol specification is published for third-party driver authors
 - No breaking changes to existing MAAS APIs or RPC interfaces
 - The MAAS snap declares a `power-drivers` content slot that driver snaps can connect to
 - The region controller receives timely notifications when drivers are added or removed from a rack
@@ -238,4 +258,4 @@
 - This feature does not publish driver snaps to the Snap Store (that is a follow-up)
 - This feature does not define a driver SDK or CLI tooling for driver authors (that is a follow-up)
 - This feature does not preserve the `maas-power` CLI — it is deprecated in favor of per-driver CLI tools
-- This feature does not define a driver SDK or language bindings for the UNIX socket protocol (that is a follow-up)
+- This feature does not define a driver SDK or language bindings for the HTTP-over-UNIX-socket protocol (that is a follow-up)

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -12,8 +12,7 @@
 - **No metadata JSON**: Driver capabilities are discovered by querying the live service at its UNIX socket. There is no static metadata file.
 - **`maas-power` removed entirely**: The `maas-power` command (currently in `provisioningserver/power_driver_command.py`) is removed. It is not deprecated — it simply no longer exists. Driver snaps provide their own CLI tools for testing and direct invocation.
 - **Independent repositories**: Each power driver lives in its own git repository as an independent project. No driver grouping — one driver per repo, one driver per snap.
-- **`webhook` builtin**: The `webhook` power driver remains builtin in MAAS core (no external dependencies, useful for testing and custom integrations). All other drivers are external snaps.
-- **No `manual` driver**: The `manual` power driver is dropped entirely. It has no value in a service-based architecture.
+- **`webhook` and `manual` builtin**: The `webhook` and `manual` power drivers remain builtin in MAAS core (no external dependencies). `webhook` is useful for custom integrations; `manual` is useful for nodes without automated BMC access. All other drivers are external snaps.
 - **Rack-to-region driver lifecycle (v3 internal API)**: When drivers appear or disappear (snap connect/disconnect), the rack controller notifies the region controller via the v3 internal API so the region's view of available power types stays in sync. This is not the legacy RPC channel.
 
 ## User Scenarios & Testing *(mandatory)*
@@ -28,7 +27,7 @@
 
 **Acceptance Scenarios**:
 
-1. **Given** a fresh MAAS installation with no driver snaps connected, **When** `rackd` starts, **Then** only the builtin `webhook` driver is available in `PowerDriverRegistry`
+1. **Given** a fresh MAAS installation with no driver snaps connected, **When** `rackd` starts, **Then** only the builtin `webhook` and `manual` drivers are available in `PowerDriverRegistry`
 2. **Given** a driver snap `maas-power-driver-ipmi` is installed, connected, and its service is running, **When** `rackd` discovers available sockets, **Then** the `ipmi` driver is discoverable via `PowerDriverRegistry.get_item("ipmi")`
 3. **Given** multiple driver snaps are connected and running, **When** `rackd` discovers available sockets, **Then** all drivers are registered and available
 4. **Given** a driver snap is disconnected or its service stops, **When** `rackd` detects the socket is unavailable, **Then** that driver is removed from the registry
@@ -81,7 +80,7 @@
 2. **Given** a driver repository, **When** inspected, **Then** it contains documentation describing the driver's supported BMC types, configuration parameters, and known limitations
 3. **Given** a driver repository, **When** `snapcraft` is run, **Then** a driver snap is produced that can be installed and connected to MAAS
 4. **Given** a driver repository, **When** its version is bumped and released, **Then** the new driver snap can be released without touching the MAAS repository
-5. **Given** the MAAS monorepo after extraction, **When** searched for driver implementation code, **Then** no driver implementation files exist (only the protocol client, registry, and builtin `webhook` driver remain)
+5. **Given** the MAAS monorepo after extraction, **When** searched for driver implementation code, **Then** no driver implementation files exist (only the protocol client, registry, and builtin `webhook` and `manual` drivers remain)
 
 ### User Story 5 - Driver snaps run as long-running services (Priority: P1)
 
@@ -153,8 +152,7 @@
 - Snap content interfaces (plug/slot) provide a shared directory for UNIX sockets
 - Driver snaps run with `strict` confinement (same as MAAS)
 - System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) are included in the driver snap, not the MAAS snap
-- The `webhook` power driver remains builtin in MAAS core (no external dependencies, useful for testing)
-- The `manual` power driver is dropped entirely
+- The `webhook` and `manual` power drivers remain builtin in MAAS core (no external dependencies)
 - Each driver is an independent project — no driver grouping, one driver per repo and per snap
 - Pod drivers (LXD, Virsh) follow a similar but separate extraction path (out of scope for this feature)
 - Driver code, tests, and documentation are maintained in driver repositories, not the MAAS monorepo
@@ -213,6 +211,7 @@
 ### Driver Listing
 - **Purpose**: Each driver is an independent project — no grouping
 - **Drivers**:
+  - `manual` (builtin in MAAS snap)
   - `webhook` (builtin in MAAS snap)
   - `ipmi` (independent snap)
   - `redfish` (independent snap)
@@ -238,7 +237,7 @@
 
 - MAAS rack controller discovers all connected driver services within 1 second of service start
 - Zero power driver tests fail after extraction (100% test pass rate preserved)
-- All 20 external power driver types remain functional after extraction (webhook stays builtin)
+- All 19 external power driver types remain functional after extraction (manual and webhook stay builtin)
 - A new power driver can be added by building and connecting a driver snap (no MAAS core changes required)
 - A power driver written in a non-Python language (e.g., Go) can be discovered and invoked by `rackd`
 - The HTTP-over-UNIX-socket protocol specification is published for third-party driver authors

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -3,83 +3,93 @@
 **Feature Branch**: `6690-power-drivers-extract`  
 **Created**: 2025-01-13  
 **Status**: Draft  
-**Input**: Move power drivers to their own repositories with entry point discovery mechanism, common interface, and snap distribution.
+**Input**: Move power drivers to their own repositories with snap plug/slot discovery mechanism, language-agnostic interface via JSON metadata, and snap distribution.
+
+## Clarifications
+
+- **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is a JSON-based protocol, not a language-specific API.
+- **Snap plug/slot discovery**: Drivers are distributed as separate snaps. When a driver snap connects to the MAAS snap (via a content plug and slot), it exposes driver metadata as a JSON file at a known path. MAAS discovers drivers by scanning these JSON files at runtime.
 
 ## User Scenarios & Testing *(mandatory)*
 
-### User Story 1 - MAAS discovers installed power drivers at startup (Priority: P1)
+### User Story 1 - MAAS discovers power drivers via snap plug/slot connections (Priority: P1)
 
-**Description**: When MAAS region or rack controller starts, it automatically discovers all installed power driver packages through Python entry points. Administrators install power driver packages separately, and MAAS recognizes them without requiring changes to MAAS core.
+**Description**: When a power driver snap is installed and connected to the MAAS snap, MAAS automatically discovers the driver by reading a JSON metadata file exposed through the snap's content interface. No MAAS core changes are required to add new drivers — installing and connecting a driver snap is sufficient.
 
-**Why this priority**: This is the foundational capability. Without runtime discovery, the entire separation architecture cannot function. All other stories depend on this working correctly.
+**Why this priority**: This is the foundational capability. Without snap-based discovery, the entire separation architecture cannot function. All other stories depend on this working correctly.
 
-**Independent Test**: Can be fully tested by installing a mock power driver package with an entry point, starting the rack controller, and verifying that `PowerDriverRegistry` contains the driver. Delivers a working plugin architecture.
-
-**Acceptance Scenarios**:
-
-1. **Given** a fresh MAAS installation with no external power drivers, **When** the rack controller starts, **Then** only builtin drivers (e.g., `manual`) are available in `PowerDriverRegistry`
-2. **Given** a MAAS installation with `maas-power-driver-ipmi` package installed, **When** the rack controller starts, **Then** the `ipmi` driver is discoverable via `PowerDriverRegistry.get_item("ipmi")`
-3. **Given** multiple power driver packages are installed, **When** the rack controller starts, **Then** all drivers from all packages are registered and available
-4. **Given** a power driver package is uninstalled, **When** the rack controller restarts, **Then** that driver is no longer available in the registry
-5. **Given** a power driver package fails to load (import error), **When** the rack controller starts, **Then** MAAS logs a warning but continues startup with remaining drivers
-
-### User Story 2 - Power driver packages declare themselves via standard entry point (Priority: P1)
-
-**Description**: Power driver package authors implement the `PowerDriverBase` interface and register their driver under the `maas.power_drivers` entry point group. The package declares its dependency on `maas-power-driver-interface`.
-
-**Why this priority**: This defines the contract between MAAS and driver packages. Without a standardized registration mechanism, discovery cannot work.
-
-**Independent Test**: Can be tested by creating a minimal Python package with an entry point that loads a driver class, verifying that `importlib.metadata.entry_points(group="maas.power_drivers")` returns it, and that the loaded class implements the required interface.
+**Independent Test**: Can be fully tested by building a minimal driver snap with a valid metadata JSON, installing it, connecting it to the MAAS snap, and verifying that `PowerDriverRegistry` contains the driver after MAAS reloads its driver list.
 
 **Acceptance Scenarios**:
 
-1. **Given** a driver package with `maas.power_drivers` entry point, **When** `importlib.metadata.entry_points(group="maas.power_drivers")` is called, **Then** the entry point is returned with the driver's name and import path
-2. **Given** an entry point loads successfully, **When** instantiated, **Then** the driver class implements all required properties (`name`, `description`, `settings`, `ip_extractor`, `queryable`, `chassis`, `can_probe`, `can_set_boot_order`)
-3. **Given** an entry point loads successfully, **When** instantiated, **Then** the driver class implements all required methods (`on`, `off`, `query`, `cycle`, `reset`)
-4. **Given** a driver package depends on `maas-power-driver-interface`, **When** the package is installed, **Then** the interface package is installed as a dependency
+1. **Given** a fresh MAAS installation with no driver snaps connected, **When** the rack controller starts, **Then** only builtin drivers (e.g., `manual`) are available in `PowerDriverRegistry`
+2. **Given** a driver snap `maas-power-driver-ipmi` is installed and connected to MAAS, **When** MAAS reloads its driver list, **Then** the `ipmi` driver is discoverable via `PowerDriverRegistry.get_item("ipmi")`
+3. **Given** multiple driver snaps are connected, **When** MAAS reloads its driver list, **Then** all drivers from all connected snaps are registered and available
+4. **Given** a driver snap is disconnected, **When** MAAS reloads its driver list, **Then** that driver is no longer available in the registry
+5. **Given** a driver snap's metadata JSON is malformed, **When** MAAS attempts to discover it, **Then** MAAS logs a warning and skips that driver but continues discovering others
+6. **Given** a driver snap is connected while MAAS is running, **When** MAAS detects the new connection (via snap change notification or periodic scan), **Then** the new driver becomes available without a full MAAS restart
 
-### User Story 3 - MAAS core uses power drivers without importing them directly (Priority: P1)
+### User Story 2 - Driver snaps expose metadata via JSON at the snap interface (Priority: P1)
 
-**Description**: MAAS region and rack controllers interact with power drivers exclusively through `PowerDriverRegistry`. MAAS core code never imports a specific power driver implementation. Power actions (on, off, query, cycle, reset) flow through the registry.
+**Description**: Each power driver snap exposes a JSON metadata file at a known path through its content interface. This file describes the driver's capabilities, parameters, and how MAAS should invoke it. The JSON schema is defined by the MAAS power driver interface contract.
 
-**Why this priority**: This ensures true decoupling. If MAAS core imports specific drivers, the separation is incomplete and drivers cannot be moved to separate repositories.
+**Why this priority**: This defines the contract between MAAS and driver snaps. Without a standardized metadata format, discovery and invocation cannot work.
 
-**Independent Test**: Can be tested by running the existing power action test suite with all driver imports removed from MAAS core, verifying that power actions still succeed through registry lookups.
-
-**Acceptance Scenarios**:
-
-1. **Given** a machine with power type `ipmi`, **When** a power query is requested via RPC, **Then** the rack controller looks up the driver via `PowerDriverRegistry.get_item("ipmi")` and executes the query
-2. **Given** a machine with power type `redfish`, **When** a power-on action is requested, **Then** the action succeeds without MAAS core importing the redfish driver directly
-3. **Given** `provisioningserver` source code, **When** searched for direct driver imports, **Then** no import of `provisioningserver.drivers.power.ipmi`, `provisioningserver.drivers.power.redfish`, etc. exists (only registry imports)
-4. **Given** `maasserver` source code, **When** searched for direct driver imports, **Then** no import of specific power driver implementations exists
-
-### User Story 4 - Power drivers are distributed as installable packages (Priority: P2)
-
-**Description**: Power drivers are packaged as Python packages that can be installed via pip or included in snap builds. Each driver package includes its system-level dependencies (e.g., `freeipmi-tools` for IPMI).
-
-**Why this priority**: This enables the operational model where drivers can be installed/uninstalled independently of MAAS core. Lower priority than discovery because it's about distribution, not functionality.
-
-**Independent Test**: Can be tested by building a driver package with `build`, installing it with `pip install`, and verifying that the driver is discovered by MAAS.
+**Independent Test**: Can be tested by creating a minimal driver snap that exposes a metadata JSON file, connecting it to MAAS, and verifying that MAAS can read and validate the metadata.
 
 **Acceptance Scenarios**:
 
-1. **Given** a power driver package repository, **When** `pip install .` is run, **Then** the package installs with its entry point registered
-2. **Given** a power driver package, **When** `python -m build` is run, **Then** a wheel and sdist are produced
-3. **Given** a power driver package with system dependencies, **When** the package metadata is inspected, **Then** the system dependencies are documented (via package metadata or documentation)
+1. **Given** a driver snap connected to MAAS, **When** MAAS reads the metadata JSON at the interface path, **Then** the JSON is valid against the power driver metadata schema
+2. **Given** a metadata JSON file, **When** validated, **Then** it contains: driver `name`, `description`, `version`, `settings` (parameter schema), `executable` path, and supported `actions`
+3. **Given** a metadata JSON with invalid or missing required fields, **When** MAAS validates it, **Then** MAAS rejects the driver and logs the validation error
+4. **Given** a driver snap is updated (new version), **When** the metadata JSON changes, **Then** MAAS detects the change and reloads the driver metadata
+5. **Given** the metadata JSON, **When** inspected, **Then** it contains no language-specific information — the format is identical regardless of whether the driver is written in Python, Go, Rust, or any other language
 
-### User Story 5 - Power drivers are available in the MAAS snap (Priority: P2)
+### User Story 3 - MAAS invokes power drivers via a language-agnostic protocol (Priority: P1)
 
-**Description**: Power driver packages are included in the MAAS snap alongside the core MAAS installation. The snap declares system-level dependencies for each included driver.
+**Description**: MAAS communicates with power drivers through a language-agnostic protocol (subprocess with JSON on stdin/stdout, or a local HTTP endpoint). MAAS core code never imports or links against driver code directly. Power actions (on, off, query, cycle, reset) are sent as structured requests and receive structured responses.
 
-**Why this priority**: This is the primary distribution channel for MAAS. Drivers must be available in the snap for production use. Lower priority because the snap configuration depends on the package structure being finalized.
+**Why this priority**: This ensures true decoupling. Drivers can be written in any language and updated independently of MAAS. The protocol is the only contract between MAAS and drivers.
 
-**Independent Test**: Can be tested by building the MAAS snap with driver packages included, installing the snap, and verifying that `maas-power` CLI shows all expected drivers.
+**Independent Test**: Can be tested by implementing a minimal driver in a non-Python language (e.g., a shell script or Go binary) that speaks the protocol, connecting it via a test snap, and verifying that MAAS can execute power actions through it.
 
 **Acceptance Scenarios**:
 
-1. **Given** the MAAS snap with power driver packages included, **When** the snap is installed, **Then** `maas-power --help` lists all included driver types as subcommands
-2. **Given** the MAAS snap, **When** a power driver's system dependency is missing, **Then** the driver reports missing packages via `detect_missing_packages()` rather than failing at import
-3. **Given** the MAAS snap with drivers, **When** `snap list` is run, **Then** the snap includes the driver packages
+1. **Given** a machine with power type `ipmi`, **When** a power query is requested via RPC, **Then** MAAS invokes the driver through the protocol and receives the power state
+2. **Given** a driver implemented in Go, **When** connected via snap, **Then** MAAS can execute all supported power actions through it
+3. **Given** a driver implemented in Python, **When** connected via snap, **Then** MAAS can execute all supported power actions through it
+4. **Given** a driver crashes or becomes unresponsive, **When** MAAS attempts to invoke it, **Then** MAAS receives a clear error and reports it to the user
+5. **Given** `provisioningserver` source code, **When** searched for direct driver imports, **Then** no import of specific power driver implementations exists (only the protocol client and registry)
+
+### User Story 4 - Power drivers are distributed as standalone snaps (Priority: P2)
+
+**Description**: Each power driver (or group of related drivers) is packaged as a standalone snap. The snap includes the driver executable, its metadata JSON, and any system-level dependencies. Installing a driver is `snap install` + `snap connect`.
+
+**Why this priority**: This enables the operational model where drivers can be installed, updated, and uninstalled independently of MAAS core and independently of each other.
+
+**Independent Test**: Can be tested by building a driver snap with `snapcraft`, installing it locally, connecting it to MAAS, and verifying that the driver is discovered and functional.
+
+**Acceptance Scenarios**:
+
+1. **Given** a driver snap, **When** `snap install --dangerous driver.snap` is run, **Then** the snap installs successfully
+2. **Given** a driver snap is installed, **When** `snap connect maas:power-drivers driver:power-drivers` is run, **Then** the driver's metadata becomes visible to MAAS
+3. **Given** a driver snap is removed, **When** `snap remove driver` is run, **Then** the driver is no longer available to MAAS
+4. **Given** a driver snap is updated, **When** `snap refresh driver` is run, **Then** MAAS picks up the updated driver metadata and version
+
+### User Story 5 - The MAAS snap exposes a content slot for driver discovery (Priority: P1)
+
+**Description**: The MAAS snap declares a content slot (`power-drivers`) that driver snaps connect to via a content plug. When connected, the slot provides MAAS with access to driver metadata JSON files. The slot path is a directory that driver snaps populate with their metadata.
+
+**Why this priority**: This is the mechanism that makes discovery work. Without the snap content interface, MAAS cannot find or read driver metadata.
+
+**Independent Test**: Can be tested by verifying that the MAAS snap declares the content slot, that a test driver snap can connect to it, and that MAAS can read the metadata JSON from the connected path.
+
+**Acceptance Scenarios**:
+
+1. **Given** the MAAS snap, **When** `snap info maas` is run, **Then** a `power-drivers` content slot is declared
+2. **Given** a driver snap with a `power-drivers` content plug, **When** `snap connect maas:power-drivers driver:power-drivers` is run, **Then** the connection succeeds and the driver's metadata JSON is accessible at the slot path
+3. **Given** multiple driver snaps connected, **When** MAAS scans the slot path, **Then** each driver's metadata JSON is found and loaded
+4. **Given** a driver snap is disconnected, **When** MAAS scans the slot path, **Then** the disconnected driver's metadata is no longer present
 
 ### User Story 6 - Existing power functionality is preserved after extraction (Priority: P1)
 
@@ -98,37 +108,57 @@
 
 ## Assumptions
 
-- Python 3.14+ is available (MAAS already requires this)
-- `importlib.metadata.entry_points()` with `group` parameter is available (Python 3.10+)
-- The existing `PowerDriverBase` ABC is sufficient as the interface contract
-- Driver packages target the same Python version as MAAS core
-- System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) remain as snap stage-packages, not Python packages
+- Power drivers may be written in any programming language (Python, Go, Rust, C, shell, etc.)
+- The communication protocol between MAAS and drivers is language-agnostic (JSON over subprocess stdin/stdout or local HTTP)
+- Snap content interfaces (plug/slot) are the discovery mechanism — not Python entry points, shared libraries, or other language-specific mechanisms
+- Driver snaps run with `strict` confinement (same as MAAS)
+- System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) are included in the driver snap, not the MAAS snap
 - The `manual` power driver remains builtin in MAAS core (no external dependencies, always available)
 - Pod drivers (LXD, Virsh) follow a similar but separate extraction path (out of scope for this feature)
-- Third-party power drivers are a valid use case (hence the public interface package)
+- Third-party power drivers are a valid use case (anyone can build a driver snap)
+- The metadata JSON schema is versioned to allow backward-compatible evolution
 
 ## Key Entities
 
-### Power Driver Interface
-- **Purpose**: Defines the contract that all power drivers must implement
-- **Properties**: `name`, `description`, `settings`, `ip_extractor`, `queryable`, `chassis`, `can_probe`, `can_set_boot_order`
-- **Methods**: `on()`, `off()`, `query()`, `cycle()`, `reset()`, `set_boot_order()`, `detect_missing_packages()`, `get_schema()`
+### Power Driver Metadata JSON
+- **Purpose**: Describes a driver's capabilities, parameters, and invocation details to MAAS
+- **Location**: Exposed at the snap content interface path when the driver snap is connected
+- **Schema** (key fields):
+  - `name`: Unique driver identifier (e.g., `ipmi`, `redfish`)
+  - `description`: Human-readable description
+  - `version`: Driver version string
+  - `actions`: List of supported actions (`on`, `off`, `query`, `cycle`, `reset`, `set-boot-order`)
+  - `settings`: Array of parameter definitions (name, label, type, required, choices, scope, secret)
+  - `ip_extractor`: Field name and regex pattern for extracting IP address from parameters
+  - `executable`: Path to the driver binary/script within the snap
+  - `protocol`: Communication method (`subprocess` or `http`)
+  - `capabilities`: Flags (`queryable`, `chassis`, `can_probe`, `can_set_boot_order`)
+- **Validation**: MAAS validates metadata against a JSON Schema before accepting the driver
+
+### Power Driver Protocol
+- **Purpose**: Language-agnostic communication between MAAS and driver processes
+- **Transport**: Subprocess with JSON lines on stdin/stdout (primary), or local HTTP (alternative)
+- **Request format**: JSON object with `action`, `system_id`, `hostname`, `context` (power parameters)
+- **Response format**: JSON object with `state` (for query) or `status`/`error` (for actions)
+- **Error format**: JSON object with `error_type` and `error_message`
+- **Lifecycle**: Driver process is started per-action (subprocess) or long-running (HTTP)
 
 ### Power Driver Registry
 - **Purpose**: Runtime registry of all discovered power drivers
 - **Operations**: `register_item()`, `get_item()`, `get_schema()`, iteration over registered drivers
-- **Discovery**: Populated via `importlib.metadata.entry_points(group="maas.power_drivers")` at startup
+- **Discovery**: Populated by scanning the snap content slot path for metadata JSON files
+- **Reload**: Supports hot-reload when snaps are connected/disconnected/updated
 
-### Power Driver Package
-- **Purpose**: A Python package containing one or more power driver implementations
-- **Structure**: Standard Python package with `pyproject.toml` declaring entry points and dependencies
-- **Entry Point Group**: `maas.power_drivers`
-- **Dependency**: `maas-power-driver-interface`
+### Snap Content Interface
+- **Purpose**: The snap plug/slot mechanism that exposes driver metadata to MAAS
+- **Slot** (MAAS snap): `power-drivers` — a directory where driver metadata JSON files appear
+- **Plug** (driver snap): `power-drivers` — connects to MAAS's slot, provides metadata JSON
+- **Path convention**: Each driver writes a single metadata JSON file named `<driver-name>.json`
 
 ### Driver Grouping
-- **Purpose**: Logical grouping of related drivers into shared packages
+- **Purpose**: Logical grouping of related drivers into shared snaps
 - **Groups**:
-  - `maas-power-drivers-core`: `manual` (builtin)
+  - `maas-power-drivers-core`: `manual` (builtin in MAAS snap)
   - `maas-power-driver-ipmi`: `ipmi`, `moonshot`
   - `maas-power-driver-redfish`: `redfish`, `openbmc`
   - `maas-power-driver-ibm`: `hmc`, `hmcz`, `mscm`
@@ -140,14 +170,15 @@
 
 ## Success Criteria
 
-- MAAS rack controller discovers all installed power drivers within 1 second of startup
+- MAAS rack controller discovers all connected driver snaps within 1 second of snap connection
 - Zero power driver tests fail after extraction (100% test pass rate preserved)
 - All 21 existing power driver types remain functional after extraction
-- The `maas-power` CLI works with all installed drivers without modification
-- A new power driver can be added by creating a Python package (no MAAS core changes required)
-- Power driver interface package can be published to PyPI for third-party consumption
+- The `maas-power` CLI works with all connected drivers without modification
+- A new power driver can be added by building and connecting a driver snap (no MAAS core changes required)
+- A power driver written in a non-Python language (e.g., Go) can be discovered and invoked by MAAS
+- The metadata JSON schema is published and versioned for third-party driver authors
 - No breaking changes to existing MAAS APIs or RPC interfaces
-- The MAAS snap builds and installs successfully with driver packages included
+- The MAAS snap declares a `power-drivers` content slot that driver snaps can connect to
 
 ## Non-Goals
 
@@ -156,4 +187,5 @@
 - This feature does not change how power parameters are stored in the database
 - This feature does not introduce a new authentication or authorization model for drivers
 - This feature does not require changes to the MAAS UI
-- This feature does not publish packages to PyPI (that is a follow-up)
+- This feature does not publish driver snaps to the Snap Store (that is a follow-up)
+- This feature does not define a driver SDK or CLI tooling for driver authors (that is a follow-up)

--- a/specs/6690-power-drivers-extract/spec.md
+++ b/specs/6690-power-drivers-extract/spec.md
@@ -10,6 +10,7 @@
 - **Language-agnostic**: Power drivers may be implemented in any programming language (Python, Go, Rust, etc.). The interface between MAAS and drivers is a JSON-based protocol, not a language-specific API.
 - **Snap plug/slot discovery**: Drivers are distributed as separate snaps. When a driver snap connects to the MAAS snap (via a content plug and slot), it exposes driver metadata as a JSON file at a known path. MAAS discovers drivers by scanning these JSON files at runtime.
 - **`maas-power` CLI deprecated**: The `maas-power` command (currently in `provisioningserver/power_driver_command.py`) is deprecated. Driver snaps provide their own CLI tools for testing and direct invocation. MAAS no longer ships a unified power CLI.
+- **Independent repositories**: Each driver group lives in its own git repository. Driver code, tests, documentation, and snapcraft configuration are all maintained in the driver's repository — not in the MAAS monorepo.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -62,7 +63,23 @@
 4. **Given** a driver crashes or becomes unresponsive, **When** MAAS attempts to invoke it, **Then** MAAS receives a clear error and reports it to the user
 5. **Given** `provisioningserver` source code, **When** searched for direct driver imports, **Then** no import of specific power driver implementations exists (only the protocol client and registry)
 
-### User Story 4 - Power drivers are distributed as standalone snaps (Priority: P2)
+### User Story 4 - Power drivers live in independent repositories (Priority: P1)
+
+**Description**: Each power driver (or group of related drivers) is maintained in its own git repository. The repository contains the driver implementation, its test suite, documentation, and snapcraft configuration. Driver teams can develop, version, and release independently of MAAS core.
+
+**Why this priority**: Independent repositories enable independent versioning, separate CI pipelines, and clear ownership. Without this, drivers cannot truly be maintained separately from MAAS.
+
+**Independent Test**: Can be tested by verifying that a driver repository contains its own test suite (runnable without the MAAS monorepo), its own documentation, and its own `snap/snapcraft.yaml` for building the driver snap.
+
+**Acceptance Scenarios**:
+
+1. **Given** a driver repository (e.g., `maas-power-driver-ipmi`), **When** cloned and built standalone, **Then** its test suite runs and passes without requiring the MAAS monorepo
+2. **Given** a driver repository, **When** inspected, **Then** it contains documentation describing the driver's supported BMC types, configuration parameters, and known limitations
+3. **Given** a driver repository, **When** `snapcraft` is run, **Then** a driver snap is produced that can be installed and connected to MAAS
+4. **Given** a driver repository, **When** its version is bumped and released, **Then** the new driver snap can be released without touching the MAAS repository
+5. **Given** the MAAS monorepo after extraction, **When** searched for driver implementation code, **Then** no driver implementation files exist (only the protocol client, registry, and builtin `manual` driver remain)
+
+### User Story 5 - Power drivers are distributed as standalone snaps (Priority: P2)
 
 **Description**: Each power driver (or group of related drivers) is packaged as a standalone snap. The snap includes the driver executable, its metadata JSON, and any system-level dependencies. Installing a driver is `snap install` + `snap connect`.
 
@@ -77,7 +94,7 @@
 3. **Given** a driver snap is removed, **When** `snap remove driver` is run, **Then** the driver is no longer available to MAAS
 4. **Given** a driver snap is updated, **When** `snap refresh driver` is run, **Then** MAAS picks up the updated driver metadata and version
 
-### User Story 5 - The MAAS snap exposes a content slot for driver discovery (Priority: P1)
+### User Story 6 - The MAAS snap exposes a content slot for driver discovery (Priority: P1)
 
 **Description**: The MAAS snap declares a content slot (`power-drivers`) that driver snaps connect to via a content plug. When connected, the slot provides MAAS with access to driver metadata JSON files. The slot path is a directory that driver snaps populate with their metadata.
 
@@ -92,7 +109,7 @@
 3. **Given** multiple driver snaps connected, **When** MAAS scans the slot path, **Then** each driver's metadata JSON is found and loaded
 4. **Given** a driver snap is disconnected, **When** MAAS scans the slot path, **Then** the disconnected driver's metadata is no longer present
 
-### User Story 6 - Existing power functionality is preserved after extraction (Priority: P1)
+### User Story 7 - Existing power functionality is preserved after extraction (Priority: P1)
 
 **Description**: After moving drivers to separate snaps, all existing power actions (on, off, query, cycle, reset, set-boot-order) continue to work as before. RPC power commands and UI power controls function identically. The `maas-power` CLI is deprecated — driver snaps provide their own CLI tools for testing and direct invocation.
 
@@ -116,8 +133,9 @@
 - System-level dependencies (e.g., `freeipmi-tools`, `amtterm`) are included in the driver snap, not the MAAS snap
 - The `manual` power driver remains builtin in MAAS core (no external dependencies, always available)
 - Pod drivers (LXD, Virsh) follow a similar but separate extraction path (out of scope for this feature)
+- Driver code, tests, and documentation are maintained in driver repositories, not the MAAS monorepo
 - Third-party power drivers are a valid use case (anyone can build a driver snap)
-- The metadata JSON schema is versioned to allow backward-compatible evolution
+- Each driver repository has its own CI pipeline for testing and snap building
 
 ## Key Entities
 
@@ -155,6 +173,16 @@
 - **Slot** (MAAS snap): `power-drivers` — a directory where driver metadata JSON files appear
 - **Plug** (driver snap): `power-drivers` — connects to MAAS's slot, provides metadata JSON
 - **Path convention**: Each driver writes a single metadata JSON file named `<driver-name>.json`
+
+### Driver Repository Structure
+- **Purpose**: Standard layout for each driver's git repository
+- **Contents**:
+  - Driver implementation source code
+  - Test suite (unit tests, integration tests against real or mocked BMCs)
+  - Documentation (driver-specific README, supported hardware, configuration guide)
+  - `snap/snapcraft.yaml` (snap build configuration)
+  - Metadata JSON template (processed during snap build to include version, executable path, etc.)
+- **Independence**: Each repository builds, tests, and releases without requiring the MAAS monorepo
 
 ### Driver Grouping
 - **Purpose**: Logical grouping of related drivers into shared snaps


### PR DESCRIPTION
Define feature specification for moving power drivers out of MAAS core into separate Python packages discovered via entry points.

Covers:
- Runtime driver discovery via importlib.metadata entry points
- Common interface package (maas-power-driver-interface)
- Driver grouping strategy (9 packages by shared dependencies)
- Snap distribution model
- Zero-regression guarantee for existing 21 driver types