### PR TITLE
chore: add python3 to the staging packages in snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -123,6 +123,7 @@ parts:
       - nmap
       - openssh-client
       - perl-base
+      - python3
       - python3-aiodns
       - python3-aiofiles
       - python3-aiohttp


### PR DESCRIPTION
Core base snaps up to and including core24 bundle the Python interpreter alongside a selection of Python libraries. But from core26 onwards, Python packages is no longer be included so we have to add it to the staging packages manually.