### PR TITLE
feat: Improved Mattermost bot messages for PR events

### DIFF
--- a/.github/workflows/add-mm-comment.yaml
+++ b/.github/workflows/add-mm-comment.yaml
@@ -1,0 +1,35 @@
+name: Ask for permission to send Mattermost message
+on:
+  pull_request_target:
+    types: [opened]
+permissions:
+  issues: write
+jobs:
+  add-mm-permission-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ask user for permission to send Mattermost message
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.ADMIN_PAT || github.token }}
+          script: |
+            const promptText = 'Check where you would like a Mattermost message to be sent';
+            const { data: comments } = await github.rest.issues.listComments({
+              ...context.repo,
+              issue_number: context.issue.number
+            });
+
+            const existingComment = comments.find(comment =>
+              comment.body && comment.body.includes(promptText)
+            );
+
+            if (existingComment) {
+              console.log('Mattermost preference comment already exists. Skipping.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              ...context.repo,
+              issue_number: context.issue.number,
+              body: `Check where you would like a Mattermost message to be sent to when CI completes and this PR is merged\n- [ ] Direct message\n- [ ] ~${{ vars.MM_CHANNEL }}`
+            });

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,18 @@ permissions:
   packages: read
 
 jobs:
+  save-pr-number:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+    steps:
+      - name: Save PR number to artifact
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+      - name: Upload PR number artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-number
+          path: pr-number.txt
+
   changes:
     runs-on: ubuntu-24.04
     if: ${{ !github.event.pull_request.draft }}
@@ -35,7 +47,7 @@ jobs:
           ref="${{ github.event.merge_group.base_ref || github.base_ref || github.ref_name }}"
           echo "tag=${ref#refs/heads/}" >> $GITHUB_OUTPUT
 
-      - uses: dorny/paths-filter@61f87a10cd2c304679af17bb73ef192addf33c1c
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
@@ -89,6 +101,74 @@ jobs:
       - name: Run lint
         run: |
           su ubuntu -c "make lint"
+
+  validate-conventional-commit:
+    if: ${{ github.event_name == 'pull_request' }}
+    name: Validate Conventional Commit standard
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check PR title for Conventional Commits format
+        uses: amannn/action-semantic-pull-request@v5
+        with:
+          types: |
+            feat
+            fix
+            refactor
+            perf
+            test
+            chore
+            docs
+          scopes: |
+            fe-base
+            fe-images
+            fe-accounts
+            fe-sites
+            fe-settings
+            fe-tokens
+            be-config
+            be-settings
+            be-sites
+            be-tokens
+            be-accounts
+            be-db
+            be-images
+            docs
+            ci
+            structural
+            content
+            linting
+            links
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Verify BREAKING CHANGE in description
+        run: |
+          PR_TITLE="${{ github.event.pull_request.title }}"
+
+          # Safely read the multiline PR body from the environment variable
+          PR_BODY="$PR_BODY_ENV"
+
+          # Extract everything before the first colon in the title
+          # e.g., "feat(ui)!: rewrite" becomes "feat(ui)!"
+          PREFIX="${PR_TITLE%%:*}"
+
+          # If the prefix contains an exclamation mark, it's a breaking change
+          if [[ "$PREFIX" == *"!"* ]]; then
+            echo "⚠️ Breaking change indicator ('!') detected in PR title."
+
+            # Check if the body contains the required text
+            if [[ "$PR_BODY" != *"BREAKING CHANGE:"* ]]; then
+              echo "❌ Error: PR title indicates a breaking change, but 'BREAKING CHANGE:' is missing from the PR description."
+              exit 1
+            fi
+
+            echo "✅ 'BREAKING CHANGE:' found in the description."
+          else
+            echo "ℹ️ No breaking change indicator in title. Skipping description check."
+          fi
+        env:
+          # We pass the body as an env var to prevent bash syntax errors
+          # that occur when injecting multiline strings directly via ${{ }}
+          PR_BODY_ENV: ${{ github.event.pull_request.body }}
 
   test-python:
     needs: changes
@@ -156,10 +236,20 @@ jobs:
         cd _scripts && python -m pytest .
 
   ci-check:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-latest
     if: always()
-    needs: [lint, test-python, test-go, test-docs]
+    needs: [lint, test-python, test-go, test-docs, validate-conventional-commit]
     steps:
-      - name: Check job results
-        if: contains(needs.*.result, 'failure')
+      - name: Determine overall CI status
+        id: status
+        run: |
+          # If any dependency failed or was cancelled, mark as failure
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "state=failure" >> $GITHUB_OUTPUT
+          else
+            echo "state=success" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fail pipeline if dependencies failed
+        if: steps.status.outputs.state == 'failure'
         run: exit 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -228,7 +228,7 @@ jobs:
         cd _scripts && python -m pytest .
 
   ci-check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     if: always()
     needs: [lint, test-python, test-go, test-docs, validate-conventional-commit]
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -119,25 +119,17 @@ jobs:
             chore
             docs
           scopes: |
-            fe-base
-            fe-images
-            fe-accounts
-            fe-sites
-            fe-settings
-            fe-tokens
-            be-config
-            be-settings
-            be-sites
-            be-tokens
-            be-accounts
-            be-db
-            be-images
-            docs
+            bootresources
+            dhcp
+            dns
+            network
+            power
+            proxy
+            security
+            storage
+            tftp
+            deps
             ci
-            structural
-            content
-            linting
-            links
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Verify BREAKING CHANGE in description

--- a/.github/workflows/send-mm-notification.yaml
+++ b/.github/workflows/send-mm-notification.yaml
@@ -1,0 +1,195 @@
+name: Send Mattermost notification
+
+on:
+  workflow_run:
+    workflows: [CI check]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  send-mm-notification:
+    if: ${{ github.event.workflow_run.event == 'pull_request' || github.event.workflow_run.event == 'merge_group' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download PR number artifact
+        id: pr-artifact
+        if: ${{ github.event.workflow_run.event == 'pull_request' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.ADMIN_PAT || github.token }}
+        run: |
+          ARTIFACT_ID=$(gh api \
+            "/repos/${{ github.repository }}/actions/runs/${{ github.event.workflow_run.id }}/artifacts" \
+            --jq '.artifacts[] | select(.name == "pr-number") | .id' | head -1)
+          if [ -n "$ARTIFACT_ID" ]; then
+            gh api "/repos/${{ github.repository }}/actions/artifacts/$ARTIFACT_ID/zip" > artifact.zip
+            unzip -p artifact.zip > pr-number.txt
+            echo "pr_number=$(cat pr-number.txt | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Parse preferences and send Mattermost notifications
+        uses: actions/github-script@v7
+        env:
+          MATTERMOST_WEBHOOK_URL: ${{ secrets.MATTERMOST_WEBHOOK_URL }}
+          MATTERMOST_BOT_TOKEN: ${{ secrets.MATTERMOST_BOT_TOKEN }}
+          DEFAULT_CHANNEL: ${{ vars.MM_CHANNEL }}
+          PR_NUMBER_FROM_ARTIFACT: ${{ steps.pr-artifact.outputs.pr_number }}
+        with:
+          github-token: ${{ secrets.ADMIN_PAT || github.token }}
+          script: |
+            const workflowRun = context.payload.workflow_run;
+            const state = workflowRun.conclusion === 'success' ? 'success' : 'failure';
+            const emoji = state === 'success' ? '✅' : ':notlikethis:';
+            const defaultChannel = process.env.DEFAULT_CHANNEL;
+            const promptText = 'Check where you would like a Mattermost message to be sent';
+
+            async function resolveNotificationTargets(pr) {
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number
+              });
+
+              const mattermostComment = comments.find(c => c.body && c.body.includes(promptText));
+              if (!mattermostComment) {
+                console.log('No permission comment found. Skipping.');
+                return null;
+              }
+
+              const escapedDefaultChannel = defaultChannel.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+              const wantsDM = /-\s*\[[xX]\]\s*Direct message/i.test(mattermostComment.body);
+              const wantsChannel = new RegExp(`-\\s*\\[[xX]\\]\\s*~${escapedDefaultChannel}`, 'i').test(mattermostComment.body);
+
+              if (!wantsDM && !wantsChannel) {
+                console.log('No options selected. Skipping.');
+                return null;
+              }
+
+              const targetChannels = [];
+              let extraNote = '';
+
+              if (wantsChannel) {
+                targetChannels.push(defaultChannel);
+              }
+
+              if (wantsDM) {
+                try {
+                  const { data: commitData } = await github.rest.repos.getCommit({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    ref: pr.head.sha
+                  });
+                  const email = commitData.commit.author.email;
+                  const mattermostURL = new URL(process.env.MATTERMOST_WEBHOOK_URL).origin;
+                  const mattermostResponse = await fetch(`${mattermostURL}/api/v4/users/email/${email}`, {
+                    headers: { Authorization: `Bearer ${process.env.MATTERMOST_BOT_TOKEN}` }
+                  });
+
+                  if (mattermostResponse.ok) {
+                    const mattermostUser = await mattermostResponse.json();
+                    targetChannels.push(`@${mattermostUser.username}`);
+                  } else {
+                    extraNote = `*(Note: Could not find Mattermost account for ${email}. Falling back to ~${defaultChannel})*`;
+                    if (!targetChannels.includes(defaultChannel)) targetChannels.push(defaultChannel);
+                  }
+                } catch (error) {
+                  console.error('Mattermost lookup failed:', error);
+                  extraNote = `*(Note: Mattermost user lookup failed. Falling back to ~${defaultChannel})*`;
+                  if (!targetChannels.includes(defaultChannel)) targetChannels.push(defaultChannel);
+                }
+              }
+
+              return { targetChannels, extraNote };
+            }
+
+            let statusMessage = '';
+            let targetChannels = [];
+
+            if (workflowRun.event === 'pull_request') {
+              let pullRequest = workflowRun.pull_requests[0];
+
+              if (!pullRequest) {
+                const artifactPrNumber = parseInt(process.env.PR_NUMBER_FROM_ARTIFACT || '');
+                if (!artifactPrNumber) {
+                  console.log('No pull request found. Skipping.');
+                  return;
+                }
+                pullRequest = { number: artifactPrNumber };
+                console.log(`Resolved pull request #${artifactPrNumber} from pr-number artifact.`);
+              }
+
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pullRequest.number
+              });
+
+              const result = await resolveNotificationTargets(pr);
+              if (!result) return;
+
+              ({ targetChannels } = result);
+              statusMessage = `${emoji} CI Checks for [PR #${pr.number} ${pr.title}](${pr.html_url}) finished: **${state}**.`;
+              if (result.extraNote) statusMessage += `\n${result.extraNote}`;
+
+            } else if (workflowRun.event === 'merge_group') {
+              // Merge queue branch format: gh-readonly-queue/{base}/pr-{number}-{sha}
+              const match = workflowRun.head_branch.match(/pr-(\d+)-/);
+              if (!match) {
+                console.log(`Could not extract PR number from merge queue branch: ${workflowRun.head_branch}. Skipping.`);
+                return;
+              }
+
+              const { data: pr } = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: parseInt(match[1])
+              });
+
+              const result = await resolveNotificationTargets(pr);
+              if (!result) return;
+
+              ({ targetChannels } = result);
+              const mergeOutcome = state === 'success' ? `merged to \`${pr.base.ref}\`` : 'removed from merge queue';
+              statusMessage = `${emoji} [PR #${pr.number} ${pr.title}](${pr.html_url}) ${mergeOutcome}.`;
+              if (result.extraNote) statusMessage += `\n${result.extraNote}`;
+
+            } else {
+              console.log(`Unsupported workflow_run event: ${workflowRun.event}. Skipping.`);
+              return;
+            }
+
+            targetChannels = [...new Set(targetChannels)];
+
+            if (targetChannels.length === 0) {
+              console.log('No targets resolved. Skipping.');
+              return;
+            }
+
+            console.log(`Sending notifications to: ${targetChannels.join(', ')}`);
+
+            for (const channel of targetChannels) {
+              const payload = {
+                text: statusMessage,
+                channel,
+                username: 'maasbot',
+                icon_url: 'https://launchpadlibrarian.net/91453111/Phoenix_landing-64x64.jpg'
+              };
+
+              const response = await fetch(process.env.MATTERMOST_WEBHOOK_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload)
+              });
+
+              if (!response.ok) {
+                core.setFailed(`Failed to send to ${channel}: ${response.status} ${response.statusText}`);
+                return;
+              }
+
+              console.log(`Successfully sent to ${channel}`);
+            }


### PR DESCRIPTION
Introduce two new workflows, 1. to opt-in to being notified of CI run statuses and merge events, and 2. to send those aforementioned statuses and events to your personal user and/or the default ~maas channel.

Also included is a small addition to lint commit messages against the conventional commit standard.

Duplicates the work by @wyattrees in the Site-manager repo.