### PR TITLE
fix: prevent concurrent scale-up from over-allocating RPC connections

### DIFF
--- a/src/provisioningserver/rpc/clusterservice.py
+++ b/src/provisioningserver/rpc/clusterservice.py
@@ -1035,9 +1035,16 @@ class ClusterClientService(TimerService):
         except exceptions.NoConnectionsAvailable:
             return self._tryUpdate().addCallback(call, self.getClient)
         except exceptions.AllConnectionsBusy:
-            return self.connections.scale_up_connections().addCallback(
-                call, self.getClient, busy_ok=True
+            return self.connections.scale_up_connections().addErrback(
+                self._handle_scale_up_failure
             )
+
+    def _handle_scale_up_failure(self, failure):
+        """If scale-up fails, fall back to returning a busy connection."""
+        log.warn(
+            f"Failed to scale up due to {failure}. Falling back to a busy connection."
+        )
+        return self.getClient(busy_ok=True)
 
     def getAllClients(self):
         """Return a list of all connected :class:`common.Client`s."""

--- a/src/provisioningserver/rpc/connectionpool.py
+++ b/src/provisioningserver/rpc/connectionpool.py
@@ -1,4 +1,4 @@
-# Copyright 2022 Canonical Ltd.  This software is licensed under the
+# Copyright 2022-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 """ RPC Connection Pooling and Lifecycle """
@@ -10,9 +10,13 @@ from twisted.internet.endpoints import connectProtocol, TCP6ClientEndpoint
 
 from provisioningserver.prometheus.metrics import PROMETHEUS_METRICS
 from provisioningserver.rpc import exceptions
+from provisioningserver.rpc.common import Client
 
 
 class ConnectionPool:
+    # Maximum time in seconds to wait for a scale-up connection handshake before giving up and releasing the pending slot.
+    SCALE_UP_TIMEOUT = 30
+
     def __init__(
         self, reactor, service, max_idle_conns=1, max_conns=1, keepalive=1000
     ):
@@ -25,6 +29,10 @@ class ConnectionPool:
 
         self.connections = {}
         self.try_connections = {}
+        # Track in-flight scale-up connections to prevent race conditions
+        # where concurrent callers all pass the capacity check before any
+        # connection handshake completes (LP:2074122).
+        self._pending_connections = {}
         self.clock = reactor
         self._service = service
 
@@ -66,7 +74,10 @@ class ConnectionPool:
             self.disconnect(conn)
             return self.remove_connection(eventloop, conn)
         return self.clock.callLater(
-            self._keepalive, self._reap_extra_connection, eventloop, conn
+            self._keepalive / 1000,  # callLater expects seconds!
+            self._reap_extra_connection,
+            eventloop,
+            conn,
         )
 
     def is_staged(self, eventloop):
@@ -84,16 +95,47 @@ class ConnectionPool:
     @PROMETHEUS_METRICS.failure_counter("maas_rpc_pool_exhaustion_count")
     @inlineCallbacks
     def scale_up_connections(self):
+        """Spawn one additional connection to a region event loop and return a client using that new connection.
+
+        Finds the first event loop with capacity for another connection, clones an existing connection to it, and waits for the handshake to complete.
+
+        A pending counter prevents concurrent callers from exceeding _max_connections while handshakes are in flight.
+
+        Ephemeral connections are reaped after _keepalive if not in use.
+
+        :raises MaxConnectionsOpen: When all event loops are at capacity or when the new connection fails to become ready.
+        """
         for ev, ev_conns in self.connections.items():
-            # pick first group with room for additional conns
-            if len(ev_conns) < self._max_connections:
-                # spawn an extra connection
-                conn_to_clone = random.choice(list(ev_conns))
-                conn = yield self.connect(ev, conn_to_clone.address)
-                self.clock.callLater(
-                    self._keepalive, self._reap_extra_connection, ev, conn
-                )
-                return
+            pending = self._pending_connections.get(ev, 0)
+            # Account for both established and in-flight connections
+            if len(ev_conns) + pending < self._max_connections:
+                self._pending_connections[ev] = pending + 1
+                conn = None
+                try:
+                    conn_to_clone = random.choice(list(ev_conns))
+                    conn = yield self.connect(ev, conn_to_clone.address)
+                    # Wait for the full handshake (auth + registration) to
+                    # complete so the connection is in the pool before we
+                    # release the pending slot.
+                    yield conn.ready.get(timeout=self.SCALE_UP_TIMEOUT)
+                    self.clock.callLater(
+                        self._keepalive / 1000,  # callLater expects seconds!
+                        self._reap_extra_connection,
+                        ev,
+                        conn,
+                    )
+                except Exception as e:
+                    # clean up and let the caller handle the case.
+                    if conn is not None:
+                        self.disconnect(conn)
+                    raise exceptions.MaxConnectionsOpen(
+                        "Scale-up connection failed to become ready"
+                    ) from e
+                finally:
+                    self._pending_connections[ev] -= 1
+                    if self._pending_connections[ev] == 0:
+                        del self._pending_connections[ev]
+                return Client(conn)
         raise exceptions.MaxConnectionsOpen()
 
     def get_connection(self, eventloop):

--- a/src/provisioningserver/rpc/tests/test_clusterservice.py
+++ b/src/provisioningserver/rpc/tests/test_clusterservice.py
@@ -78,6 +78,7 @@ from provisioningserver.rpc.clusterservice import (
     get_scan_all_networks_args,
     spawnProcessAndNullifyStdout,
 )
+from provisioningserver.rpc.common import Client
 from provisioningserver.rpc.interfaces import IConnection
 from provisioningserver.rpc.testing import (
     call_responder,
@@ -1059,7 +1060,7 @@ class TestClusterClientService(MAASTestCase):
                 if len(conns) < service.connections._max_connections:
                     conn = yield service.connections.connect()
                     service.connections[ev].append(conn)
-                    break
+                    return Client(conn)
 
         scale_up = self.patch(service.connections, "scale_up_connections")
         scale_up.side_effect = mock_scale_up_connections

--- a/src/provisioningserver/rpc/tests/test_connectionpool.py
+++ b/src/provisioningserver/rpc/tests/test_connectionpool.py
@@ -1,9 +1,14 @@
-# Copyright 2022 Canonical Ltd.  This software is licensed under the
+# Copyright 2022-2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 from unittest.mock import Mock, PropertyMock
 
-from twisted.internet.defer import inlineCallbacks, succeed
+from twisted.internet.defer import (
+    CancelledError,
+    Deferred,
+    inlineCallbacks,
+    succeed,
+)
 from twisted.internet.task import Clock
 
 from maastesting import get_testing_timeout
@@ -88,7 +93,7 @@ class TestConnectionPool(MAASTestCase):
         self.assertEqual(
             "_reap_extra_connection", clock.calls[0].func.__name__
         )
-        self.assertEqual(cp._keepalive, clock.calls[0].time)
+        self.assertEqual(cp._keepalive / 1000, clock.calls[0].time)
 
     def test_is_staged(self):
         cp = ConnectionPool(Clock(), Mock())
@@ -343,3 +348,66 @@ class TestConnectionPool(MAASTestCase):
         cp.connections[eventloop] = [connection]
         cp.remove_connection(eventloop, connection)
         self.assertEqual(cp.connections, {})
+
+    def test_scale_up_connections_prevents_concurrent_over_allocation(self):
+        """Concurrent calls to scale_up_connections must not exceed max_conns.
+
+        When the connect handshake is pending, subsequent calls should see the in-flight connection and refuse to open another one.
+        """
+        cp = ConnectionPool(Clock(), Mock(), max_conns=2)
+        eventloop = Mock()
+        connection1 = Mock()
+        connection1.address = (factory.make_ip_address(), 5240)
+        cp[eventloop] = [connection1]
+
+        # Simulate a pending connection that is not becoming ready.
+        ready_deferred = Deferred()
+        new_conn = Mock()
+        new_conn.ready.get.return_value = ready_deferred
+
+        connect = self.patch(cp, "connect")
+        connect.return_value = succeed(new_conn)
+        self.patch(connectionpoolModule, "Client")
+
+        # First call: simulate a pending connection waiting to become ready.
+        d1 = cp.scale_up_connections()
+        self.assertEqual(cp._pending_connections[eventloop], 1)
+
+        # Second call: should raise MaxConnectionsOpen because established (1) + pending (1) == max_conns (2).
+        self.assertRaises(
+            exceptions.MaxConnectionsOpen,
+            extract_result,
+            cp.scale_up_connections(),
+        )
+
+        # Unblock the first call
+        ready_deferred.callback(eventloop)
+        extract_result(d1)
+
+        # After the first call completes, pending count is cleared.
+        self.assertNotIn(eventloop, cp._pending_connections)
+
+    def test_scale_up_connections_clears_pending_on_timeout(self):
+        """If the new connection does not work for some reasons (for example, due to CancelledError while waiting for the connection to become ready), pending is cleared and MaxConnectionsOpen is raised."""
+        cp = ConnectionPool(Clock(), Mock(), max_conns=2)
+        eventloop = Mock()
+        connection1 = Mock()
+        connection1.address = (factory.make_ip_address(), 5240)
+        cp[eventloop] = [connection1]
+
+        ready_deferred = Deferred()
+        new_conn = Mock()
+        new_conn.ready.get.return_value = ready_deferred
+
+        connect = self.patch(cp, "connect")
+        connect.return_value = succeed(new_conn)
+        disconnect = self.patch(cp, "disconnect")
+
+        d1 = cp.scale_up_connections()
+        self.assertEqual(cp._pending_connections[eventloop], 1)
+
+        ready_deferred.errback(CancelledError())
+
+        self.assertRaises(exceptions.MaxConnectionsOpen, extract_result, d1)
+        self.assertNotIn(eventloop, cp._pending_connections)
+        disconnect.assert_called_once_with(new_conn)


### PR DESCRIPTION
The previous implementatino of `scale_up_connections` was not taking
into account that new connections have to go through a long-complex
asynchronous process before becoming available. This lead concurrent
calls to scale up connections without limit, because all the calls were
evaluating `len(conns) < max_connections` as true, without taking into
consideration the pending connections.

With this change, `scale_up_connections` tracks in-flight connections
with a pending counter and wait for these connections to become ready
(with a 30s timeout) before releasing the slot.

In addition to that, `_reap_extra_connection` is now called with a
timeout `_keepalive / 1000` because `keepalive` is in milliseconds, but
`callLater` expects seconds.

Resolves: LP:2074122

(cherry-picked from 6fc05cb47935ea20a1bdec90d1825a13af2389e8)