### PR TITLE
chore: automate dev setup using workshop

### DIFF
--- a/.workshop/maas-build/hooks/setup-base
+++ b/.workshop/maas-build/hooks/setup-base
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "#################################"
+echo "Installing the MAAS test database"
+if command -v snap >/dev/null 2>&1; then
+    snap install maas-test-db --channel=latest/edge
+else
+    echo "snap command not available, skipping maas-test-db installation"
+    echo "You can install it later with: snap install maas-test-db --channel=latest/edge"
+fi
+
+echo "..done"

--- a/.workshop/maas-build/hooks/setup-project
+++ b/.workshop/maas-build/hooks/setup-project
@@ -1,0 +1,84 @@
+#!/bin/bash
+set -euo pipefail
+
+cd /project
+
+# The .ve venv may have been created on the host with hardcoded paths
+# that don't exist inside the container (/home/... vs /project/).
+# Remove it so make build recreates it with the correct container paths.
+if [ -d .ve ] && head -1 .ve/bin/python3 2>/dev/null | grep -qv '/project/'; then
+    echo "###############################"
+    echo "Recreating venv for container paths"
+    rm -rf .ve
+fi
+
+echo "####################################"
+echo "Building MAAS"
+make build
+
+echo "#######################"
+echo "Building Go binaries"
+make go-bins
+
+echo "#######################"
+echo "Unpacking the snap tree"
+if command -v snap >/dev/null 2>&1; then
+    make snap-tree
+    echo "###########################"
+    echo "Syncing built files into snap tree"
+    # Use sudo because snap-tree-sync runs clean-agent/clean-openfga
+    # which may need to remove root-owned files from a previous snap try
+    sudo make snap-tree-sync
+    echo "###########################"
+    echo "Installing MAAS snap (try)"
+    sudo snap try /project/dev-snap/tree
+    echo "##########################"
+    echo "Connecting snap interfaces"
+    /project/utilities/connect-snap-interfaces || echo "Warning: Some snap interfaces could not be connected"
+    echo "#######################"
+    echo "Restarting MAAS snap"
+    sudo snap restart maas
+else
+    echo "snap not available, skipping snap tree build and interface connections"
+fi
+
+echo "#####################"
+echo "Starting the database"
+container_ip=$(hostname -I | cut -d' ' -f1)
+if command -v maas >/dev/null 2>&1; then
+    sudo maas init region+rack --maas-url="http://${container_ip}:5240/MAAS" --database-uri maas-test-db:///
+
+    echo "##########################"
+    echo "Creating a MAAS admin user"
+    sudo maas createadmin --username maas --password maas --email maas@example.com
+
+    echo "###########################"
+    echo "Waiting for MAAS API to be ready"
+    declare -i maas_up=1
+    while [ $maas_up -ne 0 ]; do
+        if curl -sf "http://${container_ip}:5240/MAAS/api/2.0/version/" > /dev/null 2>&1; then
+            maas login admin "http://${container_ip}:5240/MAAS/api/2.0/" $(sudo maas apikey --username=maas)
+            maas_up=$?
+        else
+            echo "Retrying in 5 seconds..."
+            sleep 5
+        fi
+    done
+else
+    echo "maas command not available, skipping MAAS initialization"
+    echo "You can initialize MAAS later with: workshop run init-maas"
+fi
+
+echo
+echo "#################################################################"
+echo "MAAS dev environment setup complete!"
+echo "  Access MAAS at: http://${container_ip}:5240"
+echo "  username: maas"
+echo "  password: maas"
+echo
+echo "To connect your host LXD for VM provisioning:"
+echo "  1. Go to http://${container_ip}:5240/MAAS/r/kvm/lxd"
+echo "  2. Click maas-host -> KVM host settings -> Download certificate"
+echo "  3. Run: lxc config trust add <path/to/certificate>"
+echo "  4. Click 'Refresh host'"
+echo

--- a/.workshop/maas-build/hooks/setup-project
+++ b/.workshop/maas-build/hooks/setup-project
@@ -18,6 +18,11 @@ make build
 
 echo "#######################"
 echo "Building Go binaries"
+# Allow Go to auto-download the required toolchain version when the
+# installed SDK version is older than what go.mod requires (e.g. go.mod
+# requires go >= 1.26 but the SDK provides 1.24). The Workshop go SDK
+# sets GOTOOLCHAIN=local by default, which prevents auto-downloading.
+export GOTOOLCHAIN=auto
 make go-bins
 
 echo "#######################"

--- a/.workshop/maas-build/hooks/setup-project
+++ b/.workshop/maas-build/hooks/setup-project
@@ -14,16 +14,12 @@ fi
 
 echo "####################################"
 echo "Building MAAS"
-make build
-
-echo "#######################"
-echo "Building Go binaries"
 # Allow Go to auto-download the required toolchain version when the
 # installed SDK version is older than what go.mod requires (e.g. go.mod
 # requires go >= 1.26 but the SDK provides 1.24). The Workshop go SDK
 # sets GOTOOLCHAIN=local by default, which prevents auto-downloading.
 export GOTOOLCHAIN=auto
-make go-bins
+make build
 
 echo "#######################"
 echo "Setting up the snap tree"
@@ -47,9 +43,6 @@ if command -v snap >/dev/null 2>&1; then
     echo "##########################"
     echo "Connecting snap interfaces"
     /project/utilities/connect-snap-interfaces || echo "Warning: Some snap interfaces could not be connected"
-    echo "#######################"
-    echo "Restarting MAAS snap"
-    sudo snap restart maas
 else
     echo "snap not available, skipping snap tree setup"
 fi

--- a/.workshop/maas-build/hooks/setup-project
+++ b/.workshop/maas-build/hooks/setup-project
@@ -34,9 +34,7 @@ if command -v snap >/dev/null 2>&1; then
     fi
     echo "###########################"
     echo "Syncing built files into snap tree"
-    # Use sudo because snap-tree-sync runs clean-agent/clean-openfga
-    # which may need to remove root-owned files from a previous snap try
-    sudo make snap-tree-sync
+    make snap-tree-sync
     echo "###########################"
     echo "Installing MAAS snap (try)"
     sudo snap try /project/dev-snap/tree

--- a/.workshop/maas-build/hooks/setup-project
+++ b/.workshop/maas-build/hooks/setup-project
@@ -26,9 +26,16 @@ export GOTOOLCHAIN=auto
 make go-bins
 
 echo "#######################"
-echo "Unpacking the snap tree"
+echo "Setting up the snap tree"
 if command -v snap >/dev/null 2>&1; then
-    make snap-tree
+    # The snap tree must be built on the host (make snap-tree calls
+    # snapcraft pack which needs LXD, and lxdbr0 conflicts inside
+    # the container). Just verify the tree exists and sync into it.
+    if [ ! -d dev-snap/tree ]; then
+        echo "ERROR: dev-snap/tree not found. Run 'make snap-tree' on the host first."
+        echo "Or run 'make dev-env' which builds it automatically."
+        exit 1
+    fi
     echo "###########################"
     echo "Syncing built files into snap tree"
     # Use sudo because snap-tree-sync runs clean-agent/clean-openfga
@@ -44,7 +51,7 @@ if command -v snap >/dev/null 2>&1; then
     echo "Restarting MAAS snap"
     sudo snap restart maas
 else
-    echo "snap not available, skipping snap tree build and interface connections"
+    echo "snap not available, skipping snap tree setup"
 fi
 
 echo "#####################"

--- a/.workshop/maas-build/sdk.yaml
+++ b/.workshop/maas-build/sdk.yaml
@@ -1,0 +1,12 @@
+name: maas-build
+version: "0.1"
+summary: MAAS dev environment build and runtime
+description: |
+  Builds MAAS from source, sets up the snap tree, and provides
+  the runtime environment for MAAS development.
+platforms:
+  amd64:
+slots:
+  maas-ui:
+    interface: tunnel
+    endpoint: 5240

--- a/.workshop/maas-deps/hooks/setup-base
+++ b/.workshop/maas-deps/hooks/setup-base
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "######################################"
+echo "Adding MAAS PPA"
+
+apt-get update
+apt-get install -y --no-install-recommends software-properties-common gpg-agent
+add-apt-repository -y ppa:maas-committers/latest-deps
+
+echo "############################################"
+echo "Disabling conflicting system services"
+if command -v systemctl >/dev/null 2>&1; then
+    for service in named postgresql isc-dhcp-server; do
+        if systemctl is-active "$service" >/dev/null 2>&1; then
+            systemctl stop "$service" || true
+        fi
+        if systemctl is-enabled "$service" 2>/dev/null; then
+            systemctl disable "$service" || true
+        fi
+    done
+
+    # nginx was removed between 3.6 and 3.7
+    if dpkg --list 2>/dev/null | grep -q nginx-core; then
+        systemctl stop nginx 2>/dev/null || true
+        systemctl disable nginx 2>/dev/null || true
+    fi
+else
+    echo "systemctl not available, skipping service management"
+fi
+
+echo "..done"

--- a/.workshop/maas-deps/hooks/setup-project
+++ b/.workshop/maas-deps/hooks/setup-project
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -euo pipefail
+
+cd /project
+
+echo "######################################"
+echo "Installing MAAS build dependencies"
+sudo apt build-dep -y . 2>/dev/null || sudo apt-get build-dep -y maas 2>/dev/null || echo "Warning: Could not install build-deps, continuing with explicit package list"
+
+echo "Installing base packages..."
+base_packages=$(sort -u /project/required-packages/base | sed '/^\#/d')
+dev_packages=$(sort -u /project/required-packages/dev | sed '/^\#/d')
+
+# Install packages, skipping any that aren't available in the repos
+available_packages=""
+unavailable_packages=""
+for pkg in $base_packages $dev_packages; do
+    if apt-cache show "$pkg" >/dev/null 2>&1; then
+        available_packages="$available_packages $pkg"
+    else
+        unavailable_packages="$unavailable_packages $pkg"
+    fi
+done
+
+if [ -n "$unavailable_packages" ]; then
+    echo "Warning: Skipping unavailable packages (will be installed via pip during build):$unavailable_packages"
+fi
+
+if [ -n "$available_packages" ]; then
+    sudo apt-get install -y --no-install-recommends $available_packages
+else
+    echo "Warning: No packages available to install"
+fi
+
+echo "Purging forbidden packages..."
+forbidden_packages=$(sort -u /project/required-packages/forbidden | sed '/^\#/d')
+sudo apt-get purge -y $forbidden_packages 2>/dev/null || true
+
+echo "Installing snaps..."
+if command -v snap >/dev/null 2>&1; then
+    while IFS= read -r line; do
+        # Skip comments and empty lines
+        [[ "$line" =~ ^#.*$ ]] && continue
+        [[ -z "$line" ]] && continue
+        # Split package name from flags
+        pkg=$(echo "$line" | awk '{print $1}')
+        flags=$(echo "$line" | awk '{$1=""; print $0}' | sed 's/^ *//')
+        if [ -n "$flags" ]; then
+            sudo snap install "$pkg" $flags 2>/dev/null || echo "Warning: Failed to install snap: $pkg $flags"
+        else
+            sudo snap install "$pkg" 2>/dev/null || echo "Warning: Failed to install snap: $pkg"
+        fi
+    done < /project/required-packages/snaps
+else
+    echo "snap command not available, skipping snap installation"
+fi
+
+echo "######################################"
+echo "Configuring workshop user environment"
+
+cat >> ~/.bashrc <<'EOF'
+
+# MAAS dev aliases
+alias c='clear'
+alias format='make format-py && make lint-py && make lint-py-imports'
+alias start='make format-py && make lint-py && make snap-tree-sync && sudo snap restart maas'
+alias logs='journalctl -u snap.maas.pebble.service -f -t maas-apiserver'
+alias test='./bin/pytest'
+alias testr='./bin/test.region'
+EOF
+
+echo "..done"

--- a/.workshop/maas-deps/hooks/setup-project
+++ b/.workshop/maas-deps/hooks/setup-project
@@ -45,6 +45,13 @@ if command -v snap >/dev/null 2>&1; then
         # Split package name from flags
         pkg=$(echo "$line" | awk '{print $1}')
         flags=$(echo "$line" | awk '{$1=""; print $0}' | sed 's/^ *//')
+        # Skip snapcraft — it cannot be used inside the workshop container
+        # (snapcraft pack needs LXD which conflicts with the host bridge).
+        # The snap tree is built on the host instead.
+        if [ "$pkg" = "snapcraft" ]; then
+            echo "Skipping snapcraft (only needed on host for 'make snap-tree')"
+            continue
+        fi
         if [ -n "$flags" ]; then
             sudo snap install "$pkg" $flags 2>/dev/null || echo "Warning: Failed to install snap: $pkg $flags"
         else

--- a/.workshop/maas-deps/sdk.yaml
+++ b/.workshop/maas-deps/sdk.yaml
@@ -1,0 +1,8 @@
+name: maas-deps
+version: "0.1"
+summary: MAAS development dependencies
+description: |
+  Installs all system packages, snaps, and service configurations
+  required for MAAS development.
+platforms:
+  amd64:

--- a/.workshop/maas-setup/hooks/setup-base
+++ b/.workshop/maas-setup/hooks/setup-base
@@ -1,2 +1,0 @@
-apt-get update
-apt-get install make

--- a/.workshop/maas-setup/hooks/setup-project
+++ b/.workshop/maas-setup/hooks/setup-project
@@ -1,1 +1,0 @@
-make install-dependencies

--- a/.workshop/maas-setup/sdk.yaml
+++ b/.workshop/maas-setup/sdk.yaml
@@ -1,4 +1,0 @@
-# For details: https://canonical-workshop.readthedocs-hosted.com/latest/explanation/sdks/sdks/#sketch-sdk
-name: maas-setup
-plugs:
-slots:

--- a/Makefile
+++ b/Makefile
@@ -561,7 +561,7 @@ dev-env:
 	@# which can't run inside the workshop container (lxdbr0 conflicts).
 	@if [ ! -f dev-snap/tree.marker ]; then \
 		echo "Building snap tree on host (requires LXD)..."; \
-		make snap-tree; \
+		sudo make snap-tree; \
 	fi
 	workshop launch --verbose
 	@echo ""

--- a/Makefile
+++ b/Makefile
@@ -549,6 +549,20 @@ cli-docs: cli-docs-introspect
 #
 
 dev-env:
+	@# Clean root-owned build dirs that may remain from a previous snap try.
+	@# These cause "permission denied" when the workshop user tries to rebuild.
+	@for d in src/maasagent/build src/host-info/bin src/maasopenfga/build; do \
+		if [ -d "$$d" ] && [ ! -w "$$d" ]; then \
+			echo "Removing root-owned directory: $$d"; \
+			sudo rm -rf "$$d"; \
+		fi; \
+	done
+	@# Build the snap tree on the host first. snapcraft pack needs LXD,
+	@# which can't run inside the workshop container (lxdbr0 conflicts).
+	@if [ ! -f dev-snap/tree.marker ]; then \
+		echo "Building snap tree on host (requires LXD)..."; \
+		make snap-tree; \
+	fi
 	workshop launch --verbose
 	@echo ""
 	@echo "MAAS dev environment is ready!"

--- a/Makefile
+++ b/Makefile
@@ -259,6 +259,7 @@ lint-shell:
 		utilities/run-performanced \
 		utilities/run-py-tests-ci \
 		utilities/schemaspy \
+		utilities/setup-dev-networks \
 		utilities/update-initial-sql \
 		utilities/version-bump.sh
 .PHONY: lint-shell
@@ -542,3 +543,30 @@ cli-docs-generate:
 cli-docs: cli-docs-introspect
 	@$(if $(CHECK_DOCSTRING_SYNC),,$(MAKE) cli-docs-generate)
 .PHONY: cli-docs
+
+#
+# Workshop dev environment
+#
+
+dev-env:
+	workshop launch --verbose
+	@echo ""
+	@echo "MAAS dev environment is ready!"
+	@echo "Access MAAS at: http://localhost:5240"
+	@echo "  username: maas"
+	@echo "  password: maas"
+	@echo ""
+	@echo "Useful commands:"
+	@echo "  workshop shell        - Open a shell in the workshop"
+	@echo "  workshop run restart  - Restart MAAS"
+	@echo "  workshop run logs     - View MAAS logs"
+	@echo "  workshop run test     - Run Python tests"
+.PHONY: dev-env
+
+dev-networks:
+	@utilities/setup-dev-networks
+.PHONY: dev-networks
+
+dev-env-clean:
+	workshop remove
+.PHONY: dev-env-clean

--- a/utilities/setup-dev-networks
+++ b/utilities/setup-dev-networks
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# Setup LXD networks for MAAS VM provisioning.
+# This script is idempotent — if any network already exists, it is skipped.
+#
+# Creates the following networks:
+#   maas-ctrl       - 10.10.0.1/24 (DHCP enabled, NAT)
+#   maas-kvm        - 10.20.0.1/24 (no DHCP, NAT)
+#   maas-ipv6       - fd42:be3f:b08a:3d6c::1/64 (IPv6 only, NAT)
+#   maas-dual-stack - 10.30.0.1/24 + fd42:be3f:b08b:3d6d::1/64 (dual stack, NAT)
+
+set -euo pipefail
+
+network_exists() {
+    lxc network list --format csv | cut -d',' -f1 | grep -qxF "$1"
+}
+
+echo "###############################"
+echo "Setting up LXD networks for MAAS VM provisioning"
+
+# maas-ctrl
+if network_exists maas-ctrl; then
+    echo "Network maas-ctrl already exists, skipping"
+else
+    echo "Creating maas-ctrl network..."
+    lxc network create maas-ctrl
+    cat <<EOF | lxc network edit maas-ctrl
+config:
+  dns.domain: maas-ctrl
+  ipv4.address: 10.10.0.1/24
+  ipv4.dhcp: "true"
+  ipv4.dhcp.ranges: 10.10.0.16-10.10.0.31
+  ipv4.nat: "true"
+  ipv6.address: none
+description: ""
+name: maas-ctrl
+type: bridge
+used_by: []
+managed: true
+status: Created
+locations:
+- none
+EOF
+fi
+
+# maas-kvm
+if network_exists maas-kvm; then
+    echo "Network maas-kvm already exists, skipping"
+else
+    echo "Creating maas-kvm network..."
+    lxc network create maas-kvm
+    cat <<EOF | lxc network edit maas-kvm
+config:
+  ipv4.address: 10.20.0.1/24
+  ipv4.dhcp: "false"
+  ipv4.nat: "true"
+  ipv6.address: none
+description: ""
+name: maas-kvm
+type: bridge
+used_by: []
+managed: true
+status: Created
+locations:
+- none
+EOF
+fi
+
+# maas-ipv6
+if network_exists maas-ipv6; then
+    echo "Network maas-ipv6 already exists, skipping"
+else
+    echo "Creating maas-ipv6 network..."
+    lxc network create maas-ipv6
+    cat <<EOF | lxc network edit maas-ipv6
+config:
+  ipv4.address: none
+  ipv6.address: fd42:be3f:b08a:3d6c::1/64
+  ipv6.dhcp: "false"
+  ipv6.nat: "true"
+description: "An IPv6 only network"
+name: maas-ipv6
+type: bridge
+used_by: []
+managed: true
+status: Created
+locations:
+- none
+EOF
+fi
+
+# maas-dual-stack
+if network_exists maas-dual-stack; then
+    echo "Network maas-dual-stack already exists, skipping"
+else
+    echo "Creating maas-dual-stack network..."
+    lxc network create maas-dual-stack
+    cat <<EOF | lxc network edit maas-dual-stack
+config:
+  ipv4.address: 10.30.0.1/24
+  ipv4.nat: "true"
+  ipv4.dhcp: "false"
+  ipv6.address: fd42:be3f:b08b:3d6d::1/64
+  ipv6.nat: "true"
+  ipv6.dhcp: "false"
+description: "A dual stack (IPv4 and IPv6) network"
+name: maas-dual-stack
+type: bridge
+used_by: []
+managed: true
+status: Created
+locations:
+- none
+EOF
+fi
+
+echo "################################"
+echo "Setting LXD HTTPS address to 8443"
+current_addr=$(lxc config get core.https_address 2>/dev/null || echo "")
+if [ "$current_addr" = "[::]:8443" ] || [ "$current_addr" = ":8443" ]; then
+    echo "LXD HTTPS address already set, skipping"
+else
+    lxc config set core.https_address '[::]:8443'
+fi
+
+echo
+echo "LXD networks for MAAS are ready!"
+echo "  maas-ctrl:       10.10.0.1/24 (DHCP enabled)"
+echo "  maas-kvm:        10.20.0.1/24 (no DHCP)"
+echo "  maas-ipv6:       fd42:be3f:b08a:3d6c::1/64"
+echo "  maas-dual-stack: 10.30.0.1/24 + fd42:be3f:b08b:3d6d::1/64"

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -17,7 +17,7 @@ actions:
   build: |
     export GOTOOLCHAIN=auto
     make build
-    sudo make snap-tree-sync
+    make snap-tree-sync
     sudo snap restart maas
   restart: |
     sudo snap restart maas

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -1,4 +1,37 @@
 name: dev
 base: ubuntu@26.04
 sdks:
-  - name: project-maas-setup
+  - name: go
+    channel: 1.24/stable
+  - name: project-maas-deps
+  - name: project-maas-build
+  - name: system
+    plugs:
+      maas-ui:
+        interface: tunnel
+        endpoint: 5240
+connections:
+  - plug: system:maas-ui
+    slot: maas-build:maas-ui
+actions:
+  build: |
+    make build
+    make go-bins
+    make snap-tree-sync
+    sudo snap restart maas
+  restart: |
+    sudo snap restart maas
+  logs: |
+    journalctl -u snap.maas.pebble.service -f -t maas-apiserver
+  test: |
+    ./bin/pytest "$@"
+  test-region: |
+    ./bin/test.region "$@"
+  lint: |
+    make lint
+  format: |
+    make format-py
+  init-maas: |
+    container_ip=$(hostname -I | cut -d' ' -f1)
+    sudo maas init region+rack --maas-url="http://${container_ip}:5240/MAAS" --database-uri maas-test-db:///
+    sudo maas createadmin --username maas --password maas --email maas@example.com

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -2,7 +2,7 @@ name: dev
 base: ubuntu@26.04
 sdks:
   - name: go
-    channel: 1.24/stable
+    channel: 1.26/stable
   - name: project-maas-deps
   - name: project-maas-build
   - name: system

--- a/workshop.yaml
+++ b/workshop.yaml
@@ -15,9 +15,9 @@ connections:
     slot: maas-build:maas-ui
 actions:
   build: |
+    export GOTOOLCHAIN=auto
     make build
-    make go-bins
-    make snap-tree-sync
+    sudo make snap-tree-sync
     sudo snap restart maas
   restart: |
     sudo snap restart maas


### PR DESCRIPTION
The goal is to simplify the dev environment setup using workshop, so that with one command we can set everything up. This will set up a workshop (LXD) container with a working MAAS development environment that is automatically mounted from the host filesystem.

### Prerequisites

You can try this out on your host, or through a virtual machine. If you are skeptical and don't want to install workshop or change the LXD version on your host machine, use these steps to set up a LXD VM (doesn't work with LXD containers unfortunately). If you intend to test using your host, you can skip steps 1 and 2.
1. Launch a Noble VM
```bash
lxc launch ubuntu:24.04 workshop-maas-dev --vm --config limits.cpu=4 --config limits.memory=8GiB
```
2. Open a shell into the VM, and switch to the ubuntu user
```bash
lxc shell workshop-maas-dev
su - ubuntu
```
(Common steps below ... )
Install (or refresh) the correct LXD version:
```bash
sudo snap install lxd --channel=6/stable
```

Install workshop
```bash
sudo snap install workshop --classic
```

And finally, clone this branch. If you are running these steps from a VM:
```bash
git clone https://github.com/canonical/maas
cd maas
git fetch origin pull/281/head:workshop-dev-setup
git switch workshop-dev-setup
```

If running from the host, make sure you switch to this branch before proceeding.

### Test out the workshop
- Run `make dev-env`
- Have a cup of coffee while the set up completes
- Ensure a workshop 26.04 lxd container is launched and your dev environment is set up
- If everything works, you should be able to access MAAS at "http://localhost:5240/MAAS" (or at `http://<CONTAINER_IP>:5240/MAAS` if testing with a VM) with the admin credentials
- Open a shell into the container: `workshop shell`
- Run `format` (it is just a useful alias that I often use and I've added it here
- Try running some pytests with `test <path_to_file>` (again, an alias for `./bin/pytest`)
- If you encounter any issues, please leave comments with logs so that I can investigate the issue

### Tear everything down
- Run `make dev-env-clean` or `workshop remove`
- If you performed these steps in a VM, you can:
```bash
lxc delete -f workshop-maas-dev
```