### PR TITLE
fix: lp2138223 subnet deletion ip check

### DIFF
--- a/src/maasapiserver/v3/api/public/handlers/subnets.py
+++ b/src/maasapiserver/v3/api/public/handlers/subnets.py
@@ -3,11 +3,12 @@
 
 from typing import Union
 
-from fastapi import Depends, Header, Response, status
+from fastapi import Depends, Header, Query, Response, status
 
 from maasapiserver.common.api.base import Handler, handler
 from maasapiserver.common.api.models.responses.errors import (
     NotFoundBodyResponse,
+    PreconditionFailedBodyResponse,
 )
 from maasapiserver.v3.api import services
 from maasapiserver.v3.api.public.models.requests.query import PaginationParams
@@ -285,6 +286,7 @@ class SubnetsHandler(Handler):
         responses={
             204: {},
             404: {"model": NotFoundBodyResponse},
+            412: {"model": PreconditionFailedBodyResponse},
         },
         response_model_exclude_none=True,
         status_code=204,
@@ -304,6 +306,10 @@ class SubnetsHandler(Handler):
         etag_if_match: Union[str, None] = Header(
             alias="if-match", default=None
         ),
+        force: bool = Query(
+            description="If true, delete the subnet even if it has IP addresses in use by nodes.",
+            default=False,
+        ),
         services: ServiceCollectionV3 = Depends(services),  # noqa: B008
     ) -> Response:
         query = QuerySpec(
@@ -316,7 +322,7 @@ class SubnetsHandler(Handler):
             )
         )
         await services.subnets.delete_one(
-            query=query, etag_if_match=etag_if_match
+            query=query, etag_if_match=etag_if_match, force=force
         )
         return Response(status_code=status.HTTP_204_NO_CONTENT)
 

--- a/src/maasserver/api/subnets.py
+++ b/src/maasserver/api/subnets.py
@@ -279,6 +279,9 @@ class SubnetHandler(OperationsHandler):
 
         @param (int) "{id}" [required=true] A subnet ID.
 
+        @param (boolean) "force" [required=false] If True, delete the subnet
+        even if it has IP addresses in use by nodes. Defaults to False.
+
         @success (http-status-code) "server-success" 204
 
         @error (http-status-code) "404" 404
@@ -289,7 +292,9 @@ class SubnetHandler(OperationsHandler):
         subnet = Subnet.objects.get_subnet_or_404(
             id, request.user, NodePermission.admin
         )
-        subnet.delete()
+        subnet.delete(
+            force=get_optional_param(request.GET, "force", False, StringBool)
+        )
         return rc.DELETED
 
     @operation(idempotent=True)

--- a/src/maasserver/api/tests/test_subnets.py
+++ b/src/maasserver/api/tests/test_subnets.py
@@ -5,6 +5,7 @@
 import http.client
 import json
 import random
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.http import QueryDict
@@ -670,6 +671,42 @@ class TestSubnetAPI(APITestCase.ForUser):
         self.assertEqual(
             http.client.NOT_FOUND, response.status_code, response.content
         )
+
+    def test_delete_fails_when_ips_in_use_by_nodes(self):
+        self.become_admin()
+        node = factory.make_Node_with_Interface_on_Subnet()
+        iface = node.current_config.interface_set.first()
+        subnet = iface.vlan.subnet_set.first()
+        factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            interface=iface,
+            subnet=subnet,
+        )
+        uri = get_subnet_uri(subnet)
+        response = self.client.delete(uri)
+        self.assertEqual(
+            http.client.BAD_REQUEST, response.status_code, response.content
+        )
+        self.assertIsNotNone(reload_object(subnet))
+
+    def test_delete_with_force_succeeds_when_ips_in_use_by_nodes(self):
+        self.become_admin()
+        node = factory.make_Node_with_Interface_on_Subnet()
+        iface = node.current_config.interface_set.first()
+        subnet = iface.vlan.subnet_set.first()
+        factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            interface=iface,
+            subnet=subnet,
+        )
+        uri = get_subnet_uri(subnet)
+        response = self.client.delete(
+            uri, QUERY_STRING=urlencode({"force": "true"}, doseq=True)
+        )
+        self.assertEqual(
+            http.client.NO_CONTENT, response.status_code, response.content
+        )
+        self.assertIsNone(reload_object(subnet))
 
 
 class TestSubnetAPIAuth(APITestCase.ForAnonymous):

--- a/src/maasserver/models/subnet.py
+++ b/src/maasserver/models/subnet.py
@@ -491,7 +491,7 @@ class Subnet(CleanSave, TimestampedModel):
             and self.staticipaddress_set.filter(
                 ~Q(alloc_type=IPADDRESS_TYPE.DISCOVERED),
                 ~Q(alloc_type=IPADDRESS_TYPE.DHCP),
-                ~Q(ip__isnull=True),
+                Q(ip__isnull=False),
                 interface__isnull=False,
             ).exists()
         ):

--- a/src/maasserver/models/subnet.py
+++ b/src/maasserver/models/subnet.py
@@ -477,7 +477,7 @@ class Subnet(CleanSave, TimestampedModel):
         self.validate_gateway_ip()
         self.validate_cidr(self.id)
 
-    def delete(self, *args, **kwargs):
+    def delete(self, force=False, *args, **kwargs):
         from maasserver.models.staticipaddress import FreeIPAddress
 
         # Check if DHCP is enabled on the VLAN this subnet is attached to.
@@ -485,6 +485,19 @@ class Subnet(CleanSave, TimestampedModel):
             raise ValidationError(
                 "Cannot delete a subnet that is actively servicing a dynamic "
                 "IP range. (Delete the dynamic range or disable DHCP first.)"
+            )
+        if (
+            not force
+            and self.staticipaddress_set.filter(
+                ~Q(alloc_type=IPADDRESS_TYPE.DISCOVERED),
+                ~Q(alloc_type=IPADDRESS_TYPE.DHCP),
+                ~Q(ip__isnull=True),
+                interface__isnull=False,
+            ).exists()
+        ):
+            raise ValidationError(
+                "Cannot delete a subnet that has IP addresses in use by nodes. "
+                "(Use the 'force' parameter to override.)"
             )
         FreeIPAddress.remove_cache(self)
         super().delete(*args, **kwargs)

--- a/src/maasserver/models/tests/test_subnet.py
+++ b/src/maasserver/models/tests/test_subnet.py
@@ -744,6 +744,47 @@ class TestSubnet(MAASServerTestCase):
             ):
                 subnet.delete()
 
+    def test_cannot_delete_subnet_with_ips_in_use_by_nodes(self):
+        node = factory.make_Node_with_Interface_on_Subnet()
+        iface = node.current_config.interface_set.first()
+        subnet = iface.vlan.subnet_set.first()
+        factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            interface=iface,
+            subnet=subnet,
+        )
+        with post_commit_hooks:
+            with self.assertRaisesRegex(
+                ValidationError, "IP addresses in use by nodes"
+            ):
+                subnet.delete()
+
+    def test_can_delete_subnet_with_ips_in_use_by_nodes_when_forced(self):
+        node = factory.make_Node_with_Interface_on_Subnet()
+        iface = node.current_config.interface_set.first()
+        subnet = iface.vlan.subnet_set.first()
+        factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            interface=iface,
+            subnet=subnet,
+        )
+        with post_commit_hooks:
+            subnet.delete(force=True)
+        self.assertIsNone(reload_object(subnet))
+
+    def test_can_delete_subnet_with_discovered_ips(self):
+        node = factory.make_Node_with_Interface_on_Subnet()
+        iface = node.current_config.interface_set.first()
+        subnet = iface.vlan.subnet_set.first()
+        factory.make_StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.DISCOVERED,
+            interface=iface,
+            subnet=subnet,
+        )
+        with post_commit_hooks:
+            subnet.delete()
+        self.assertIsNone(reload_object(subnet))
+
     def test_overlapping_subnets_not_allowed(self):
         vlan = factory.make_VLAN()
         subnet = Subnet(

--- a/src/maasserver/websockets/handlers/subnet.py
+++ b/src/maasserver/websockets/handlers/subnet.py
@@ -100,7 +100,7 @@ class SubnetHandler(TimestampedModelHandler):
         assert self.user.has_perm(NodePermission.admin, subnet), (
             "Permission denied."
         )
-        subnet.delete()
+        subnet.delete(force=parameters.get("force", False))
 
     def scan(self, parameters):
         """Scan the subnet for connected neighbours.

--- a/src/maasserver/websockets/handlers/subnet.py
+++ b/src/maasserver/websockets/handlers/subnet.py
@@ -100,7 +100,7 @@ class SubnetHandler(TimestampedModelHandler):
         assert self.user.has_perm(NodePermission.admin, subnet), (
             "Permission denied."
         )
-        subnet.delete(force=parameters.get("force", False))
+        subnet.delete()
 
     def scan(self, parameters):
         """Scan the subnet for connected neighbours.

--- a/src/maasservicelayer/db/repositories/staticipaddress.py
+++ b/src/maasservicelayer/db/repositories/staticipaddress.py
@@ -67,6 +67,34 @@ class StaticIPAddressClauseFactory(ClauseFactory):
         )
 
     @classmethod
+    def with_linked_to_interface(cls) -> Clause:
+        return Clause(
+            condition=InterfaceIPAddressTable.c.interface_id.isnot(None),
+            joins=[
+                join(
+                    StaticIPAddressTable,
+                    InterfaceIPAddressTable,
+                    eq(
+                        StaticIPAddressTable.c.id,
+                        InterfaceIPAddressTable.c.staticipaddress_id,
+                    ),
+                ),
+            ],
+        )
+
+    @classmethod
+    def with_alloc_type_not_in(
+        cls, alloc_types: List[IpAddressType]
+    ) -> Clause:
+        return Clause(
+            condition=StaticIPAddressTable.c.alloc_type.notin_(alloc_types)
+        )
+
+    @classmethod
+    def with_ip_not_null(cls) -> Clause:
+        return Clause(condition=StaticIPAddressTable.c.ip.isnot(None))
+
+    @classmethod
     def with_interface_ids(cls, interface_ids: List[int]) -> Clause:
         return Clause(
             condition=InterfaceTable.c.id.in_(interface_ids),

--- a/src/maasservicelayer/exceptions/constants.py
+++ b/src/maasservicelayer/exceptions/constants.py
@@ -48,6 +48,11 @@ CANNOT_DELETE_DEFAULT_RESOURCEPOOL_VIOLATION_TYPE = (
     "CannotDeleteDefaultResourcePoolViolation"
 )
 
+# Subnets
+CANNOT_DELETE_SUBNET_WITH_IPS_IN_USE_VIOLATION_TYPE = (
+    "CannotDeleteSubnetWithIPsInUseViolation"
+)
+
 # VLANs
 CANNOT_DELETE_DEFAULT_FABRIC_VLAN_VIOLATION_TYPE = (
     "CannotDeleteDefaultFabricVlanViolation"

--- a/src/maasservicelayer/services/subnets.py
+++ b/src/maasservicelayer/services/subnets.py
@@ -5,6 +5,7 @@ from ipaddress import IPv4Address, IPv6Address
 from typing import List
 
 from maascommon.enums.dns import DnsUpdateAction
+from maascommon.enums.ipaddress import IpAddressType
 from maascommon.enums.subnet import RdnsMode
 from maascommon.workflows.dhcp import (
     CONFIGURE_DHCP_WORKFLOW_NAME,
@@ -34,7 +35,14 @@ from maasservicelayer.db.repositories.subnets import (
     SubnetClauseFactory,
     SubnetsRepository,
 )
-from maasservicelayer.exceptions.catalog import ValidationException
+from maasservicelayer.exceptions.catalog import (
+    BaseExceptionDetail,
+    PreconditionFailedException,
+    ValidationException,
+)
+from maasservicelayer.exceptions.constants import (
+    CANNOT_DELETE_SUBNET_WITH_IPS_IN_USE_VIOLATION_TYPE,
+)
 from maasservicelayer.models.base import Unset
 from maasservicelayer.models.subnets import Subnet
 from maasservicelayer.services.base import BaseService
@@ -174,6 +182,34 @@ class SubnetsService(BaseService[Subnet, SubnetsRepository, SubnetBuilder]):
 
     async def post_update_many_hook(self, resources: List[Subnet]) -> None:
         raise NotImplementedError("Not implemented yet.")
+
+    async def pre_delete_hook(self, resource_to_be_deleted: Subnet) -> None:
+        has_ips_in_use = await self.staticipaddress_service.exists(
+            query=QuerySpec(
+                where=StaticIPAddressClauseFactory.and_clauses(
+                    [
+                        StaticIPAddressClauseFactory.with_subnet_id(
+                            resource_to_be_deleted.id
+                        ),
+                        StaticIPAddressClauseFactory.with_linked_to_interface(),
+                        StaticIPAddressClauseFactory.with_alloc_type_not_in(
+                            [IpAddressType.DISCOVERED, IpAddressType.DHCP]
+                        ),
+                        StaticIPAddressClauseFactory.with_ip_not_null(),
+                    ]
+                )
+            )
+        )
+        if has_ips_in_use:
+            raise PreconditionFailedException(
+                details=[
+                    BaseExceptionDetail(
+                        type=CANNOT_DELETE_SUBNET_WITH_IPS_IN_USE_VIOLATION_TYPE,
+                        message="Cannot delete a subnet that has IP addresses in use by nodes. "
+                        "Use the 'force' flag to override.",
+                    )
+                ]
+            )
 
     async def post_delete_hook(self, resource: Subnet) -> None:
         # cascade delete

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_subnets.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_subnets.py
@@ -426,6 +426,7 @@ class TestSubnetApi(ApiCommonTests):
                 )
             ),
             etag_if_match="wrong_etag",
+            force=False,
         )
 
 

--- a/src/tests/maasservicelayer/services/test_subnets.py
+++ b/src/tests/maasservicelayer/services/test_subnets.py
@@ -643,16 +643,8 @@ class TestSubnetsService:
         dhcpsnippets_service_mock.delete_many.assert_not_called()
         nodegrouptorackcontrollers_service_mock.delete_many.assert_not_called()
 
-    @pytest.mark.parametrize(
-        "has_ips_in_use, should_raise",
-        [
-            (True, True),
-            (False, False),
-        ],
-    )
-    async def test_pre_delete_hook(
-        self, has_ips_in_use: bool, should_raise: bool
-    ) -> None:
+    @pytest.mark.parametrize("has_ips_in_use", [True, False])
+    async def test_pre_delete_hook(self, has_ips_in_use: bool) -> None:
         now = utcnow()
         subnet = Subnet(
             id=1,
@@ -690,7 +682,7 @@ class TestSubnetsService:
             ),
         )
 
-        if should_raise:
+        if has_ips_in_use:
             with pytest.raises(PreconditionFailedException) as exc_info:
                 await subnets_service.pre_delete_hook(subnet)
             assert exc_info.value.details[0].type == (

--- a/src/tests/maasservicelayer/services/test_subnets.py
+++ b/src/tests/maasservicelayer/services/test_subnets.py
@@ -193,6 +193,34 @@ class TestCommonSubnetsService(ServiceCommonTests):
             updated=now,
         )
 
+    async def test_delete_one(
+        self, service_instance, test_instance: MaasBaseModel
+    ):
+        service_instance.staticipaddress_service.exists.return_value = False
+        await super().test_delete_one(service_instance, test_instance)
+
+    async def test_delete_one_etag_match(
+        self, service_instance, test_instance: MaasBaseModel
+    ):
+        service_instance.staticipaddress_service.exists.return_value = False
+        await super().test_delete_one_etag_match(
+            service_instance, test_instance
+        )
+
+    async def test_delete_by_id(
+        self, service_instance, test_instance: MaasBaseModel
+    ):
+        service_instance.staticipaddress_service.exists.return_value = False
+        await super().test_delete_by_id(service_instance, test_instance)
+
+    async def test_delete_by_id_etag_match(
+        self, service_instance, test_instance: MaasBaseModel
+    ):
+        service_instance.staticipaddress_service.exists.return_value = False
+        await super().test_delete_by_id_etag_match(
+            service_instance, test_instance
+        )
+
     async def test_update_many(
         self, service_instance, test_instance: MaasBaseModel, builder_model
     ):

--- a/src/tests/maasservicelayer/services/test_subnets.py
+++ b/src/tests/maasservicelayer/services/test_subnets.py
@@ -36,6 +36,9 @@ from maasservicelayer.exceptions.catalog import (
     PreconditionFailedException,
     ValidationException,
 )
+from maasservicelayer.exceptions.constants import (
+    CANNOT_DELETE_SUBNET_WITH_IPS_IN_USE_VIOLATION_TYPE,
+)
 from maasservicelayer.models.base import MaasBaseModel, ResourceBuilder
 from maasservicelayer.models.subnets import Subnet
 from maasservicelayer.services import ServiceCollectionV3
@@ -376,6 +379,7 @@ class TestSubnetsService:
 
         mock_temporal = Mock(TemporalService)
         staticipaddress_service_mock = Mock(StaticIPAddressService)
+        staticipaddress_service_mock.exists.return_value = False
         ipranges_service_mock = Mock(IPRangesService)
         staticroutes_service_mock = Mock(StaticRoutesService)
         reservedips_service_mock = Mock(ReservedIPsService)
@@ -483,6 +487,7 @@ class TestSubnetsService:
 
         mock_temporal = Mock(TemporalService)
         staticipaddress_service_mock = Mock(StaticIPAddressService)
+        staticipaddress_service_mock.exists.return_value = False
         ipranges_service_mock = Mock(IPRangesService)
         staticroutes_service_mock = Mock(StaticRoutesService)
         reservedips_service_mock = Mock(ReservedIPsService)
@@ -609,3 +614,59 @@ class TestSubnetsService:
         reservedips_service_mock.delete_many.assert_not_called()
         dhcpsnippets_service_mock.delete_many.assert_not_called()
         nodegrouptorackcontrollers_service_mock.delete_many.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "has_ips_in_use, should_raise",
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    async def test_pre_delete_hook(
+        self, has_ips_in_use: bool, should_raise: bool
+    ) -> None:
+        now = utcnow()
+        subnet = Subnet(
+            id=1,
+            name="my subnet",
+            description="subnet description",
+            cidr=IPv4Network("10.0.0.0/24"),
+            rdns_mode=RdnsMode.DEFAULT,
+            gateway_ip=IPv4Address("10.0.0.1"),
+            dns_servers=[],
+            allow_dns=True,
+            allow_proxy=True,
+            active_discovery=False,
+            managed=True,
+            disabled_boot_architectures=[],
+            vlan_id=2,
+            created=now,
+            updated=now,
+        )
+
+        staticipaddress_service_mock = Mock(StaticIPAddressService)
+        staticipaddress_service_mock.exists.return_value = has_ips_in_use
+
+        subnets_service = SubnetsService(
+            context=Context(),
+            temporal_service=Mock(TemporalService),
+            staticipaddress_service=staticipaddress_service_mock,
+            ipranges_service=Mock(IPRangesService),
+            staticroutes_service=Mock(StaticRoutesService),
+            reservedips_service=Mock(ReservedIPsService),
+            subnets_repository=Mock(SubnetsRepository),
+            dhcpsnippets_service=Mock(DhcpSnippetsService),
+            dnspublications_service=Mock(DNSPublicationsService),
+            nodegrouptorackcontrollers_service=Mock(
+                NodeGroupToRackControllersService
+            ),
+        )
+
+        if should_raise:
+            with pytest.raises(PreconditionFailedException) as exc_info:
+                await subnets_service.pre_delete_hook(subnet)
+            assert exc_info.value.details[0].type == (
+                CANNOT_DELETE_SUBNET_WITH_IPS_IN_USE_VIOLATION_TYPE
+            )
+        else:
+            await subnets_service.pre_delete_hook(subnet)


### PR DESCRIPTION
Currently you are able to delete a subnet when machines still have IPs on it. Added a check to validate if nodes have IPs assigned, If they do, deletion is blocked unless you explicitly pass `force` flag. 

Resolves [lp:2138223](https://bugs.launchpad.net/maas/+bug/2138223)