### PR TITLE
fix: properly wait maas-netmon in observe-arp

### DIFF
--- a/src/provisioningserver/utils/arp.py
+++ b/src/provisioningserver/utils/arp.py
@@ -51,6 +51,5 @@ def run(args, output=sys.stdout):
     cmd = sudo(cmd)
     network_monitor = subprocess.Popen(cmd, stdout=output)
     if network_monitor is not None:
-        return_code = network_monitor.poll()
-        if return_code is not None:
-            raise SystemExit(return_code)
+        return_code = network_monitor.wait()
+        raise SystemExit(return_code)

--- a/src/provisioningserver/utils/tests/test_arp.py
+++ b/src/provisioningserver/utils/tests/test_arp.py
@@ -31,11 +31,12 @@ class TestObserveARPCommand(MAASTestCase):
         add_arguments(parser)
         args = parser.parse_args(["eth0"])
         popen = self.patch(arp_module.subprocess, "Popen")
-        popen.return_value.poll = Mock()
-        popen.return_value.poll.return_value = None
+        popen.return_value.wait = Mock()
+        popen.return_value.wait.return_value = 0
         popen.return_value.stdout = io.StringIO("{}")
         output = io.StringIO()
-        run(args, output=output)
+        with self.assertRaisesRegex(SystemExit, "0"):
+            run(args, output=output)
         popen.assert_called_once_with(
             ["sudo", "-n", "/usr/sbin/maas-netmon", "eth0"], stdout=output
         )
@@ -45,28 +46,25 @@ class TestObserveARPCommand(MAASTestCase):
         add_arguments(parser)
         args = parser.parse_args(["eth0"])
         popen = self.patch(arp_module.subprocess, "Popen")
-        popen.return_value.poll = Mock()
-        popen.return_value.poll.return_value = None
+        popen.return_value.wait = Mock()
+        popen.return_value.wait.return_value = 0
         popen.return_value.stdout = io.StringIO("{}")
         output = io.StringIO()
-        run(args, output=output)
+        with self.assertRaisesRegex(SystemExit, "0"):
+            run(args, output=output)
         popen.assert_called_once_with(
             ["sudo", "-n", "/usr/sbin/maas-netmon", "eth0"], stdout=output
         )
 
-    def test_raises_systemexit_poll_result(self):
+    def test_raises_systemexit_on_wait(self):
         parser = ArgumentParser()
         add_arguments(parser)
         args = parser.parse_args(["eth0"])
         popen = self.patch(arp_module.subprocess, "Popen")
-        popen.return_value.poll = Mock()
-        popen.return_value.poll.return_value = None
+        popen.return_value.wait = Mock()
+        popen.return_value.wait.return_value = 42
         popen.return_value.stdout = io.StringIO("{}")
         output = io.StringIO()
-        observe_arp_packets = self.patch(arp_module, "observe_arp_packets")
-        observe_arp_packets.return_value = None
-        popen.return_value.poll = Mock()
-        popen.return_value.poll.return_value = 42
         with self.assertRaisesRegex(SystemExit, "42"):
             run(args, output=output)
 


### PR DESCRIPTION
Replace `poll()` with `wait()` in maas-rack `observe-arp`.

`poll()` is non-blocking and returns `None` while the subprocess is still running, causing `run()` to return immediately before `maas-netmon` finishes. The Twisted parent then incorrectly treats the still-running child as having completed successfully. `wait()` blocks until the subprocess actually exits and always propagates the real exit code via `SystemExit`, ensuring the parent observes the true outcome.

This `poll()` call was effectively unreachable before commit https://github.com/canonical/maas/commit/25c89ad1c37c4ea75dc8d3c04b8bc06b73b188cf. Previously, `run()` blocked inside `observe_arp_packets()`, which read and parsed the monitor's output from a *separate* pipe for the entire lifetime of the process; the trailing `poll()` was only ever reached after that read loop had already finished. The switch to `maas-netmon` removed the `observe_arp_packets()` relay (the binary now writes JSON directly to the inherited stdout), leaving the non-blocking `poll()` as the only thing between spawning the child and returning — so the wrapper began exiting immediately while `maas-netmon` kept running. Restoring blocking behaviour via `wait()` makes the wrapper live for the full lifetime of `maas-netmon` again, as it did before that commit.

Resolves: LP:2151804