### PR TITLE
fix: correct truncated pyright ignore in reserved IP request

### DIFF
--- a/src/maasapiserver/v3/api/public/models/requests/reservedips.py
+++ b/src/maasapiserver/v3/api/public/models/requests/reservedips.py
@@ -37,7 +37,9 @@ class ReservedIPCreateRequest(ReservedIPBaseRequest):
     ) -> ReservedIPBuilder:
         # TODO: move this logic to service layer
         existing_ip = await services.staticipaddress.get_one(
-            QuerySpec(where=StaticIPAddressClauseFactory.with_ip(self.ip))  # pyright: ignore [reportArgument
+            QuerySpec(
+                where=StaticIPAddressClauseFactory.with_ip(self.ip)  # pyright: ignore [reportArgumentType]
+            )
         )
         if existing_ip is not None:
             mac_addresses = await services.staticipaddress.get_mac_addresses(


### PR DESCRIPTION
Fix pyright suppress on `ReservedIPCreateRequest.to_builder`. It got truncated in 517214c4e commit.