### PR TITLE
chore: fix building of snap tree by using offline docs environment variable directly in make command

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -286,14 +286,12 @@ parts:
       - git            # for git+https://git.launchpad.net/django-piston3 in requirements.txt
     override-build: |
       cd $CRAFT_PART_SRC/docs
-      make html
+      MAAS_OFFLINE_DOCS=true make html
       INSTALL_DIR="$CRAFT_PART_INSTALL/usr/share/maas/web/static/docs"
       mkdir -p "$INSTALL_DIR"
       cp -a _build/* "$INSTALL_DIR/"
     prime:
       - usr/share/maas/web/static/docs
-    environment:
-      MAAS_OFFLINE_DOCS=true
 
   host-info:
     plugin: make


### PR DESCRIPTION
Snapcraft doesn't like receiving environment variables in the snapcraft yaml for building the offline docs without analytics. This moves the environment variable directly into the make html call.