### PR TITLE
docs: add google analytics (#296)

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -31,7 +31,7 @@ override_dh_auto_install:
 	mv $(CURDIR)/src/maasui/build $(CURDIR)/debian/tmp/usr/share/maas/web/static
 
 	# Build and install offline docs
-	make -C $(CURDIR)/docs html
+	MAAS_OFFLINE_DOCS=true make -C $(CURDIR)/docs html
 	install -d -m 755 $(CURDIR)/debian/tmp/usr/share/maas/web/static/docs
 	cp -a $(CURDIR)/docs/_build/. $(CURDIR)/debian/tmp/usr/share/maas/web/static/docs/
 

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -1,0 +1,103 @@
+<div class="related-pages">
+  {# mod: Per-page navigation #}
+  {% if meta %}
+    {% if 'sequential_nav' in meta %}
+      {% set sequential_nav = meta.sequential_nav %}
+    {% endif %}
+  {% endif %}
+  {# mod: Conditional wrappers to control page navigation buttons #}
+  {% if sequential_nav != "none" -%}
+    {% if next and (sequential_nav == "next" or sequential_nav == "both") -%}
+      <a class="next-page" href="{{ next.link }}">
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Next") }}</span>
+          </div>
+          <div class="title">{{ next.title }}</div>
+        </div>
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+      </a>
+    {%- endif %}
+    {% if prev and (sequential_nav == "prev" or sequential_nav == "both") -%}
+      <a class="prev-page" href="{{ prev.link }}">
+        <svg class="furo-related-icon"><use href="#svg-arrow-right"></use></svg>
+        <div class="page-info">
+          <div class="context">
+            <span>{{ _("Previous") }}</span>
+          </div>
+          {% if prev.link == pathto(root_doc) %}
+            <div class="title">{{ _("Home") }}</div>
+          {% else %}
+            <div class="title">{{ prev.title }}</div>
+          {% endif %}
+        </div>
+      </a>
+    {%- endif %}
+  {%- endif %}
+</div>
+<div class="bottom-of-page">
+  <div class="left-details">
+    {%- if show_copyright %}
+    <div class="copyright">
+      {%- if hasdoc('copyright') %}
+        {% trans path=pathto('copyright'), copyright=copyright|e -%}
+          <a href="{{ path }}">&copy; {{ copyright }} {{ author }}</a>
+        {%- endtrans %}
+      {%- else %}
+        {% trans copyright=copyright|e -%}
+          &copy; {{ copyright }} {{ author }}
+        {%- endtrans %}
+      {%- endif %}
+    </div>
+    {%- endif %}
+    {%- if license and license.name -%}
+      {%- if license.url -%}
+      <div class="license">
+        This page is licensed under <a href="{{ license.url }}">{{ license.name }}</a>
+      </div>
+      {%- else -%}
+      <div class="license">
+        This page is licensed under {{ license.name }}
+      </div>
+      {%- endif -%}
+    {%- endif -%}
+
+    {# mod: removed "Made with" #}
+
+    {%- if last_updated -%}
+    <div class="last-updated">
+      {% trans last_updated=last_updated|e -%}
+        Last updated on {{ last_updated }}
+      {%- endtrans -%}
+    </div>
+    {%- endif %}
+
+    {%- if show_source and has_source and sourcename %}
+    <div class="show-source">
+      <a class="muted-link" href="{{ pathto('_sources/' + sourcename, true)|e }}"
+         rel="nofollow">Show source</a>
+    </div>
+    {%- endif %}
+  </div>
+  <div>
+   {% if has_contributor_listing and display_contributors and pagename and page_source_suffix %}
+       {% set contributors = get_contributors_for_file(pagename, page_source_suffix) %}
+       {% if contributors %}
+          {% if contributors | length > 1 %}
+              <a class="display-contributors">Thanks to the {{ contributors |length }} contributors!</a>
+          {% else %}
+              <a class="display-contributors">Thanks to our contributor!</a>
+          {% endif %}
+          <div id="overlay"></div>
+          <ul class="all-contributors">
+              {% for contributor in contributors %}
+                  <li>
+                      <a href="{{ contributor[1] }}" class="contributor">{{ contributor[0] }}</a>
+                  </li>
+              {% endfor %}
+          </ul>
+       {% endif %}
+   {% endif %}
+  </div>
+  <div class="right-details"><a href="" class="js-revoke-cookie-manager muted-link">Manage your tracker settings</a></div>
+</div>

--- a/docs/_templates/header.html
+++ b/docs/_templates/header.html
@@ -1,0 +1,72 @@
+<header id="header" class="p-navigation">
+
+  <!-- Google Tag Manager -->
+  <script>
+    (function(w, d, s, l, i) {
+      w[l] = w[l] || [];
+      w[l].push({
+        'gtm.start': new Date().getTime(),
+        event: 'gtm.js'
+      });
+      var f = d.getElementsByTagName(s)[0];
+      var j = d.createElement(s);
+      var dl = '';
+      if (l != 'dataLayer') {
+          dl = '&l=' + l;
+      }
+      j.async = true;
+      j.src = 'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+      f.parentNode.insertBefore(j, f);
+    })(window, document, 'script', 'dataLayer', 'GTM-KNX3CJC');
+  </script>
+
+  <div class="p-navigation__nav" role="menubar">
+
+    <ul class="p-navigation__links" role="menu">
+
+      <li>
+        <a class="p-logo" href="https://{{ product_page }}" aria-current="page">
+          <img src="{{ pathto(product_tag,1) }}" alt="Logo" class="p-logo-image">
+          <div class="p-logo-text p-heading--4">{{ project }}
+          </div>
+        </a>
+      </li>
+
+      <li class="nav-ubuntu-com">
+        <a href="https://{{ product_page }}" class="p-navigation__link">{{ product_page }}</a>
+      </li>
+
+      <li>
+        <a href="#" class="p-navigation__link nav-more-links">More resources</a>
+        <ul class="more-links-dropdown">
+
+          {% if discourse %}
+          <li>
+            <a href="{{ discourse }}" class="p-navigation__sub-link p-dropdown__link">Discourse</a>
+          </li>
+          {% endif %}
+
+          {% if mattermost %}
+          <li>
+            <a href="{{ mattermost }}" class="p-navigation__sub-link p-dropdown__link">Mattermost</a>
+          </li>
+          {% endif %}
+
+          {% if matrix %}
+          <li>
+            <a href="{{ matrix }}" class="p-navigation__sub-link p-dropdown__link">Matrix</a>
+          </li>
+          {% endif %}
+
+          {% if github_url %}
+          <li>
+            <a href="{{ github_url }}" class="p-navigation__sub-link p-dropdown__link">GitHub</a>
+          </li>
+          {% endif %}
+
+        </ul>
+      </li>
+
+    </ul>
+  </div>
+</header>

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,8 @@ import warnings
 
 import yaml
 
+IS_ONLINE = os.getenv("MAAS_OFFLINE_DOCS", "").lower() != "true"
+
 # Add custom extensions directory to Python path
 sys.path.insert(0, str(Path(__file__).parent / "_ext"))
 
@@ -254,7 +256,10 @@ sitemap_excludes = [
 #######################
 
 html_static_path = ["_static"]
-# templates_path = ["_templates"]
+
+# Our _templates folder are only being used for google analytics.
+if IS_ONLINE:
+    templates_path = ["_templates"]
 
 
 #############
@@ -362,12 +367,22 @@ exclude_patterns = [
 
 # Adds custom CSS files, located under 'html_static_path'
 
-# html_css_files = []
+html_css_files = []
+
+# CSS for google analytics tracker settings:
+if IS_ONLINE:
+    html_css_files.append(
+        "https://assets.ubuntu.com/v1/d86746ef-cookie_banner.css"
+    )
 
 
 # Adds custom JavaScript files, located under 'html_static_path'
 
 html_js_files = ["js/overwrite_links.js"]
+
+# JS for google analytics tracker setup:
+if IS_ONLINE:
+    html_js_files.append("https://assets.ubuntu.com/v1/287a5e8f-bundle.js")
 
 
 # Specifies a reST snippet to be appended to each .rst file

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -278,7 +278,7 @@ parts:
       - git            # for git+https://git.launchpad.net/django-piston3 in requirements.txt
     override-build: |
       cd $CRAFT_PART_SRC/docs
-      make html
+      MAAS_OFFLINE_DOCS=true make html
       INSTALL_DIR="$CRAFT_PART_INSTALL/usr/share/maas/web/static/docs"
       mkdir -p "$INSTALL_DIR"
       cp -a _build/* "$INSTALL_DIR/"


### PR DESCRIPTION
The Documentation team asked us to add google analytics support to our docs before merging it to prod.

Here is the page with the instructions:
https://documentation.ubuntu.com/sphinx-stack/latest/how-to/optional-customisation/enable-google-analytics

Given that we have offline docs, I've done some conditional treatment to ignore those files for the offline build.

(cherry picked from commit abb05df5881b60bc224838203032b814f060c887)