### PR TITLE
chore: pin aiohttp version to <3.14 to avoid change in init function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Topic :: System :: Systems Administration",
 ]
 optional-dependencies.testing = [
+  "aiohttp<3.14",              # pin until https://github.com/pnuckowski/aioresponses/issues/289 is fixed"
   "aioresponses>=0.7,<0.8",
   "fixtures>=4.3,<4.4",
   "httpx>=0.28,<0.29",


### PR DESCRIPTION
See https://github.com/pnuckowski/aioresponses/issues/289 for details on what breaks in aiohttp 3.14.
aioresponses depends on it but does not pin the version to the one that does not break compatibility.