### PR TITLE
fix: bump `starlette>=1.0.1` and use `scope["path"]`

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -111,7 +111,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 sphinxcontrib-svg2pdfconverter==2.1.0
-starlette==1.0.0
+starlette==1.0.1
 tinycss2==1.5.1
 typing-extensions==4.15.0
 uc-micro-py==2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -111,7 +111,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 sphinxcontrib-svg2pdfconverter==2.1.0
-starlette==1.0.1
+starlette>=1.0.1
 tinycss2==1.5.1
 typing-extensions==4.15.0
 uc-micro-py==2.0.0

--- a/src/maasapiserver/common/middlewares/prometheus.py
+++ b/src/maasapiserver/common/middlewares/prometheus.py
@@ -80,7 +80,7 @@ class PrometheusMiddleware(BaseHTTPMiddleware):
             match, _ = route.matches(request.scope)
             if match == Match.FULL:
                 return route.path
-        return request.url.path
+        return request.scope["path"]
 
 
 def _get_metrics() -> PrometheusMetrics:

--- a/src/maasapiserver/v3/middlewares/auth.py
+++ b/src/maasapiserver/v3/middlewares/auth.py
@@ -590,7 +590,7 @@ class V3AuthenticationMiddleware(BaseHTTPMiddleware):
     ) -> Response:
         # Just pass through the request if it's not for a V3 handler. The other V2 endpoints have another authentication
         # architecture/mechanism.
-        if not request.url.path.startswith(V3_API_PREFIX):
+        if not request.scope["path"].startswith(V3_API_PREFIX):
             return await call_next(request)
 
         encryptor = await request.state.services.external_oauth.get_encryptor()

--- a/src/maasapiserver/v3/middlewares/context.py
+++ b/src/maasapiserver/v3/middlewares/context.py
@@ -43,8 +43,8 @@ class ContextMiddleware(BaseHTTPMiddleware):
         logger.info(
             "Start processing request",
             request_method=request.method,
-            request_path=request.url.path,
-            request_query=request.url.query,
+            request_path=request.scope["path"],
+            request_query=request.scope.get("query_string", b"").decode(),
             # From our nginx config
             request_remote_ip=request.headers.get("x-real-ip"),
             useragent=request.headers.get("user-agent"),

--- a/src/maasapiserver/v3/middlewares/services.py
+++ b/src/maasapiserver/v3/middlewares/services.py
@@ -36,7 +36,7 @@ class ServicesMiddleware(BaseHTTPMiddleware):
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
         # Just pass through the request if it's not a V3 endpoint.
-        if not request.url.path.startswith(V3_API_PREFIX):
+        if not request.scope["path"].startswith(V3_API_PREFIX):
             return await call_next(request)
 
         services = await ServiceCollectionV3.produce(


### PR DESCRIPTION
addresses [CVE-2026-48710](https://nvd.nist.gov/vuln/detail/CVE-2026-48710) ( MAAS likely not vaunerable, but let's patch anyway )

`request.url.path` is derived from the Host header and can be forged by an attacker to bypass path-based middleware checks. scope["path"] comes from the ASGI request line and cannot be manipulated this way