### PR TITLE
test: pin pyright version to avoid errors on authlib.AsyncOAuth2Client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ optional-dependencies.testing = [
   "ipdb>=0.13,<0.14",
   "junitxml>=0.7,<0.8",
   "postgresfixture>=0.5,<0.6",
-  "pyright>=1.1.400",
+  "pyright==1.1.407",           # pin until https://github.com/python/typeshed/pull/15190 is merged and added to pyright.
   "pytest>=7.4,<8",
   "pytest-asyncio>=0.23,<0.24",
   "pytest-cov>=6,<6.1",


### PR DESCRIPTION
Pyright version 1.1.408 has introduced an issue where it doesn't recognize AsyncOAuth2Client as an httpx.AsyncClient. The issue relies on typeshed: https://github.com/python/typeshed/pull/15190.

To avoid tests failures and adding unnecessary ignore directives to the code, let's pin the version to 1.1.407 and remove it once the bug is fixed.

(cherry picked from commit 3f8469f5794294d1b28cefe1b68b60919e4877c7)