### PR TITLE
chore: change source of django-piston3 to github

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -27,7 +27,7 @@ vale==3.13.0.0
 
 # Bare minimum MAAS dependencies for API documentation generation
 django==5.2.9
-git+https://git.launchpad.net/django-piston3
+git+https://github.com/canonical/django-piston3.git
 aiofiles==25.1.0
 aiohttp==3.13.5
 Authlib==1.6.9


### PR DESCRIPTION
This should fix the issues we face due to availability problems with launchpad.