### PR TITLE
fix: HTTP response body leak

### DIFF
--- a/src/maasagent/internal/dhcp/service.go
+++ b/src/maasagent/internal/dhcp/service.go
@@ -223,6 +223,9 @@ func queueFlush(c *apiclient.APIClient, interval time.Duration) func(context.Con
 				return err
 			}
 
+			//nolint:errcheck // we do not care about possible error here
+			defer resp.Body.Close()
+
 			if resp.StatusCode < 200 || resp.StatusCode >= 400 {
 				return ErrFailedToPostNotifications
 			}


### PR DESCRIPTION
The `queueFlush` function in `src/maasagent/internal/dhcp/service.go` never closes the HTTP response body returned by `apiclient.Request()`

Resolves: LP:2146799