### PR TITLE
refactor: revert boot sources immutability

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -27,7 +27,7 @@ vale==3.13.0.0
 
 # Bare minimum MAAS dependencies for API documentation generation
 django==5.2.9
-git+https://git.launchpad.net/django-piston3
+git+https://github.com/canonical/django-piston3.git
 aiofiles==25.1.0
 aiohttp==3.13.5
 Authlib==1.6.9

--- a/src/maasserver/api/tests/test_boot_sources.py
+++ b/src/maasserver/api/tests/test_boot_sources.py
@@ -7,10 +7,6 @@ import http.client
 
 from django.urls import reverse
 
-from maascommon.constants import (
-    CANDIDATE_IMAGES_STREAM_URL,
-    STABLE_IMAGES_STREAM_URL,
-)
 import maasserver.api.boot_sources as boot_source_module
 from maasserver.api.boot_sources import DISPLAYED_BOOTSOURCE_FIELDS
 from maasserver.audit import Event
@@ -261,50 +257,6 @@ class TestBootSourceAPI(APITestCase.ForUser):
         self.assertEqual(http.client.OK, response.status_code)
         boot_source = reload_object(boot_source)
         self.assertTrue(boot_source.skip_keyring_verification)
-
-    def test_PUT_default_boot_source_allows_priority_and_enabled(self):
-        self.become_admin()
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        new_values = {"priority": 42, "enabled": False}
-        response = self.client.put(
-            get_boot_source_uri(boot_source), new_values
-        )
-        self.assertEqual(http.client.OK, response.status_code)
-        boot_source = reload_object(boot_source)
-        self.assertEqual(boot_source.priority, 42)
-        self.assertFalse(boot_source.enabled)
-
-    def test_PUT_default_boot_source_rejects_url(self):
-        self.become_admin()
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        new_values = {"url": "http://other.example.com"}
-        response = self.client.put(
-            get_boot_source_uri(boot_source), new_values
-        )
-        self.assertEqual(http.client.BAD_REQUEST, response.status_code)
-
-    def test_PUT_default_boot_source_rejects_name(self):
-        self.become_admin()
-        boot_source = BootSource.objects.get(url=CANDIDATE_IMAGES_STREAM_URL)
-        new_values = {"name": "renamed"}
-        response = self.client.put(
-            get_boot_source_uri(boot_source), new_values
-        )
-        self.assertEqual(http.client.BAD_REQUEST, response.status_code)
-
-    def test_DELETE_rejects_stable_default_boot_source(self):
-        self.become_admin()
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        response = self.client.delete(get_boot_source_uri(boot_source))
-        self.assertEqual(http.client.BAD_REQUEST, response.status_code)
-        self.assertIsNotNone(reload_object(boot_source))
-
-    def test_DELETE_rejects_candidate_default_boot_source(self):
-        self.become_admin()
-        boot_source = BootSource.objects.get(url=CANDIDATE_IMAGES_STREAM_URL)
-        response = self.client.delete(get_boot_source_uri(boot_source))
-        self.assertEqual(http.client.BAD_REQUEST, response.status_code)
-        self.assertIsNotNone(reload_object(boot_source))
 
 
 class TestBootSourcesAPI(APITestCase.ForUser):

--- a/src/maasserver/forms/__init__.py
+++ b/src/maasserver/forms/__init__.py
@@ -87,10 +87,6 @@ from formencode.validators import StringBool
 from lxml import etree
 from netaddr import IPNetwork, valid_ipv6
 
-from maascommon.constants import (
-    CANDIDATE_IMAGES_STREAM_URL,
-    STABLE_IMAGES_STREAM_URL,
-)
 from maascommon.logging.security import CREATED
 from maascommon.osystem import (
     LINUX_OSYSTEMS,
@@ -2306,32 +2302,8 @@ class BootSourceForm(MAASModelForm):
     enabled = forms.NullBooleanField(required=False)
     skip_keyring_verification = forms.NullBooleanField(required=False)
 
-    _DEFAULT_BOOT_SOURCE_URLS = frozenset(
-        {STABLE_IMAGES_STREAM_URL, CANDIDATE_IMAGES_STREAM_URL}
-    )
-    _ALLOWED_FIELDS_FOR_DEFAULTS = {"priority", "enabled"}
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-
-    def clean(self):
-        cleaned_data = super().clean()
-        if (
-            self.instance
-            and self.instance.pk
-            and self.instance.url in self._DEFAULT_BOOT_SOURCE_URLS
-        ):
-            denied_fields = (
-                set(self.changed_data) - self._ALLOWED_FIELDS_FOR_DEFAULTS
-            )
-            if denied_fields:
-                raise ValidationError(
-                    {
-                        field: f"'{field}' cannot be changed for MAAS default boot sources."
-                        for field in denied_fields
-                    }
-                )
-        return cleaned_data
 
     def clean_keyring_data(self):
         """Process 'keyring_data' field.

--- a/src/maasserver/forms/tests/test_bootsource.py
+++ b/src/maasserver/forms/tests/test_bootsource.py
@@ -7,12 +7,7 @@ from io import BytesIO
 
 from django.core.files.uploadedfile import InMemoryUploadedFile
 
-from maascommon.constants import (
-    CANDIDATE_IMAGES_STREAM_URL,
-    STABLE_IMAGES_STREAM_URL,
-)
 from maasserver.forms import BootSourceForm
-from maasserver.models import BootSource
 from maasserver.models.signals import bootsources
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
@@ -115,67 +110,7 @@ class TestBootSourceForm(MAASServerTestCase):
         self.assertTrue(form.is_valid(), form._errors)
         boot_source = form.save()
         self.assertEqual(boot_source.name, "http://example.com")
-        # Candidate and stable boot sources are created with priority 1 and 2 respectively, so the next priority is 3
-        self.assertEqual(boot_source.priority, 3)
+        # Stable boot source is created with priority 1 by the migrations.
+        self.assertEqual(boot_source.priority, 2)
         self.assertTrue(boot_source.enabled)
         self.assertFalse(boot_source.skip_keyring_verification)
-
-    def test_update_default_boot_source_allows_priority(self):
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        form = BootSourceForm(instance=boot_source, data={"priority": 42})
-        self.assertTrue(form.is_valid(), form._errors)
-
-    def test_update_default_boot_source_allows_enabled(self):
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        form = BootSourceForm(instance=boot_source, data={"enabled": False})
-        self.assertTrue(form.is_valid(), form._errors)
-
-    def test_update_default_boot_source_rejects_url(self):
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        form = BootSourceForm(
-            instance=boot_source,
-            data={"url": "http://other.example.com"},
-        )
-        self.assertFalse(form.is_valid())
-        self.assertIn("url", form.errors)
-
-    def test_update_default_boot_source_rejects_name(self):
-        boot_source = BootSource.objects.get(url=CANDIDATE_IMAGES_STREAM_URL)
-        form = BootSourceForm(
-            instance=boot_source,
-            data={"name": "new-name"},
-        )
-        self.assertFalse(form.is_valid())
-        self.assertIn("name", form.errors)
-
-    def test_update_default_boot_source_rejects_keyring_filename(self):
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        form = BootSourceForm(
-            instance=boot_source,
-            data={"keyring_filename": "/new/path"},
-        )
-        self.assertFalse(form.is_valid())
-        self.assertIn("keyring_filename", form.errors)
-
-    def test_update_default_boot_source_rejects_skip_keyring_verification(
-        self,
-    ):
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        form = BootSourceForm(
-            instance=boot_source,
-            data={"skip_keyring_verification": True},
-        )
-        self.assertFalse(form.is_valid())
-        self.assertIn("skip_keyring_verification", form.errors)
-
-    def test_update_non_default_boot_source_allows_any_field(self):
-        boot_source = factory.make_BootSource()
-        form = BootSourceForm(
-            instance=boot_source,
-            data={
-                "url": "http://other.example.com",
-                "name": "new-name",
-                "keyring_filename": "/new/path",
-            },
-        )
-        self.assertTrue(form.is_valid(), form._errors)

--- a/src/maasserver/models/bootsource.py
+++ b/src/maasserver/models/bootsource.py
@@ -18,10 +18,6 @@ from django.db.models import (
     URLField,
 )
 
-from maascommon.constants import (
-    CANDIDATE_IMAGES_STREAM_URL,
-    STABLE_IMAGES_STREAM_URL,
-)
 from maascommon.workflows.bootresource import (
     POST_UPDATE_BOOT_SOURCE_URL_WORKFLOW_NAME,
     PostUpdateBootSourceUrlParam,
@@ -231,11 +227,6 @@ class BootSource(CleanSave, TimestampedModel):
         return super().save(*args, **kwargs)
 
     def delete(self, *args, **kwargs):
-        if self.url in (STABLE_IMAGES_STREAM_URL, CANDIDATE_IMAGES_STREAM_URL):
-            raise ValidationError(
-                "The MAAS default boot sources can't be deleted."
-            )
-
         related_selections = BootSourceSelection.objects.filter(
             boot_source=self
         )

--- a/src/maasserver/models/tests/test_bootsource.py
+++ b/src/maasserver/models/tests/test_bootsource.py
@@ -7,10 +7,6 @@ import os
 
 from django.core.exceptions import ValidationError
 
-from maascommon.constants import (
-    CANDIDATE_IMAGES_STREAM_URL,
-    STABLE_IMAGES_STREAM_URL,
-)
 from maascommon.workflows.bootresource import (
     POST_UPDATE_BOOT_SOURCE_URL_WORKFLOW_NAME,
     PostUpdateBootSourceUrlParam,
@@ -246,20 +242,6 @@ class TestBootSource(MAASServerTestCase):
         self.assertEqual(boot_source.name, boot_source_dict["name"])
         self.assertEqual(boot_source.priority, boot_source_dict["priority"])
         self.assertEqual(boot_source.enabled, boot_source_dict["enabled"])
-
-    def test_cannot_delete_stable_default_boot_source(self):
-        boot_source = BootSource.objects.get(url=STABLE_IMAGES_STREAM_URL)
-        self.assertRaises(ValidationError, boot_source.delete)
-
-    def test_cannot_delete_candidate_default_boot_source(self):
-        boot_source = BootSource.objects.get(url=CANDIDATE_IMAGES_STREAM_URL)
-        self.assertRaises(ValidationError, boot_source.delete)
-
-    def test_can_delete_non_default_boot_source(self):
-        boot_source = factory.make_BootSource(url="http://custom.example.com")
-        boot_source_id = boot_source.id
-        boot_source.delete()
-        self.assertFalse(BootSource.objects.filter(id=boot_source_id).exists())
 
     def test_verify_selection_after_url_update(self):
         mock_start_workflow = self.patch(boot_source_module, "start_workflow")

--- a/src/maasserver/models/tests/test_bootsource.py
+++ b/src/maasserver/models/tests/test_bootsource.py
@@ -172,14 +172,14 @@ class TestBootSource(MAASServerTestCase):
     def test_generate_priority_boot_source(self):
         # create a boot source
         boot_source_1 = make_BootSource()
-        # Candidate and stable boot sources are created with priority 1 and 2 respectively, so the next priority is 3
-        assert boot_source_1.priority == 3
+        # Stable boot source is created with priority 1, so the next priority is 2
+        assert boot_source_1.priority == 2
         # update boot source: _generate_priority() is called
         boot_source_1.url = "http://%s.com/" % factory.make_name("source-url")
         boot_source_1.save()
-        # create a new boot source (max priority == 3)
+        # create a new boot source (max priority == 2)
         boot_source_2 = make_BootSource()
-        assert boot_source_2.priority == 4
+        assert boot_source_2.priority == 3
         # create a new boot source (max priority == 10)
         boot_source_1.priority = 10
         boot_source_1.save()

--- a/src/maasserver/testing/initial.maas_test.sql
+++ b/src/maasserver/testing/initial.maas_test.sql
@@ -4,8 +4,8 @@
 
 \restrict jDB4gdI1N8dbUCAC3vcdCvWs48TBU3tT39yhtb0ijqwqYnAc3QoCur8LfK1MnsD
 
--- Dumped from database version 18.3 (Ubuntu 18.3-1)
--- Dumped by pg_dump version 18.3 (Ubuntu 18.3-1)
+-- Dumped from database version 18.4 (Ubuntu 18.4-0ubuntu0.26.04.1)
+-- Dumped by pg_dump version 18.4 (Ubuntu 18.4-0ubuntu0.26.04.1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -5388,7 +5388,7 @@ CREATE VIEW public.maasserver_bootsourceselectionstatus_view AS
            FROM (((public.maasserver_bootsourcecache cache
              JOIN public.maasserver_bootsource source ON ((source.id = cache.boot_source_id)))
              JOIN public.maasserver_bootsourceselection sel ON ((sel.boot_source_id = source.id)))
-             JOIN public.maasserver_bootresource res ON (((res.selection_id = sel.id) AND ((res.name)::text = (((cache.os)::text || '/'::text) || (cache.release)::text)) AND ((res.kflavor)::text = (cache.kflavor)::text) AND ((((res.architecture)::text = (((cache.arch)::text || '/'::text) || (cache.subarch)::text)) OR ((res.architecture)::text = (((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text))) OR ((res.architecture)::text = ((((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text) || '-edge'::text))))))
+             JOIN public.maasserver_bootresource res ON (((res.selection_id = sel.id) AND ((res.name)::text = (((cache.os)::text || '/'::text) || (cache.release)::text)) AND ((res.kflavor)::text = (cache.kflavor)::text) AND (((res.architecture)::text = (((cache.arch)::text || '/'::text) || (cache.subarch)::text)) OR ((res.architecture)::text = (((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text)) OR ((res.architecture)::text = ((((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text) || '-edge'::text))))))
         ), resource_set_counts AS (
          SELECT sync_stats.resource_id,
             count(*) AS set_count
@@ -11219,8 +11219,7 @@ COPY public.maasserver_bootresourceset (id, created, updated, version, label, re
 --
 
 COPY public.maasserver_bootsource (id, created, updated, url, keyring_filename, keyring_data, priority, name, enabled, skip_keyring_verification) FROM stdin;
-1	2026-04-20 16:27:58.892622+00	2026-04-20 16:27:58.892622+00	http://images.maas.io/ephemeral-v3/stable	/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg	\\x	2	MAAS Stable	t	f
-2	2026-04-20 16:27:58.892622+00	2026-04-20 16:27:58.892622+00	http://images.maas.io/ephemeral-v3/candidate	/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg	\\x	1	MAAS Candidate	f	f
+1	2026-04-20 16:27:58.892622+00	2026-04-20 16:27:58.892622+00	http://images.maas.io/ephemeral-v3/stable	/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg	\\x	1	MAAS Stable	t	f
 \.
 
 

--- a/src/maasserver/testing/initial.maas_test.sql
+++ b/src/maasserver/testing/initial.maas_test.sql
@@ -4,8 +4,8 @@
 
 \restrict jDB4gdI1N8dbUCAC3vcdCvWs48TBU3tT39yhtb0ijqwqYnAc3QoCur8LfK1MnsD
 
--- Dumped from database version 18.4 (Ubuntu 18.4-0ubuntu0.26.04.1)
--- Dumped by pg_dump version 18.4 (Ubuntu 18.4-0ubuntu0.26.04.1)
+-- Dumped from database version 18.3 (Ubuntu 18.3-0ubuntu0.26.04.1)
+-- Dumped by pg_dump version 18.3 (Ubuntu 18.3-0ubuntu0.26.04.1)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -5388,7 +5388,7 @@ CREATE VIEW public.maasserver_bootsourceselectionstatus_view AS
            FROM (((public.maasserver_bootsourcecache cache
              JOIN public.maasserver_bootsource source ON ((source.id = cache.boot_source_id)))
              JOIN public.maasserver_bootsourceselection sel ON ((sel.boot_source_id = source.id)))
-             JOIN public.maasserver_bootresource res ON (((res.selection_id = sel.id) AND ((res.name)::text = (((cache.os)::text || '/'::text) || (cache.release)::text)) AND ((res.kflavor)::text = (cache.kflavor)::text) AND (((res.architecture)::text = (((cache.arch)::text || '/'::text) || (cache.subarch)::text)) OR ((res.architecture)::text = (((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text)) OR ((res.architecture)::text = ((((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text) || '-edge'::text))))))
+             JOIN public.maasserver_bootresource res ON (((res.selection_id = sel.id) AND ((res.name)::text = (((cache.os)::text || '/'::text) || (cache.release)::text)) AND ((res.kflavor)::text = (cache.kflavor)::text) AND ((((res.architecture)::text = (((cache.arch)::text || '/'::text) || (cache.subarch)::text)) OR ((res.architecture)::text = (((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text))) OR ((res.architecture)::text = ((((((cache.arch)::text || '/'::text) || (cache.subarch)::text) || '-'::text) || (cache.kflavor)::text) || '-edge'::text))))))
         ), resource_set_counts AS (
          SELECT sync_stats.resource_id,
             count(*) AS set_count

--- a/src/maasservicelayer/db/alembic/versions/0005_add_columns_to_bootsource.py
+++ b/src/maasservicelayer/db/alembic/versions/0005_add_columns_to_bootsource.py
@@ -9,7 +9,7 @@ Create Date: 2025-06-24 11:16:07.410600+00:00
 
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import auto, IntFlag
 import os
@@ -37,16 +37,12 @@ KEYRINGS_PATH = (
 STABLE_IMAGES_STREAM_URL = "http://images.maas.io/ephemeral-v3/stable"
 STABLE_IMAGES_STREAM_NAME = "MAAS Stable"
 
-CANDIDATE_IMAGES_STREAM_URL = "http://images.maas.io/ephemeral-v3/candidate"
-CANDIDATE_IMAGES_STREAM_NAME = "MAAS Candidate"
-
 LATEST_UBUNTU_LTS = "noble"
 
 
 class BootSourceFlag(IntFlag):
     NO_BOOT_SOURCE = auto()
     STABLE = auto()
-    CANDIDATE = auto()
 
 
 def get_boot_source_status() -> BootSourceFlag:
@@ -61,8 +57,6 @@ def get_boot_source_status() -> BootSourceFlag:
     for boot_source in boot_sources:
         if boot_source["url"] == STABLE_IMAGES_STREAM_URL:
             flag |= BootSourceFlag.STABLE
-        elif boot_source["url"] == CANDIDATE_IMAGES_STREAM_URL:
-            flag |= BootSourceFlag.CANDIDATE
 
     return flag
 
@@ -72,7 +66,7 @@ class BootSourceCreateModel:
     name: str
     url: str
     priority: int
-    enabled: bool = field(init=False, default=False)
+    enabled: bool
 
     def create(self):
         return (
@@ -162,7 +156,7 @@ def upgrade() -> None:
     op.execute(f"""
         UPDATE maasserver_bootsource
         SET url = RTRIM(url, '/')
-        WHERE url IN ('{STABLE_IMAGES_STREAM_URL}/', '{CANDIDATE_IMAGES_STREAM_URL}/')
+        WHERE url = '{STABLE_IMAGES_STREAM_URL}/'
     """)
 
     status = get_boot_source_status()
@@ -170,32 +164,17 @@ def upgrade() -> None:
     stable_boot_source = BootSourceCreateModel(
         name=STABLE_IMAGES_STREAM_NAME,
         url=STABLE_IMAGES_STREAM_URL,
-        priority=2,
-    )
-    candidate_boot_source = BootSourceCreateModel(
-        name=CANDIDATE_IMAGES_STREAM_NAME,
-        url=CANDIDATE_IMAGES_STREAM_URL,
         priority=1,
+        enabled=True,
     )
 
     if status & BootSourceFlag.NO_BOOT_SOURCE:
-        stable_boot_source.enabled = True
-        candidate_boot_source.enabled = False
-        create_default_selection = True
-    else:
-        stable_boot_source.enabled = (
-            True if status & BootSourceFlag.STABLE else False
-        )
-        candidate_boot_source.enabled = (
-            True if status & BootSourceFlag.CANDIDATE else False
-        )
-        create_default_selection = True
-
-    id = stable_boot_source.create()
-    candidate_boot_source.create()
-
-    if create_default_selection:
+        # New environment: create stable source and default selection
+        id = stable_boot_source.create()
         create_selection_stable(id)
+    elif status & BootSourceFlag.STABLE:
+        # Stable source exists: ensure it's up to date but don't create selection
+        stable_boot_source.create()
 
     # Backfill priority based on creation order:
     # - newer boot sources (later 'created' timestamps) get higher priority
@@ -203,13 +182,12 @@ def upgrade() -> None:
     #   insertions without immediate reordering
     # - a unique constraint will be added later, so all priorities must be
     #   distinct
-    # - stable and candidate boot sources are excluded as they were created
-    #   earlier
+    # - the stable boot source is excluded as it was created earlier
     op.execute(f"""
         WITH ranked AS (
             SELECT id, ROW_NUMBER() OVER (ORDER BY created ASC) AS priority
             FROM maasserver_bootsource
-            WHERE url NOT IN ('{STABLE_IMAGES_STREAM_URL}', '{CANDIDATE_IMAGES_STREAM_URL}')
+            WHERE url != '{STABLE_IMAGES_STREAM_URL}'
         )
         UPDATE maasserver_bootsource
         SET priority = ranked.priority*10
@@ -220,7 +198,7 @@ def upgrade() -> None:
     op.execute(f"""
         UPDATE maasserver_bootsource
         SET name = url
-        WHERE url NOT IN ('{STABLE_IMAGES_STREAM_URL}', '{CANDIDATE_IMAGES_STREAM_URL}')
+        WHERE url != '{STABLE_IMAGES_STREAM_URL}'
     """)
 
     # Set skip_keyring_verification to False for the unsigned streams (until

--- a/src/maasservicelayer/db/alembic/versions/0005_add_columns_to_bootsource.py
+++ b/src/maasservicelayer/db/alembic/versions/0005_add_columns_to_bootsource.py
@@ -151,13 +151,8 @@ def upgrade() -> None:
         ),
     )
 
-    # Make sure that the URLs for stable and candidate don't have a trailing slash.
-    # In this way we'll make sure to find them in any case.
-    op.execute(f"""
-        UPDATE maasserver_bootsource
-        SET url = RTRIM(url, '/')
-        WHERE url = '{STABLE_IMAGES_STREAM_URL}/'
-    """)
+    # Make sure that the URLs don't have a trailing slash.
+    op.execute("UPDATE maasserver_bootsource SET url = RTRIM(url, '/')")
 
     status = get_boot_source_status()
 

--- a/src/maasservicelayer/exceptions/constants.py
+++ b/src/maasservicelayer/exceptions/constants.py
@@ -14,11 +14,6 @@ PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE = (
     "ProviderCommunicationFailedViolation"
 )
 
-# Boot sources
-CANNOT_DELETE_DEFAULT_BOOT_SOURCE_VIOLATION_TYPE = (
-    "CannotDeleteDefaultBootSourceViolation"
-)
-
 # Domains
 CANNOT_DELETE_DEFAULT_DOMAIN_VIOLATION_TYPE = (
     "CannotDeleteDefaultDomainViolation"

--- a/src/maasservicelayer/services/boot_sources.py
+++ b/src/maasservicelayer/services/boot_sources.py
@@ -2,14 +2,12 @@
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 
+from contextlib import suppress
 from typing import List, Sequence
 
 import structlog
 
-from maascommon.constants import (
-    CANDIDATE_IMAGES_STREAM_URL,
-    STABLE_IMAGES_STREAM_URL,
-)
+from maascommon.constants import STABLE_IMAGES_STREAM_URL
 from maascommon.enums.events import EventTypeEnum
 from maascommon.workflows.bootresource import (
     FETCH_MANIFEST_AND_UPDATE_CACHE_WORKFLOW_NAME,
@@ -27,14 +25,7 @@ from maasservicelayer.db.repositories.bootsources import (
 from maasservicelayer.db.repositories.bootsourceselections import (
     BootSourceSelectionClauseFactory,
 )
-from maasservicelayer.exceptions.catalog import (
-    BadRequestException,
-    BaseExceptionDetail,
-)
-from maasservicelayer.exceptions.constants import (
-    CANNOT_DELETE_DEFAULT_BOOT_SOURCE_VIOLATION_TYPE,
-    INVALID_ARGUMENT_VIOLATION_TYPE,
-)
+from maasservicelayer.exceptions.catalog import NotFoundException
 from maasservicelayer.models.bootsources import BootSource
 from maasservicelayer.services.base import BaseService
 from maasservicelayer.services.bootsourcecache import BootSourceCacheService
@@ -133,58 +124,19 @@ class BootSourcesService(
                 event_description=f"Deleted boot source {resource.url}",
             )
 
-    async def pre_delete_hook(
-        self, resource_to_be_deleted: BootSource
-    ) -> None:
-        if resource_to_be_deleted.url in (
-            STABLE_IMAGES_STREAM_URL,
-            CANDIDATE_IMAGES_STREAM_URL,
-        ):
-            raise BadRequestException(
-                details=[
-                    BaseExceptionDetail(
-                        type=CANNOT_DELETE_DEFAULT_BOOT_SOURCE_VIOLATION_TYPE,
-                        message="The MAAS default boot sources can't be deleted.",
-                    )
-                ]
-            )
-
-    async def pre_update_instance(
-        self, existing_resource: BootSource, builder: BootSourceBuilder
-    ) -> None:
-        if existing_resource.url in (
-            STABLE_IMAGES_STREAM_URL,
-            CANDIDATE_IMAGES_STREAM_URL,
-        ):
-            allowed_fields = {"priority", "enabled"}
-            changed_fields = {
-                k
-                for k, v in builder.populated_fields().items()
-                if getattr(existing_resource, k) != v
-            }
-            denied_fields = changed_fields - allowed_fields
-            if denied_fields:
-                details = [
-                    BaseExceptionDetail(
-                        type=INVALID_ARGUMENT_VIOLATION_TYPE,
-                        message=f"'{field}' cannot be changed for MAAS default boot sources.",
-                        field=field,
-                    )
-                    for field in denied_fields
-                ]
-                raise BadRequestException(details=details)
-
     async def disable_all(self) -> None:
         await self.update_many(
             query=QuerySpec(), builder=BootSourceBuilder(enabled=False)
         )
 
     async def set_stable_enabled(self) -> None:
-        await self.update_one(
-            query=QuerySpec(
-                where=BootSourcesClauseFactory.with_url(
-                    STABLE_IMAGES_STREAM_URL
-                )
-            ),
-            builder=BootSourceBuilder(enabled=True),
-        )
+        """Enables the stable boot source if it exists."""
+        with suppress(NotFoundException):
+            await self.update_one(
+                query=QuerySpec(
+                    where=BootSourcesClauseFactory.with_url(
+                        STABLE_IMAGES_STREAM_URL
+                    )
+                ),
+                builder=BootSourceBuilder(enabled=True),
+            )

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_boot_sources.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_boot_sources.py
@@ -29,7 +29,6 @@ from maasapiserver.v3.api.public.models.responses.boot_sources import (
     UISourceAvailableImageListResponse,
 )
 from maasapiserver.v3.constants import V3_API_PREFIX
-from maascommon.constants import STABLE_IMAGES_STREAM_URL
 from maascommon.enums.boot_resources import (
     BootResourceType,
     ImageStatus,
@@ -50,12 +49,10 @@ from maasservicelayer.db.repositories.bootsourceselections import (
 )
 from maasservicelayer.exceptions.catalog import (
     AlreadyExistsException,
-    BadRequestException,
     BaseExceptionDetail,
     NotFoundException,
 )
 from maasservicelayer.exceptions.constants import (
-    INVALID_ARGUMENT_VIOLATION_TYPE,
     UNEXISTING_RESOURCE_VIOLATION_TYPE,
     UNIQUE_CONSTRAINT_VIOLATION_TYPE,
 )
@@ -111,18 +108,6 @@ TEST_BOOTSOURCE_2 = BootSource(
     enabled=True,
 )
 
-TEST_DEFAULT_BOOTSOURCE = BootSource(
-    id=3,
-    created=utcnow(),
-    updated=utcnow(),
-    name="default",
-    url=STABLE_IMAGES_STREAM_URL,
-    keyring_filename="/path/to/keyring.gpg",
-    keyring_data="",
-    priority=1,
-    skip_keyring_verification=False,
-    enabled=True,
-)
 
 TEST_BOOTSOURCESELECTION = BootSourceSelection(
     id=1,
@@ -366,50 +351,6 @@ class TestBootSourcesApi(ApiCommonTests):
         )
         assert response.status_code == 422
         services_mock.boot_sources.update_by_id.assert_not_called()
-
-    async def test_put_default_boot_source_rejects_disallowed_fields(
-        self,
-        services_mock: ServiceCollectionV3,
-        mocked_api_client_user_with_permissions: Callable[..., AsyncClient],
-    ) -> None:
-        """Updating a default boot source with a changed disallowed field
-        (e.g. name) returns 400."""
-        client = mocked_api_client_user_with_permissions(
-            MAASResourceEntitlement.CAN_EDIT_BOOT_ENTITIES,
-        )
-        services_mock.boot_sources = Mock(BootSourcesService)
-        services_mock.boot_sources.exists.return_value = False
-        services_mock.boot_sources.get_by_id.return_value = (
-            TEST_DEFAULT_BOOTSOURCE
-        )
-        services_mock.boot_sources.update_by_id.side_effect = BadRequestException(
-            details=[
-                BaseExceptionDetail(
-                    type=INVALID_ARGUMENT_VIOLATION_TYPE,
-                    message="'name' cannot be changed for MAAS default boot sources.",
-                    field="name",
-                )
-            ]
-        )
-
-        update_request = {
-            "name": "new name",
-            "url": TEST_DEFAULT_BOOTSOURCE.url,
-            "keyring_filename": "/path/to/keyring.gpg",
-            "keyring_data": "",
-            "priority": 15,
-            "skip_keyring_verification": False,
-            "enabled": True,
-        }
-        response = await client.put(
-            f"{self.BASE_PATH}/{TEST_DEFAULT_BOOTSOURCE.id}",
-            json=jsonable_encoder(update_request),
-        )
-        assert response.status_code == 400
-
-        error_response = ErrorBodyResponse(**response.json())
-        assert error_response.kind == "Error"
-        assert error_response.code == 400
 
     async def test_post_200(
         self,

--- a/src/tests/maasservicelayer/db/repositories/test_bootsources.py
+++ b/src/tests/maasservicelayer/db/repositories/test_bootsources.py
@@ -54,7 +54,7 @@ class TestBootSourcesRepository(RepositoryCommonTests[BootSource]):
     async def _setup_test_list(
         self, fixture: Fixture, num_objects: int
     ) -> list[BootSource]:
-        # The migration creates 2 boot sources (stable + candidate)
+        # The migration creates the stable boot source by default
         items = [
             BootSource(**row)
             for row in await fixture.get(BootSourceTable.name)

--- a/src/tests/maasservicelayer/services/test_boot_sources.py
+++ b/src/tests/maasservicelayer/services/test_boot_sources.py
@@ -5,10 +5,6 @@ from unittest.mock import Mock
 
 import pytest
 
-from maascommon.constants import (
-    CANDIDATE_IMAGES_STREAM_URL,
-    STABLE_IMAGES_STREAM_URL,
-)
 from maascommon.enums.events import EventTypeEnum
 from maascommon.workflows.bootresource import (
     FETCH_MANIFEST_AND_UPDATE_CACHE_WORKFLOW_NAME,
@@ -19,14 +15,10 @@ from maasservicelayer.db.filters import QuerySpec
 from maasservicelayer.db.repositories.bootsourcecache import (
     BootSourceCacheClauseFactory,
 )
-from maasservicelayer.db.repositories.bootsources import (
-    BootSourcesClauseFactory,
-    BootSourcesRepository,
-)
+from maasservicelayer.db.repositories.bootsources import BootSourcesRepository
 from maasservicelayer.db.repositories.bootsourceselections import (
     BootSourceSelectionClauseFactory,
 )
-from maasservicelayer.exceptions.catalog import BadRequestException
 from maasservicelayer.models.bootsources import BootSource
 from maasservicelayer.services.boot_sources import BootSourcesService
 from maasservicelayer.services.bootsourcecache import BootSourceCacheService
@@ -115,158 +107,12 @@ class TestBootSourcesService(ServiceCommonTests):
             {boot_source.id}
         )
 
-    @pytest.mark.parametrize(
-        "url",
-        [STABLE_IMAGES_STREAM_URL, CANDIDATE_IMAGES_STREAM_URL],
-    )
-    async def test_pre_delete_hook_rejects_default_boot_source(
-        self, service_instance, url
-    ):
-        now = utcnow()
-        boot_source = BootSource(
-            id=1,
-            created=now,
-            updated=now,
-            name="default",
-            url=url,
-            keyring_filename="",
-            keyring_data=b"",
-            priority=1,
-            skip_keyring_verification=False,
-            enabled=True,
-        )
-        with pytest.raises(BadRequestException):
-            await service_instance.pre_delete_hook(boot_source)
-
-    async def test_pre_delete_hook_allows_non_default_boot_source(
-        self, service_instance, test_instance
-    ):
-        await service_instance.pre_delete_hook(test_instance)
-
-    @pytest.fixture
-    def default_boot_source(self) -> BootSource:
-        now = utcnow()
-        return BootSource(
-            id=1,
-            created=now,
-            updated=now,
-            name="default",
-            url=STABLE_IMAGES_STREAM_URL,
-            keyring_filename="",
-            keyring_data=b"",
-            priority=1,
-            skip_keyring_verification=False,
-            enabled=True,
-        )
-
-    @pytest.mark.parametrize(
-        "builder",
-        [
-            BootSourceBuilder(priority=5),
-            BootSourceBuilder(enabled=False),
-            BootSourceBuilder(priority=5, enabled=False),
-        ],
-    )
-    async def test_pre_update_instance_allows_priority_and_enabled(
-        self, service_instance, default_boot_source, builder
-    ):
-        await service_instance.pre_update_instance(
-            default_boot_source, builder
-        )
-
-    @pytest.mark.parametrize(
-        "builder",
-        [
-            BootSourceBuilder(name="new-name"),
-            BootSourceBuilder(url="http://other.example.com"),
-            BootSourceBuilder(keyring_filename="/new/path"),
-            BootSourceBuilder(keyring_data=b"new-data"),
-            BootSourceBuilder(skip_keyring_verification=True),
-        ],
-    )
-    async def test_pre_update_instance_rejects_disallowed_fields(
-        self, service_instance, default_boot_source, builder
-    ):
-        with pytest.raises(BadRequestException):
-            await service_instance.pre_update_instance(
-                default_boot_source, builder
-            )
-
-    async def test_pre_update_instance_allows_unchanged_disallowed_fields(
-        self, service_instance, default_boot_source
-    ):
-        builder = BootSourceBuilder(
-            name=default_boot_source.name,
-            keyring_filename=default_boot_source.keyring_filename,
-            keyring_data=default_boot_source.keyring_data,
-            skip_keyring_verification=default_boot_source.skip_keyring_verification,
-            priority=5,
-        )
-        await service_instance.pre_update_instance(
-            default_boot_source, builder
-        )
-
-    @pytest.mark.parametrize(
-        "builder",
-        [
-            BootSourceBuilder(name="new-name"),
-            BootSourceBuilder(url="http://other.example.com"),
-            BootSourceBuilder(keyring_filename="/new/path"),
-            BootSourceBuilder(keyring_data=b"new-data"),
-            BootSourceBuilder(skip_keyring_verification=True),
-            BootSourceBuilder(priority=5),
-            BootSourceBuilder(enabled=False),
-        ],
-    )
-    async def test_pre_update_instance_allows_any_field_for_non_default(
-        self, service_instance, test_instance, builder
-    ):
-        await service_instance.pre_update_instance(test_instance, builder)
-
     async def test_disable_all(self, service_instance):
         service_instance.repository.update_many.return_value = []
         await service_instance.disable_all()
         service_instance.repository.update_many.assert_called_once_with(
             query=QuerySpec(),
             builder=BootSourceBuilder(enabled=False),
-        )
-
-    async def test_set_stable_enabled(self, service_instance):
-        service_instance.repository.get_one.return_value = BootSource(
-            id=1,
-            created=utcnow(),
-            updated=utcnow(),
-            name="stable",
-            url=STABLE_IMAGES_STREAM_URL,
-            keyring_filename="",
-            keyring_data=b"",
-            priority=2,
-            skip_keyring_verification=False,
-            enabled=False,
-        )
-        service_instance.repository.update_by_id.return_value = BootSource(
-            id=1,
-            created=utcnow(),
-            updated=utcnow(),
-            name="stable",
-            url=STABLE_IMAGES_STREAM_URL,
-            keyring_filename="",
-            keyring_data=b"",
-            priority=2,
-            skip_keyring_verification=False,
-            enabled=True,
-        )
-        await service_instance.set_stable_enabled()
-        service_instance.repository.get_one.assert_called_once_with(
-            query=QuerySpec(
-                where=BootSourcesClauseFactory.with_url(
-                    STABLE_IMAGES_STREAM_URL
-                )
-            )
-        )
-        service_instance.repository.update_by_id.assert_called_once_with(
-            id=1,
-            builder=BootSourceBuilder(enabled=True),
         )
 
     async def test_post_create_hook_creates_event(


### PR DESCRIPTION
Let's postpone this change to MAAS 4.x, as it will break some automation.
Also, don't create the candidate boot source.