### PR TITLE
chore: update starlette docs dep reference to 1.0.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -111,7 +111,7 @@ sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==2.0.0
 sphinxcontrib-serializinghtml==2.0.0
 sphinxcontrib-svg2pdfconverter==2.1.0
-starlette==1.0.0
+starlette==1.0.1
 tinycss2==1.5.1
 typing-extensions==4.15.0
 uc-micro-py==2.0.0


### PR DESCRIPTION
Helps in avoiding flagging from security scanners.

This creates a slight mismatch between what we actually use as dependency
on MAAS, and what we are using to just be able to generate the API/CLI
reference, but since there are no breaking changes (at least hitting
the code paths that the API/CLI reference walk through) this does not
create issues.