### PR TITLE
fix: preserve installation log pointer after machine release (#316)

### DIFF
--- a/src/maasserver/models/node.py
+++ b/src/maasserver/models/node.py
@@ -3970,7 +3970,6 @@ class Node(CleanSave, TimestampedModel):
         self.distro_series = ""
         self.license_key = ""
         self.hwe_kernel = None
-        self.current_installation_script_set = None
         self.install_rackd = False
         self.install_kvm = False
         self.register_vmhost = False

--- a/src/maasserver/models/tests/test_node.py
+++ b/src/maasserver/models/tests/test_node.py
@@ -3248,14 +3248,21 @@ class TestNode(MAASServerTestCase):
             node.release()
         self.assertIsNone(reload_object(hugepages))
 
-    def test_releases_clears_current_installation_script_set(self):
+    def test_release_preserves_current_installation_script_set(self):
         node = factory.make_Node(
             status=NODE_STATUS.ALLOCATED, owner=factory.make_User()
         )
+        script_set = factory.make_ScriptSet(
+            node=node, result_type=RESULT_TYPE.INSTALLATION
+        )
+        node.current_installation_script_set = script_set
+        node.save()
         self.patch(node, "_stop")
         with post_commit_hooks:
             node.release()
-        self.assertIsNone(node.current_installation_script_set)
+        self.assertEqual(
+            script_set, reload_object(node).current_installation_script_set
+        )
 
     def test_accept_enlistment_gets_node_out_of_declared_state(self):
         # If called on a node in New state, accept_enlistment()


### PR DESCRIPTION
Releasing a machine cleared current_installation_script_set, so the CLI could not resolve current-installation even though install logs still existed in the database.

Resolves [LP:2155055](https://bugs.launchpad.net/maas/+bug/2155055)

(cherry picked from commit 38fa551506d26403c8abbd58902c86c461d873d9)