### PR TITLE
fix(dhcp): remove dhcpd6-interfaces when no IPv6 interfaces are configured

### DIFF
--- a/src/maasagent/internal/dhcp/service.go
+++ b/src/maasagent/internal/dhcp/service.go
@@ -567,6 +567,15 @@ func (s *DHCPService) configureViaFile(ctx context.Context) error {
 		}
 
 		path := s.dataPathFactory(file)
+
+		if !hasData && (file == "dhcpd-interfaces" || file == "dhcpd6-interfaces") {
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				return err
+			}
+
+			continue
+		}
+
 		if err := writeConfigFile(path, data, mode); err != nil {
 			return err
 		}

--- a/src/maasagent/internal/dhcp/service_test.go
+++ b/src/maasagent/internal/dhcp/service_test.go
@@ -430,6 +430,58 @@ func (s *DHCPServiceTestSuite) TestConfigureViaFile() {
 	}
 }
 
+// TestConfigureViaFileNoV4Interfaces ensures that when no IPv4 interfaces are
+// configured, the dhcpd-interfaces file is removed.
+func (s *DHCPServiceTestSuite) TestConfigureViaFileNoV4Interfaces() {
+	v4InterfacesPath := s.svc.dataPathFactory("dhcpd-interfaces")
+	err := os.WriteFile(v4InterfacesPath, []byte("eth0"), 0o640)
+	s.Require().NoError(err)
+
+	config := `{
+    "dhcpd": "",
+    "dhcpd_interfaces": "",
+    "dhcpd6": "Y29uZmlndXJhdGlvbl92Ng==",
+    "dhcpd6_interfaces": "aW50ZXJmYWNlc192Ng=="
+  }`
+
+	s.configAPIResponse = []byte(config)
+	_, err = s.activityEnv.ExecuteActivity(
+		"configure-dhcp-via-file",
+	)
+	assert.NoError(s.T(), err)
+
+	_, err = os.Stat(v4InterfacesPath)
+	assert.True(s.T(), os.IsNotExist(err), "dhcpd-interfaces should not exist when no IPv4 interfaces are configured")
+
+	assert.False(s.T(), s.svc.runningV4.Load())
+}
+
+// TestConfigureViaFileNoV6Interfaces ensures that when no IPv6 interfaces are
+// configured, the dhcpd6-interfaces file is removed.
+func (s *DHCPServiceTestSuite) TestConfigureViaFileNoV6Interfaces() {
+	v6InterfacesPath := s.svc.dataPathFactory("dhcpd6-interfaces")
+	err := os.WriteFile(v6InterfacesPath, []byte("eth0"), 0o640)
+	s.Require().NoError(err)
+
+	config := `{
+    "dhcpd": "Y29uZmlndXJhdGlvbl92NA==",
+    "dhcpd_interfaces": "aW50ZXJmYWNlc192NA==",
+    "dhcpd6": "Y29uZmlndXJhdGlvbl92Ng==",
+    "dhcpd6_interfaces": ""
+  }`
+
+	s.configAPIResponse = []byte(config)
+	_, err = s.activityEnv.ExecuteActivity(
+		"configure-dhcp-via-file",
+	)
+	assert.NoError(s.T(), err)
+
+	_, err = os.Stat(v6InterfacesPath)
+	assert.True(s.T(), os.IsNotExist(err), "dhcpd6-interfaces should not exist when no IPv6 interfaces are configured")
+
+	assert.False(s.T(), s.svc.runningV6.Load())
+}
+
 func TestHostMarshalJSON(t *testing.T) {
 	h := Host{
 		Hostname: "localhost",


### PR DESCRIPTION
When no IPv6 interfaces are active, writing an empty dhcpd6-interfaces file still satisfies the systemd ConditionPathExists gate, causing dhcpd6 to attempt to start and fail. Remove the file instead so the service stays inactive.

Resolves LP:2156076