### PR TITLE
docs: split docs django piston3 dependency

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -36,4 +36,4 @@ formats:
 # Optionally declare the Python requirements required to build your docs
 python:
   install:
-  - requirements: docs/requirements.txt
+  - requirements: docs/requirements-github.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -59,7 +59,7 @@ $(VENVDIR):
 	@echo "... setting up virtualenv"
 	python3 -m venv $(VENVDIR) || { echo "You must install python3-venv and python3-dev before you can build the documentation."; exit 1; }
 	. $(VENV); pip install $(PIPOPTS) --require-virtualenv \
-	    --upgrade -r requirements.txt \
+	    --upgrade -r requirements-launchpad.txt \
             --log $(VENVDIR)/pip_install.log
 	@test ! -f $(VENVDIR)/pip_list.txt || \
             mv $(VENVDIR)/pip_list.txt $(VENVDIR)/pip_list.txt.bak

--- a/docs/requirements-github.txt
+++ b/docs/requirements-github.txt
@@ -1,0 +1,6 @@
+# Intended mainly for RTD builds, to avoid
+# availability issues that we experience with launchpad.
+
+-r requirements.txt
+
+git+https://github.com/canonical/django-piston3.git

--- a/docs/requirements-launchpad.txt
+++ b/docs/requirements-launchpad.txt
@@ -1,0 +1,8 @@
+# Intended mainly for deb builds, since they cannot use
+# github sources. For consistency, we do the same for snaps and local tests.
+#
+# Suffers from availability issues in launchpad.
+
+-r requirements.txt
+
+git+https://git.launchpad.net/django-piston3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,9 @@
+# This requirements.txt does not contemplate all necessary dependencies.
+# It is missing specifically one: django-piston3. 
+#
+# Look at requirements-launchpad.txt or requirements-github.txt
+# depending on your usecase.
+
 # Canonical theme (still needed for Furo theme and custom templates)
 canonical-sphinx==0.6.0
 
@@ -27,7 +33,6 @@ vale==3.13.0.0
 
 # Bare minimum MAAS dependencies for API documentation generation
 django==5.2.9
-git+https://github.com/canonical/django-piston3.git
 aiofiles==25.1.0
 aiohttp==3.13.5
 Authlib==1.6.9


### PR DESCRIPTION
We need to use the launchpad dependency in order to build the deb. 

The split is not the prettiest thing, but it maintains things in `requirements.txt` files (which is what the [sphinx-stack](https://github.com/canonical/sphinx-stack/blob/main/docs/requirements.txt) uses), and allows us to avoid random build failures in the RTD builds.

We could theoretically do something a little cleaner with a `pyproject.toml`, but again this would deviate from the "standard" above. It is also a simple enough situation.