### PR TITLE
fix: handle exceptions when decrypting cookies and log a warning

### DIFF
--- a/src/maasapiserver/v3/auth/cookie_manager.py
+++ b/src/maasapiserver/v3/auth/cookie_manager.py
@@ -3,10 +3,15 @@
 
 from enum import StrEnum
 
+from cryptography.exceptions import InvalidTag
 from starlette.requests import Request
 from starlette.responses import Response
+import structlog
 
+from maascommon.logging.security import SECURITY
 from maasservicelayer.utils.encryptor import Encryptor
+
+logger = structlog.getLogger(__name__)
 
 MAAS_STATE_COOKIE_NAME = "maas.auth_state_cookie"
 MAAS_NONCE_COOKIE_NAME = "maas.auth_nonce_cookie"
@@ -86,7 +91,16 @@ class EncryptedCookieManager:
         encrypted_value = self.request.cookies.get(key)
         if encrypted_value is None:
             return None
-        return self.encryptor.decrypt(encrypted_value)
+
+        try:
+            return self.encryptor.decrypt(encrypted_value)
+        except (ValueError, InvalidTag):
+            # Catch the exceptions raised by the decrypt method, which usually
+            # mean that the token was manually altered.
+            logger.warning(
+                f"Invalid encrypted cookie '{key}' received.", type=SECURITY
+            )
+            return None
 
     def clear_cookie(self, key: str) -> None:
         self._apply_cookie(key, "", max_age=0, expires=0)

--- a/src/tests/maasapiserver/v3/auth/test_cookie_manager.py
+++ b/src/tests/maasapiserver/v3/auth/test_cookie_manager.py
@@ -103,7 +103,7 @@ class TestCookieManager:
         response = Mock()
         encryptor = Mock()
         encryptor.decrypt.side_effect = exception
-        mock_logger = mocker.patch("maasapiserver.v3.auth.cookie_manager")
+        mock_logger = mocker.patch("maasapiserver.v3.auth.cookie_manager.logger")
 
         manager = EncryptedCookieManager(
             request, encryptor=encryptor, response=response, ttl_seconds=1200

--- a/src/tests/maasapiserver/v3/auth/test_cookie_manager.py
+++ b/src/tests/maasapiserver/v3/auth/test_cookie_manager.py
@@ -1,11 +1,15 @@
 from unittest.mock import Mock
 
+from cryptography.exceptions import InvalidTag
+import pytest
+
 from maasapiserver.v3.auth.cookie_manager import (
     EncryptedCookieManager,
     MAAS_NONCE_COOKIE_NAME,
     MAAS_STATE_COOKIE_NAME,
     MAASOAuth2Cookie,
 )
+from maascommon.logging.security import SECURITY
 
 
 class TestCookieManager:
@@ -89,6 +93,29 @@ class TestCookieManager:
 
         request.cookies.get.assert_called_once_with("missing_key")
         assert result is None
+
+    @pytest.mark.parametrize("exception", [ValueError(), InvalidTag()])
+    def test_cookie_returns_none_when_cookie_not_valid_and_logs_warning(
+        self, exception, mocker
+    ) -> None:
+        request = Mock()
+        request.cookies.get.return_value = "a"
+        response = Mock()
+        encryptor = Mock()
+        encryptor.decrypt.side_effect = exception
+        mock_logger = mocker.patch("maasapiserver.v3.auth.cookie_manager")
+
+        manager = EncryptedCookieManager(
+            request, encryptor=encryptor, response=response, ttl_seconds=1200
+        )
+
+        result = manager.get_cookie("invalid")
+
+        request.cookies.get.assert_called_once_with("invalid")
+        assert result is None
+        mock_logger.warning.assert_called_once_with(
+            "Invalid encrypted cookie 'invalid' received.", type=SECURITY
+        )
 
     def test_clear_cookie(self) -> None:
         request = Mock()

--- a/src/tests/maasapiserver/v3/auth/test_cookie_manager.py
+++ b/src/tests/maasapiserver/v3/auth/test_cookie_manager.py
@@ -103,7 +103,9 @@ class TestCookieManager:
         response = Mock()
         encryptor = Mock()
         encryptor.decrypt.side_effect = exception
-        mock_logger = mocker.patch("maasapiserver.v3.auth.cookie_manager.logger")
+        mock_logger = mocker.patch(
+            "maasapiserver.v3.auth.cookie_manager.logger"
+        )
 
         manager = EncryptedCookieManager(
             request, encryptor=encryptor, response=response, ttl_seconds=1200


### PR DESCRIPTION
CookieManager.decrypt method can raise exceptions in the following scenarios:
- if the cookie is not of the expected length, a `ValueError` is raised
- if the cookie is not cryptographically valid, an `InvalidTag` is raised

In any case, log a warning since the cookie was probably manually altered.