### PR TITLE
docs: allow downloading the html bundle from RTD

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -32,6 +32,7 @@ sphinx:
 # If using Sphinx, optionally build your docs in additional formats such as PDF
 formats:
 - pdf
+- htmlzip
 
 # Optionally declare the Python requirements required to build your docs
 python:


### PR DESCRIPTION
This makes it easier for someone to have an offline version if they want, independently from having our own "bundled" version inside the snap/deb.