### PR TITLE
fix(network): normalize and enforce canonical interface MAC addresses

### DIFF
--- a/src/maascommon/fields.py
+++ b/src/maascommon/fields.py
@@ -37,3 +37,14 @@ def normalise_macaddress(mac: str) -> str:
         case _:  # single-byte tokens
             tokens = (token.zfill(2) for token in tokens)
     return ":".join(tokens)
+
+
+def normalise_mac_query(value: str) -> str:
+    """Return a separator-less, lowercase form of a full or partial MAC.
+
+    Unlike ``normalise_macaddress``, this accepts partial fragments and does
+    not pad or group, so it can be used to build format-agnostic
+    ``startswith``/``contains`` queries against the separator-less form of the
+    stored MAC address.
+    """
+    return MAC_SPLIT_RE.sub("", value.lower())

--- a/src/maasserver/fields.py
+++ b/src/maasserver/fields.py
@@ -15,6 +15,7 @@ from django.db.models import (
     Field,
     GenericIPAddressField,
     IntegerField,
+    lookups,
     Q,
     TextField,
     URLField,
@@ -23,7 +24,12 @@ from django.utils.deconstruct import deconstructible
 from django.utils.encoding import force_str
 from netaddr import AddrFormatError, IPNetwork
 
-from maascommon.fields import MAC_FIELD_RE, MAC_RE, normalise_macaddress
+from maascommon.fields import (
+    MAC_FIELD_RE,
+    MAC_RE,
+    normalise_mac_query,
+    normalise_macaddress,
+)
 from maasserver.models.versionedtextfile import VersionedTextFile
 from maasserver.utils.dns import validate_domain_name
 from maasserver.utils.orm import get_one, validate_in_transaction
@@ -72,7 +78,7 @@ class MACAddressField(TextField):
         # Only normalize complete MACs. Partial fragments (e.g. the value
         # behind a ``__contains``/``__startswith`` lookup) are passed through
         # untouched so pattern queries keep working.
-        if value and MAC_FIELD_RE.match(value):
+        if value and MAC_FIELD_RE.fullmatch(value):
             return normalise_macaddress(value)
         return value
 
@@ -86,6 +92,45 @@ class MACAddressField(TextField):
 
     def get_prep_value(self, value):
         return self._normalize(super().get_prep_value(value))
+
+
+class _MACPatternLookup(lookups.PatternLookup):
+    """Match a full or partial MAC ignoring separators and case.
+
+    The search term is reduced to its separator-less, lowercase form and
+    compared against the separator-less form of the stored MAC, so
+    ``00-16-3E``, ``00:16:3e`` and ``00163e`` all match the canonical
+    ``aa:bb:cc:dd:ee:ff`` storage.
+    """
+
+    def get_prep_lookup(self):
+        if isinstance(self.rhs, str):
+            self.rhs = normalise_mac_query(self.rhs)
+        return super().get_prep_lookup()
+
+    def process_lhs(self, compiler, connection, lhs=None):
+        lhs_sql, params = super().process_lhs(compiler, connection, lhs)
+        return f"REPLACE({lhs_sql}, ':', '')", params
+
+
+@MACAddressField.register_lookup
+class MACContains(_MACPatternLookup, lookups.Contains):
+    pass
+
+
+@MACAddressField.register_lookup
+class MACIContains(_MACPatternLookup, lookups.Contains):
+    lookup_name = "icontains"
+
+
+@MACAddressField.register_lookup
+class MACStartsWith(_MACPatternLookup, lookups.StartsWith):
+    pass
+
+
+@MACAddressField.register_lookup
+class MACIStartsWith(_MACPatternLookup, lookups.StartsWith):
+    lookup_name = "istartswith"
 
 
 class XMLField(Field):

--- a/src/maasserver/fields.py
+++ b/src/maasserver/fields.py
@@ -16,6 +16,7 @@ from django.db.models import (
     GenericIPAddressField,
     IntegerField,
     Q,
+    TextField,
     URLField,
 )
 from django.utils.deconstruct import deconstructible
@@ -55,6 +56,36 @@ class MACAddressFormField(forms.CharField):
     def clean(self, value):
         value = super().clean(value)
         return normalise_macaddress(value)
+
+
+class MACAddressField(TextField):
+    """Model field that stores MAC addresses in a single canonical form.
+
+    Normalizes both values written to the database and values used in exact
+    lookups, so the same MAC supplied in a different case or separator style
+    (``AA-BB-CC-DD-EE-FF`` vs ``aa:bb:cc:dd:ee:ff``) always resolves to the
+    same stored value. This prevents inconsistently formatted MACs from
+    bypassing the uniqueness checks.
+    """
+
+    def _normalize(self, value):
+        # Only normalize complete MACs. Partial fragments (e.g. the value
+        # behind a ``__contains``/``__startswith`` lookup) are passed through
+        # untouched so pattern queries keep working.
+        if value and MAC_FIELD_RE.match(value):
+            return normalise_macaddress(value)
+        return value
+
+    def pre_save(self, model_instance, add):
+        # Normalize on save and write the canonical value back onto the
+        # instance, so the in-memory attribute matches what is persisted
+        # without requiring a reload.
+        value = self._normalize(getattr(model_instance, self.attname))
+        setattr(model_instance, self.attname, value)
+        return value
+
+    def get_prep_value(self, value):
+        return self._normalize(super().get_prep_value(value))
 
 
 class XMLField(Field):

--- a/src/maasserver/forms/__init__.py
+++ b/src/maasserver/forms/__init__.py
@@ -1513,16 +1513,16 @@ class WithMACAddressesMixin:
         for mac in data:
             if self.instance.id is not None:
                 query = (
-                    Interface.objects.filter(mac_address=mac.lower())
+                    Interface.objects.filter(mac_address=mac)
                     .exclude(node_config__node=self.instance)
                     .exclude(type=INTERFACE_TYPE.UNKNOWN)
                 )
             else:
                 # This node does not exist yet, we should only check if this
                 # MAC address is already attached to another node.
-                query = Interface.objects.filter(
-                    mac_address=mac.lower()
-                ).exclude(type=INTERFACE_TYPE.UNKNOWN)
+                query = Interface.objects.filter(mac_address=mac).exclude(
+                    type=INTERFACE_TYPE.UNKNOWN
+                )
             for iface in query:
                 node = iface.node_config.node
                 errors.append(self._mac_in_use_on_node_error(mac, node))

--- a/src/maasserver/forms/tests/test_interface.py
+++ b/src/maasserver/forms/tests/test_interface.py
@@ -334,6 +334,42 @@ class TestPhysicalInterfaceForm(MAASServerTestCase):
         self.assertEqual(interface.numa_node, node.default_numanode)
         self.assertCountEqual([], interface.parents.all())
 
+    def test_creates_physical_interface_normalises_mac_address(self):
+        node = factory.make_Node()
+        form = PhysicalInterfaceForm(
+            node=node,
+            data={
+                "name": "eth0",
+                "mac_address": "AA:BB:CC:DD:EE:FF",
+            },
+        )
+        self.assertTrue(form.is_valid(), dict(form.errors))
+        with post_commit_hooks:
+            interface = form.save()
+        self.assertEqual(interface.mac_address, "aa:bb:cc:dd:ee:ff")
+
+    def test_rejects_duplicate_mac_address_with_different_case(self):
+        node = factory.make_Node()
+        factory.make_Interface(
+            INTERFACE_TYPE.PHYSICAL,
+            node=node,
+            name="eth0",
+            mac_address="aa:bb:cc:dd:ee:ff",
+        )
+        form = PhysicalInterfaceForm(
+            node=node,
+            data={
+                "name": "eth1",
+                "mac_address": "AA:BB:CC:DD:EE:FF",
+            },
+        )
+        self.assertFalse(form.is_valid(), dict(form.errors))
+        self.assertIn("mac_address", form.errors)
+        self.assertIn(
+            "This MAC address is already in use",
+            form.errors["mac_address"][0],
+        )
+
     def test_create_ensures_link_up(self):
         node = factory.make_Node()
         mac_address = factory.make_mac_address()

--- a/src/maasserver/models/interface.py
+++ b/src/maasserver/models/interface.py
@@ -54,7 +54,7 @@ from maasserver.exceptions import (
     StaticIPAddressReservedIPConflict,
     StaticIPAddressUnavailable,
 )
-from maasserver.fields import MAC_VALIDATOR
+from maasserver.fields import MAC_VALIDATOR, MACAddressField
 from maasserver.models.cleansave import CleanSave
 from maasserver.models.reservedip import ReservedIP
 from maasserver.models.staticipaddress import StaticIPAddress
@@ -587,7 +587,9 @@ class Interface(CleanSave, TimestampedModel):
         "StaticIPAddress", editable=True, blank=True
     )
 
-    mac_address = TextField(null=True, blank=True, validators=[MAC_VALIDATOR])
+    mac_address = MACAddressField(
+        null=True, blank=True, validators=[MAC_VALIDATOR]
+    )
 
     params = JSONField(blank=True, default=dict)
 

--- a/src/maasserver/models/tests/test_interface.py
+++ b/src/maasserver/models/tests/test_interface.py
@@ -1729,6 +1729,39 @@ class TestPhysicalInterface(MAASServerTestCase):
             error.message_dict,
         )
 
+    def test_mac_address_is_normalised_on_save(self):
+        node_config = factory.make_NodeConfig()
+        interface = PhysicalInterface(
+            node_config=node_config,
+            mac_address="AA:BB:CC:DD:EE:FF",
+            name=factory.make_name("eth"),
+        )
+        interface.save()
+        self.assertEqual(interface.mac_address, "aa:bb:cc:dd:ee:ff")
+
+    def test_mac_address_uniqueness_ignores_case(self):
+        node_config = factory.make_NodeConfig()
+        interface = factory.make_Interface(
+            INTERFACE_TYPE.PHYSICAL,
+            node_config=node_config,
+            mac_address="aa:bb:cc:dd:ee:ff",
+        )
+        bad_interface = PhysicalInterface(
+            node_config=node_config,
+            mac_address="AA:BB:CC:DD:EE:FF",
+            name=factory.make_name("eth"),
+        )
+        error = self.assertRaises(ValidationError, bad_interface.save)
+        self.assertEqual(
+            {
+                "mac_address": [
+                    "This MAC address is already in use by %s."
+                    % (interface.get_log_string())
+                ]
+            },
+            error.message_dict,
+        )
+
     def test_mac_address_can_be_duplicated_for_other_nodeconfig(self):
         node = factory.make_Node()
         if1 = factory.make_Interface(

--- a/src/maasserver/rpc/boot.py
+++ b/src/maasserver/rpc/boot.py
@@ -14,7 +14,6 @@ from maascommon.utils.url import splithost
 from maasserver.compose_preseed import RSYSLOG_PORT
 from maasserver.dns.config import get_resource_name_for_subnet
 from maasserver.enum import BOOT_RESOURCE_FILE_TYPE, INTERFACE_TYPE
-from maasserver.fields import normalise_macaddress
 from maasserver.models import (
     BootResource,
     Config,
@@ -68,9 +67,6 @@ def get_node_from_mac_or_hardware_uuid(mac=None, hardware_uuid=None):
     hardware UUID exists.
     """
     if mac:
-        if "-" in mac:
-            mac = normalise_macaddress(mac)
-
         q = Q(
             current_config__interface__type=INTERFACE_TYPE.PHYSICAL,
             current_config__interface__mac_address=mac,
@@ -570,7 +566,7 @@ def get_config(
                 machine.boot_interface = (
                     machine.current_config.interface_set.get(
                         type=INTERFACE_TYPE.PHYSICAL,
-                        mac_address=normalise_macaddress(mac),
+                        mac_address=mac,
                     )
                 )
             except ObjectDoesNotExist:

--- a/src/maasserver/tests/test_fields.py
+++ b/src/maasserver/tests/test_fields.py
@@ -24,6 +24,7 @@ from maasserver.fields import (
     VersionedTextFileField,
 )
 from maasserver.models import Node, VersionedTextFile
+from maasserver.models.interface import Interface
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import (
     MAASLegacyServerTestCase,
@@ -856,3 +857,49 @@ class TestIPWithOptionalPort(MAASTestCase):
             self.assertEqual(
                 "Invalid IPv4/IPv6 address with optional port.", error.message
             )
+
+
+class TestMACAddressFieldLookups(MAASServerTestCase):
+    """Format-agnostic ``startswith``/``contains`` lookups on mac_address."""
+
+    def make_interface(self, mac_address):
+        return factory.make_Interface(mac_address=mac_address)
+
+    def test_startswith_ignores_separator_and_case(self):
+        interface = self.make_interface("00:16:3e:55:60:96")
+        for term in ("00:16:3E", "00-16-3e", "00163E", "0016.3e55"):
+            self.assertEqual(
+                [interface],
+                list(Interface.objects.filter(mac_address__startswith=term)),
+                term,
+            )
+
+    def test_startswith_does_not_match_other_prefix(self):
+        self.make_interface("00:16:3e:55:60:96")
+        self.assertEqual(
+            [],
+            list(Interface.objects.filter(mac_address__startswith="aa:bb")),
+        )
+
+    def test_contains_ignores_separator_and_case(self):
+        interface = self.make_interface("00:16:3e:55:60:96")
+        for term in ("3E:55", "3e-55", "3e55"):
+            self.assertEqual(
+                [interface],
+                list(Interface.objects.filter(mac_address__contains=term)),
+                term,
+            )
+
+    def test_contains_does_not_match_absent_fragment(self):
+        self.make_interface("00:16:3e:55:60:96")
+        self.assertEqual(
+            [],
+            list(Interface.objects.filter(mac_address__contains="ffff")),
+        )
+
+    def test_icontains_behaves_like_contains(self):
+        interface = self.make_interface("00:16:3e:55:60:96")
+        self.assertEqual(
+            [interface],
+            list(Interface.objects.filter(mac_address__icontains="3E-55")),
+        )

--- a/src/maasservicelayer/builders/interfaces.py
+++ b/src/maasservicelayer/builders/interfaces.py
@@ -7,6 +7,7 @@ from pydantic import Field
 
 from maascommon.enums.interface import InterfaceType
 from maasservicelayer.models.base import ResourceBuilder, UNSET, Unset
+from maasservicelayer.models.fields import MacAddress
 from maasservicelayer.models.interfaces import Link
 
 
@@ -23,7 +24,7 @@ class InterfaceBuilder(ResourceBuilder):
     link_connected: bool | Unset = Field(default=UNSET)
     link_speed: int | Unset = Field(default=UNSET)
     links: list[Link] | Unset = Field(default=UNSET)
-    mac_address: str | None | Unset = Field(default=UNSET)
+    mac_address: MacAddress | None | Unset = Field(default=UNSET)
     name: str | Unset = Field(default=UNSET)
     node_config_id: int | None | Unset = Field(default=UNSET)
     sriov_max_vf: int | Unset = Field(default=UNSET)

--- a/src/maasservicelayer/db/alembic/versions/0023_normalize_interface_mac_addresses.py
+++ b/src/maasservicelayer/db/alembic/versions/0023_normalize_interface_mac_addresses.py
@@ -1,0 +1,136 @@
+# Copyright 2026 Canonical Ltd. This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+"""normalize_interface_mac_addresses
+
+Revision ID: 0023
+Revises: 0022
+Create Date: 2026-06-16 00:00:00.000000+00:00
+
+"""
+
+from itertools import chain
+import re
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0023"
+down_revision: str | None = "0022"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Frozen copy of maascommon.fields.normalise_macaddress. Migrations must not
+# depend on application code that can change over time.
+_MAC_SPLIT_RE = re.compile(r"[-:.]")
+
+# Canonical stored form: lowercase, colon-separated, zero-padded octets.
+_CANONICAL_MAC_RE = "^([0-9a-f]{2}:){5}[0-9a-f]{2}$"
+
+_CHECK_CONSTRAINT_NAME = "maasserver_interface_mac_address_canonical"
+
+
+def _normalize_mac(mac: str) -> str:
+    tokens = _MAC_SPLIT_RE.split(mac.lower())
+    match len(tokens):
+        case 1:  # no separator
+            tokens = re.findall("..", tokens[0])
+        case 3:  # each token is two bytes
+            tokens = chain(
+                *(re.findall("..", token.zfill(4)) for token in tokens)
+            )
+        case _:  # single-byte tokens
+            tokens = (token.zfill(2) for token in tokens)
+    return ":".join(tokens)
+
+
+def upgrade() -> None:
+    connection = op.get_bind()
+    rows = connection.execute(
+        sa.text(
+            "SELECT i.id, i.node_config_id, i.mac_address, i.type, "
+            "nc.node_id, n.system_id "
+            "FROM maasserver_interface i "
+            "LEFT JOIN maasserver_nodeconfig nc ON nc.id = i.node_config_id "
+            "LEFT JOIN maasserver_node n ON n.id = nc.node_id "
+            "WHERE i.mac_address IS NOT NULL"
+        )
+    ).fetchall()
+
+    changed = []
+    # Physical interfaces sharing a MAC are only legitimate when they belong to
+    # the same node under different node configs (e.g. the same NIC seen in the
+    # commissioning and deployment configs). Sharing within a single node_config
+    # violates maasserver_interface_node_config_mac_address_uniq, and sharing
+    # across different nodes violates the application-level uniqueness rules;
+    # both must be resolved before the canonical format is enforced.
+    physical_by_mac: dict[str, list] = {}
+    for row in rows:
+        # An empty MAC address is a valid "no MAC" marker (e.g. for unknown
+        # interfaces); leave it untouched and skip normalization.
+        if row.mac_address == "":
+            continue
+        normalized = _normalize_mac(row.mac_address)
+        if normalized != row.mac_address:
+            changed.append({"id": row.id, "mac": normalized})
+        if row.type == "physical" and row.node_config_id is not None:
+            physical_by_mac.setdefault(normalized, []).append(row)
+
+    conflicts: list[str] = []
+    for normalized, interfaces in physical_by_mac.items():
+        if len(interfaces) < 2:
+            continue
+        node_ids = {iface.node_id for iface in interfaces}
+        node_config_ids = [iface.node_config_id for iface in interfaces]
+        same_node = len(node_ids) == 1
+        distinct_node_configs = len(set(node_config_ids)) == len(
+            node_config_ids
+        )
+        if same_node and distinct_node_configs:
+            continue
+        details = ", ".join(
+            f"{iface.id} (node {iface.system_id}, "
+            f"node_config {iface.node_config_id})"
+            for iface in sorted(interfaces, key=lambda iface: iface.id)
+        )
+        conflicts.append(f"{normalized}: interfaces {details}")
+
+    if conflicts:
+        raise RuntimeError(
+            "Cannot normalize interface MAC addresses: doing so would create "
+            "duplicate physical interfaces. MAAS requires every physical "
+            "interface to have a unique MAC address, unless the same node "
+            "exposes it under different node configurations. Remove or correct "
+            "the conflicting interfaces listed below, then retry the upgrade "
+            "(see the MAAS release notes for guidance on resolving duplicate "
+            "MAC addresses):\n" + "\n".join(conflicts)
+        )
+
+    if changed:
+        # A data migration runs in a single transaction and can fire triggers.
+        # Disable MAAS's own triggers (USER, not ALL) for the bulk update: ALL
+        # also targets internal referential-integrity triggers, which requires
+        # superuser privileges the upgrade role does not have.
+        op.execute("ALTER TABLE maasserver_interface DISABLE TRIGGER USER;")
+        connection.execute(
+            sa.text(
+                "UPDATE maasserver_interface SET mac_address = :mac "
+                "WHERE id = :id"
+            ),
+            changed,
+        )
+        op.execute("ALTER TABLE maasserver_interface ENABLE TRIGGER USER;")
+
+    op.create_check_constraint(
+        _CHECK_CONSTRAINT_NAME,
+        "maasserver_interface",
+        "mac_address IS NULL OR mac_address = '' "
+        f"OR mac_address ~ '{_CANONICAL_MAC_RE}'",
+    )
+
+
+def downgrade() -> None:
+    # We do not support migration downgrade
+    pass

--- a/src/maasservicelayer/db/repositories/interfaces.py
+++ b/src/maasservicelayer/db/repositories/interfaces.py
@@ -11,6 +11,7 @@ from sqlalchemy.sql.operators import eq
 
 from maascommon.enums.interface import InterfaceType
 from maascommon.enums.ipaddress import IpAddressType
+from maascommon.fields import normalise_macaddress
 from maasservicelayer.db.filters import Clause, ClauseFactory
 from maasservicelayer.db.repositories.base import BaseRepository
 from maasservicelayer.db.tables import (
@@ -39,7 +40,12 @@ class InterfaceClauseFactory(ClauseFactory):
 
     @classmethod
     def with_mac_address(cls, mac_address: str) -> Clause:
-        return Clause(condition=eq(InterfaceTable.c.mac_address, mac_address))
+        return Clause(
+            condition=eq(
+                InterfaceTable.c.mac_address,
+                normalise_macaddress(mac_address),
+            )
+        )
 
     @classmethod
     def with_vlan_id_in(cls, vlan_ids: list[int]) -> Clause:
@@ -115,7 +121,7 @@ class InterfaceRepository(BaseRepository):
 
     async def get_interfaces_for_mac(self, mac: str) -> List[Interface]:
         stmt = self._select_all_statement().filter(
-            InterfaceTable.c.mac_address == mac
+            InterfaceTable.c.mac_address == normalise_macaddress(mac)
         )
 
         result = (await self.execute_stmt(stmt)).all()
@@ -180,7 +186,7 @@ class InterfaceRepository(BaseRepository):
             .returning(InterfaceTable.c.id)
             .values(
                 name=name,
-                mac_address=mac,
+                mac_address=normalise_macaddress(mac),
                 switch_id=switch_id,
                 type=InterfaceType.PHYSICAL,
                 params={},
@@ -211,7 +217,7 @@ class InterfaceRepository(BaseRepository):
             .returning(InterfaceTable.c.id)
             .values(
                 name=UNKNOWN_INTERFACE_NAME,
-                mac_address=mac,
+                mac_address=normalise_macaddress(mac),
                 vlan_id=vlan_id,
                 type=InterfaceType.UNKNOWN,
                 params={},

--- a/src/maasservicelayer/db/tables.py
+++ b/src/maasservicelayer/db/tables.py
@@ -4,6 +4,7 @@
 from sqlalchemy import (
     BigInteger,
     Boolean,
+    CheckConstraint,
     Column,
     Date,
     DateTime,
@@ -1040,6 +1041,11 @@ InterfaceTable = Table(
         nullable=True,
     ),
     UniqueConstraint("node_config_id", "name"),
+    CheckConstraint(
+        "mac_address IS NULL OR mac_address = '' OR "
+        "mac_address ~ '^([0-9a-f]{2}:){5}[0-9a-f]{2}$'",
+        name="maasserver_interface_mac_address_canonical",
+    ),
     Index("maasserver_interface_vlan_id_5f39995d", "vlan_id"),
     Index("maasserver_interface_numa_node_id_6e790407", "numa_node_id"),
     Index("maasserver_interface_node_config_id_a52b0f8a", "node_config_id"),

--- a/src/maasservicelayer/models/fields.py
+++ b/src/maasservicelayer/models/fields.py
@@ -91,11 +91,16 @@ class MacAddress(str):
         # their own validation via __get_pydantic_core_schema__.
         return core_schema.no_info_after_validator_function(
             cls.validate,
-            core_schema.str_schema(pattern=MAC_FIELD_RE.pattern),
+            core_schema.str_schema(pattern=rf"^$|{MAC_FIELD_RE.pattern}"),
         )
 
     @classmethod
     def validate(cls, value: str) -> str:
+        # An empty string is a legitimate "no MAC" marker for unknown
+        # interfaces and is stored verbatim in the database, so it must
+        # pass through unchanged rather than being rejected.
+        if value == "":
+            return value
         match = re.fullmatch(MAC_FIELD_RE, value)
         if match is None:
             raise ValueError("Value is not a valid MAC address.")

--- a/src/maasservicelayer/models/interfaces.py
+++ b/src/maasservicelayer/models/interfaces.py
@@ -9,6 +9,7 @@ from maasservicelayer.models.base import (
     generate_builder,
     MaasTimestampedBaseModel,
 )
+from maasservicelayer.models.fields import MacAddress
 
 
 class Link(BaseModel):
@@ -42,7 +43,7 @@ class Link(BaseModel):
 class Interface(MaasTimestampedBaseModel):
     name: str
     type: InterfaceType
-    mac_address: str | None = None
+    mac_address: MacAddress | None = None
     vlan_id: int | None = None
     # TODO
     # effective_mtu: int = 0

--- a/src/metadataserver/builtin_scripts/hooks.py
+++ b/src/metadataserver/builtin_scripts/hooks.py
@@ -20,6 +20,7 @@ from django.db import IntegrityError, transaction
 from django.db.models import Q
 from temporalio.common import WorkflowIDReusePolicy
 
+from maascommon.fields import normalise_macaddress
 from maascommon.workflows.configure import CONFIGURE_AGENT_WORKFLOW_NAME
 from maasserver.enum import (
     NODE_DEVICE_BUS,
@@ -115,6 +116,8 @@ def parse_interfaces(node, data):
         # See LP:1939456
         if is_ipoib_mac(mac):
             return
+        if mac:
+            mac = normalise_macaddress(mac)
         interface = {
             "name": port.get("id"),
             "link_connected": port.get("link_detected"),
@@ -586,10 +589,11 @@ def update_node_devices(
             for port in card.get("ports", []):
                 if "address" not in port:
                     continue
+                mac = normalise_macaddress(port["address"])
                 if "pci_address" in card:
-                    mac_to_dev_ids[port["address"]] = card["pci_address"]
+                    mac_to_dev_ids[mac] = card["pci_address"]
                 elif "usb_address" in card:
-                    mac_to_dev_ids[port["address"]] = card["usb_address"]
+                    mac_to_dev_ids[mac] = card["usb_address"]
         for iface in node.current_config.interface_set.filter(
             mac_address__in=mac_to_dev_ids.keys()
         ):

--- a/src/tests/maasservicelayer/db/repositories/test_interfaces.py
+++ b/src/tests/maasservicelayer/db/repositories/test_interfaces.py
@@ -484,19 +484,37 @@ class TestInterfaceRepository:
         )
         unknown_interface = (
             await interfaces_repository.create_unknwown_interface(
-                "00:00:00:00:00", vlan["id"]
+                "00:00:00:00:00:00", vlan["id"]
             )
         )
 
         assert unknown_interface.type == InterfaceType.UNKNOWN
         assert unknown_interface.links == []
         assert unknown_interface.name == "eth0"
-        assert unknown_interface.mac_address == "00:00:00:00:00"
+        assert unknown_interface.mac_address == "00:00:00:00:00:00"
         assert unknown_interface.enabled is True
         assert unknown_interface.link_connected is True
         assert unknown_interface.interface_speed == 0
         assert unknown_interface.link_speed == 0
         assert unknown_interface.sriov_max_vf == 0
+
+    async def test_create_unkwnown_interface_normalises_mac(
+        self, db_connection: AsyncConnection, fixture: Fixture
+    ):
+        vlan = await create_test_vlan_entry(
+            fixture=fixture,
+            fabric_id=0,
+        )
+        interfaces_repository = InterfaceRepository(
+            context=Context(connection=db_connection)
+        )
+        unknown_interface = (
+            await interfaces_repository.create_unknwown_interface(
+                "AA:BB:CC:DD:EE:FF", vlan["id"]
+            )
+        )
+
+        assert unknown_interface.mac_address == "aa:bb:cc:dd:ee:ff"
 
     async def test_get_for_ip(
         self, db_connection: AsyncConnection, fixture: Fixture

--- a/src/tests/maasservicelayer/models/test_fields.py
+++ b/src/tests/maasservicelayer/models/test_fields.py
@@ -1,0 +1,42 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+from pydantic import BaseModel, ValidationError
+import pytest
+
+from maasservicelayer.models.fields import MacAddress
+
+
+class TestMacAddress:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("", ""),
+            ("aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:ff"),
+            ("AA-BB-CC-DD-EE-FF", "aa:bb:cc:dd:ee:ff"),
+            ("aabb.ccdd.eeff", "aa:bb:cc:dd:ee:ff"),
+            ("0:11:22:33:44:55", "00:11:22:33:44:55"),
+        ],
+    )
+    def test_validate(self, value, expected):
+        assert str(MacAddress(value)) == expected
+
+    @pytest.mark.parametrize("value", ["nope", "aa:bb:cc:dd:ee", "zz:..."])
+    def test_validate_rejects_invalid(self, value):
+        with pytest.raises(ValueError):
+            MacAddress(value)
+
+    def test_in_pydantic_model_allows_empty_and_none(self):
+        class Model(BaseModel):
+            mac: MacAddress | None = None
+
+        assert Model(mac="").mac == ""
+        assert Model(mac=None).mac is None
+        assert Model(mac="AA-BB-CC-DD-EE-FF").mac == "aa:bb:cc:dd:ee:ff"
+
+    def test_in_pydantic_model_rejects_invalid(self):
+        class Model(BaseModel):
+            mac: MacAddress | None = None
+
+        with pytest.raises(ValidationError):
+            Model(mac="nope")


### PR DESCRIPTION
MAAS stored interface MAC addresses verbatim, so the same physical address saved in a different case or separator (e.g. `AA:BB:..`, `aa-bb-..`) was treated as unique, bypassing the physical-interface MAC uniqueness checks. Partial/full MAC search was likewise format-sensitive, missing matches when the query's separators or case differed from storage.

This normalizes MACs (lowercase, colon-separated) on every write path that previously skipped it:

- Legacy: a custom `MACAddressField` normalizes on save, update, bulk-create and lookups, replacing ad-hoc `.lower()`/`normalise_macaddress()` calls in forms and boot RPC. Custom `startswith`/`contains` lookups match a full or partial MAC ignoring separators and case.
- Commissioning: network/hooks interface and node-device processing.
- v3 service layer: `MacAddress` model field, builder and repository create/lookup methods.

A new Alembic migration (0023) normalizes existing rows in a single pass and adds a CHECK constraint enforcing the canonical format, so future writes cannot regress. NULL and empty MACs (valid for unknown interfaces) are preserved. The migration aborts with guidance if pre-existing case-collisions would violate physical-interface uniqueness.

Bonds, bridges and VLANs validly reuse a child's MAC, so the duplicate check covers only physical interfaces, excluding legitimate reuse across a node's `node_config`s.

Resolves: LP:2137492