### PR TITLE
chore: core26 is now stable

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,16 @@
 name: maas
 adopt-info: maas
+title: MAAS
 summary: Metal as a Service
 description: |
   Total automation of your physical servers for amazing data center operational efficiency.
-grade: devel
+license: AGPL-3.0
+website: https://maas.io
+contact: https://discourse.maas.io
+issues: https://bugs.launchpad.net/maas
+source-code: https://github.com/canonical/maas
 confinement: strict
 base: core26
-build-base: devel
 assumes:
   - snapd2.75
 system-usernames:
@@ -74,6 +78,15 @@ apps:
       - network
 
 parts:
+  python-runtime:
+    plugin: nil
+    stage-packages:
+      - libpython3.14-minimal
+      - libpython3.14-stdlib
+      - python3-minimal
+      - python3.14-minimal
+      - python3.14-venv
+
   maas-slices:
     plugin: nil
     stage-packages:
@@ -116,6 +129,7 @@ parts:
       bin: usr/sbin
 
   maas:
+    after: [python-runtime]
     plugin: python
     source: .
     build-packages:
@@ -145,7 +159,6 @@ parts:
       - lshw
       - nginx-core
       - nmap
-      - python3
       - python3-aiodns # optional async DNS resolver for aiohttp
       - python3-aiofiles
       - python3-aiohttp
@@ -236,15 +249,18 @@ parts:
       - etc/maas
       - etc/nginx
       - etc/openwsman
-      - -lib/python3.*/site-packages/etc
-      - -lib/python3.*/site-packages/usr
-      - -lib/python3/dist-packages/maastesting
+      - -usr/lib/python3.*/site-packages/etc
+      - -usr/lib/python3.*/site-packages/usr
+      - -usr/lib/python3/dist-packages/maastesting
       - usr/bin
       - usr/bin/python3*
       - -usr/bin/xdg-*
       - -usr/bin/maas-sampledata
+      - -usr/bin/pydoc3.14
+      - -usr/bin/pygettext3.14
       - usr/lib
       - -usr/lib/python3.14/test
+      - -usr/lib/python3.14/encodings/rot_13.py
       - -usr/lib/systemd
       - -usr/lib/udev
       - -usr/lib/tmpfiles.d


### PR DESCRIPTION
adjust build parts as snapcraft docs recommends: 
https://documentation.ubuntu.com/snapcraft/stable/how-to/change-bases/change-from-core24-to-core26/

also includes some metadata required by snapcraft 9.0