### PR TITLE
fix: add block-devices and hardware-observe snap plugs required by host-info using LXD 6.8

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -61,6 +61,8 @@ apps:
   maas:
     command: usr/bin/maas
     plugs:
+      - block-devices  # allow blkid (machine-resources) to read disk devices
+      - hardware-observe  # allow machine-resources to read hardware info from /sys
       - home
       - mount-observe  # to read /proc/*/mounts
       - network # for external authentication


### PR DESCRIPTION
host-info is using LXD 6.8 which requires access to additional plugs in order to read the machine information properly for the controllers