### PR TITLE
fix: move the block-devices snap plug under pebble

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,6 +50,7 @@ apps:
     command: usr/bin/run-pebble-daemon
     plugs:
       - avahi-observe
+      - block-devices  # allow blkid (machine-resources) to read disk devices
       - hardware-observe
       - kernel-module-observe
       - mount-observe
@@ -65,8 +66,6 @@ apps:
   maas:
     command: usr/bin/maas
     plugs:
-      - block-devices  # allow blkid (machine-resources) to read disk devices
-      - hardware-observe  # allow machine-resources to read hardware info from /sys
       - home
       - mount-observe  # to read /proc/*/mounts
       - network # for external authentication


### PR DESCRIPTION
`/usr/sbin/blkid` access was denied because the correct profile to apply the plug is pebble and not maas.

Dmesg apparmor message:
``` 
audit: type=1400 audit(1781602195.196:6720172): apparmor="DENIED" operation="exec" class="file" namespace="root//lxd-foo_<var-snap-lxd-common-lxd>" profile="snap.maas.pebble" name="/usr/sbin/blkid" pid=2093677 comm="amd64" requested_mask="x" denied_mask="x" fsuid=1000000 ouid=1000000
```