### PR TITLE
fix: increase client buffer header size in nginx

### DIFF
--- a/debian/extras/nginx.conf
+++ b/debian/extras/nginx.conf
@@ -18,6 +18,7 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048;
     client_max_body_size 10M;
+    large_client_header_buffers 4 32k;
 
     proxy_buffer_size 16k;
     proxy_buffers 4 32k;

--- a/snap/local/tree/usr/share/maas/nginx/nginx.conf
+++ b/snap/local/tree/usr/share/maas/nginx/nginx.conf
@@ -19,6 +19,7 @@ http {
     keepalive_timeout 65;
     types_hash_max_size 2048;
     client_max_body_size 10M;
+    large_client_header_buffers 4 32k;
 
     proxy_buffer_size 16k;
     proxy_buffers 4 32k;


### PR DESCRIPTION
Microsoft Entra ID can sometimes return unusually long tokens (depending on the IdP configuration)  which, after encryption, do not make it through in the headers to the backend due to nginx constraints. This PR increases the limit by allocating 4 buffers of 32k for the headers (note, this is not pre-allocated or reserved; instead, it is only used on-demand. See [nginx docs](https://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers) for more info)