### PR TITLE
fix(dhcp): change decimal to octal format for config file permissions LP#2156073 (#364)

### DIFF
--- a/src/maasagent/internal/dhcp/service.go
+++ b/src/maasagent/internal/dhcp/service.go
@@ -64,7 +64,7 @@ var writeConfigFileSnap = atomicfile.WriteFile
 var writeConfigFileDeb = func(path string, data []byte, mode os.FileMode) error {
 	scriptPath := "/usr/lib/maas/maas-write-file"
 	fileName := path
-	modeStr := fmt.Sprintf("%d", mode)
+	modeStr := fmt.Sprintf("%o", mode)
 
 	// create the command that runs maas-write-file
 	// #nosec G204: the inputs are sanitized and validated by `maas-write-file`


### PR DESCRIPTION
When calling `writeConfigFileDeb` we are passing in an octal value, but parsing it as a decimal value, which was incorrect, and was causing the incorrect permission mode (see bug link).

Resolves: [LP:2156073](https://bugs.launchpad.net/maas/+bug/2156073)
(cherry picked from commit [cd37a9d](https://github.com/canonical/maas/commit/cd37a9d65d708103101057d107859124bca3f2aa))