### PR TITLE
refactor: filter httpx logging in openfga clients

### DIFF
--- a/src/maascommon/openfga/async_client.py
+++ b/src/maascommon/openfga/async_client.py
@@ -34,32 +34,34 @@ class OpenFGAClient(BaseOpenFGAClient):
         await self.client.aclose()
 
     async def _check(self, user_id: int, relation: str, obj: str) -> bool:
-        response = await self.client.post(
-            f"/stores/{OPENFGA_STORE_ID}/check",
-            json={
-                "tuple_key": {
-                    "user": f"user:{user_id}",
-                    "relation": relation,
-                    "object": obj,
+        with self._suppress_httpx_logging():
+            response = await self.client.post(
+                f"/stores/{OPENFGA_STORE_ID}/check",
+                json={
+                    "tuple_key": {
+                        "user": f"user:{user_id}",
+                        "relation": relation,
+                        "object": obj,
+                    },
+                    "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
                 },
-                "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
-            },
-        )
+            )
         response.raise_for_status()
         return response.json().get("allowed", False)
 
     async def _list_objects(
         self, user_id: int, relation: str, obj_type: str
     ) -> list[int]:
-        response = await self.client.post(
-            f"/stores/{OPENFGA_STORE_ID}/list-objects",
-            json={
-                "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
-                "user": f"user:{user_id}",
-                "relation": relation,
-                "type": obj_type,
-            },
-        )
+        with self._suppress_httpx_logging():
+            response = await self.client.post(
+                f"/stores/{OPENFGA_STORE_ID}/list-objects",
+                json={
+                    "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
+                    "user": f"user:{user_id}",
+                    "relation": relation,
+                    "type": obj_type,
+                },
+            )
         response.raise_for_status()
         return self._parse_list_objects(response.json())
 

--- a/src/maascommon/openfga/base.py
+++ b/src/maascommon/openfga/base.py
@@ -1,10 +1,12 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
+from contextlib import contextmanager
 from enum import StrEnum
+import logging
 import os
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator
 
 from maascommon.path import get_maas_data_path
 
@@ -59,8 +61,26 @@ class BaseOpenFGAClient:
     HEADERS = {"User-Agent": "maas-openfga-client/1.0"}
     MAAS_GLOBAL_OBJ = f"{OpenFGAEntitlementResourceType.MAAS}:0"
 
+    _httpx_logger = logging.getLogger("httpx")
+    _httpcore_logger = logging.getLogger("httpcore")
+
     def __init__(self, unix_socket: str | None = None):
         self.socket_path = unix_socket or self._get_default_socket_path()
+
+    @classmethod
+    @contextmanager
+    def _suppress_httpx_logging(cls) -> Iterator[None]:
+        levels = (
+            cls._httpx_logger.level,
+            cls._httpcore_logger.level,
+        )
+        cls._httpx_logger.setLevel(logging.WARNING)
+        cls._httpcore_logger.setLevel(logging.WARNING)
+        try:
+            yield
+        finally:
+            cls._httpx_logger.setLevel(levels[0])
+            cls._httpcore_logger.setLevel(levels[1])
 
     def _get_default_socket_path(self) -> str:
         return str(

--- a/src/maascommon/openfga/base.py
+++ b/src/maascommon/openfga/base.py
@@ -2,6 +2,7 @@
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 from contextlib import contextmanager
+import contextvars
 from enum import StrEnum
 import logging
 import os
@@ -9,6 +10,32 @@ from pathlib import Path
 from typing import Any, Iterator
 
 from maascommon.path import get_maas_data_path
+
+_suppress_httpx = contextvars.ContextVar("suppress_httpx", default=False)
+
+
+class _HTTPXLogFilter(logging.Filter):
+    """Drop httpx/httpcore INFO/DEBUG records when the `_suppress_httpx`
+    ContextVar is set to True. Warnings and above always pass through.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        if record.levelno >= logging.WARNING:
+            return True
+        return not _suppress_httpx.get()
+
+
+def _install_httpx_log_filter() -> None:
+    """Attach the context-aware filter to the httpx/httpcore loggers.
+
+    `addFilter` is idempotent, so repeated calls are harmless.
+    """
+    for name in ("httpx", "httpcore"):
+        logging.getLogger(name).addFilter(_HTTPX_LOG_FILTER)
+
+
+_HTTPX_LOG_FILTER = _HTTPXLogFilter()
+_install_httpx_log_filter()
 
 
 class OpenFGAEntitlementResourceType(StrEnum):
@@ -61,26 +88,14 @@ class BaseOpenFGAClient:
     HEADERS = {"User-Agent": "maas-openfga-client/1.0"}
     MAAS_GLOBAL_OBJ = f"{OpenFGAEntitlementResourceType.MAAS}:0"
 
-    _httpx_logger = logging.getLogger("httpx")
-    _httpcore_logger = logging.getLogger("httpcore")
-
     def __init__(self, unix_socket: str | None = None):
         self.socket_path = unix_socket or self._get_default_socket_path()
 
     @classmethod
     @contextmanager
     def _suppress_httpx_logging(cls) -> Iterator[None]:
-        levels = (
-            cls._httpx_logger.level,
-            cls._httpcore_logger.level,
-        )
-        cls._httpx_logger.setLevel(logging.WARNING)
-        cls._httpcore_logger.setLevel(logging.WARNING)
-        try:
+        with _suppress_httpx.set(True):
             yield
-        finally:
-            cls._httpx_logger.setLevel(levels[0])
-            cls._httpcore_logger.setLevel(levels[1])
 
     def _get_default_socket_path(self) -> str:
         return str(

--- a/src/maascommon/openfga/sync_client.py
+++ b/src/maascommon/openfga/sync_client.py
@@ -34,30 +34,32 @@ class SyncOpenFGAClient(BaseOpenFGAClient):
         self.client.close()
 
     def _check(self, user, relation: str, obj: str) -> bool:
-        response = self.client.post(
-            f"/stores/{OPENFGA_STORE_ID}/check",
-            json={
-                "tuple_key": {
-                    "user": f"user:{user.id}",  # type: ignore[reportAttributeAccessIssue]
-                    "relation": relation,
-                    "object": obj,
+        with self._suppress_httpx_logging():
+            response = self.client.post(
+                f"/stores/{OPENFGA_STORE_ID}/check",
+                json={
+                    "tuple_key": {
+                        "user": f"user:{user.id}",  # type: ignore[reportAttributeAccessIssue]
+                        "relation": relation,
+                        "object": obj,
+                    },
+                    "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
                 },
-                "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
-            },
-        )
+            )
         response.raise_for_status()
         return response.json().get("allowed", False)
 
     def _list_objects(self, user, relation: str, obj_type: str) -> list[int]:
-        response = self.client.post(
-            f"/stores/{OPENFGA_STORE_ID}/list-objects",
-            json={
-                "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
-                "user": f"user:{user.id}",  # type: ignore[reportAttributeAccessIssue]
-                "relation": relation,
-                "type": obj_type,
-            },
-        )
+        with self._suppress_httpx_logging():
+            response = self.client.post(
+                f"/stores/{OPENFGA_STORE_ID}/list-objects",
+                json={
+                    "authorization_model_id": OPENFGA_AUTHORIZATION_MODEL_ID,
+                    "user": f"user:{user.id}",  # type: ignore[reportAttributeAccessIssue]
+                    "relation": relation,
+                    "type": obj_type,
+                },
+            )
         response.raise_for_status()
         return self._parse_list_objects(response.json())
 


### PR DESCRIPTION
After introducing openfga, we had many logs related to requests to the openfga store, like:

```
Jun 18 12:35:48 maas-resolute maas-regiond[3398]: httpx: [info] HTTP Request: POST http://unix/stores/00000000000000000000000000/list-objects "HTTP/1.1 200 OK"
Jun 18 12:35:48 maas-resolute maas-regiond[3398]: httpx: [info] HTTP Request: POST http://unix/stores/00000000000000000000000000/check "HTTP/1.1 200 OK"
```

Since they don't bring any additional value, and might actually confuse users, we change the logging level for those `httpx` calls to warning.