### PR TITLE
feat: start operation workflows after commit with OperationUUID

### DIFF
--- a/src/maascommon/workflows/operation.py
+++ b/src/maascommon/workflows/operation.py
@@ -1,4 +1,11 @@
 #  Copyright 2026 Canonical Ltd.  This software is licensed under the
 #  GNU Affero General Public License version 3 (see the file LICENSE).
 
+from maascommon.enums.operations import OperationType
+from maascommon.workflows.commission import COMMISSION_WORKFLOW_NAME
+
 OPERATION_UUID_SEARCH_ATTRIBUTE = "OperationUUID"
+
+OPERATION_TYPE_WORKFLOW_NAME: dict[OperationType, str] = {
+    OperationType.MACHINE_COMMISSION: COMMISSION_WORKFLOW_NAME,
+}

--- a/src/maasservicelayer/services/__init__.py
+++ b/src/maasservicelayer/services/__init__.py
@@ -772,5 +772,6 @@ class ServiceCollectionV3:
             context=context,
             operations_repository=OperationsRepository(context),
             operation_tasks_repository=OperationTasksRepository(context),
+            temporal_service=services.temporal,
         )
         return services

--- a/src/maasservicelayer/services/operations.py
+++ b/src/maasservicelayer/services/operations.py
@@ -76,7 +76,7 @@ class OperationsService(
         await self.set_current_task(operation_uuid, name)
         return task
 
-    async def start_operation(
+    async def create_accepted_operation(
         self,
         *,
         op_type: OperationType,

--- a/src/maasservicelayer/services/operations.py
+++ b/src/maasservicelayer/services/operations.py
@@ -1,7 +1,21 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from maascommon.enums.operations import OperationStatus, OperationTaskStatus
+from typing import Any
+from uuid import uuid4
+
+from temporalio.common import (
+    SearchAttributeKey,
+    SearchAttributePair,
+    TypedSearchAttributes,
+)
+
+from maascommon.enums.operations import (
+    OperationStatus,
+    OperationTaskStatus,
+    OperationType,
+)
+from maascommon.workflows.operation import OPERATION_UUID_SEARCH_ATTRIBUTE
 from maasservicelayer.builders.operations import (
     OperationBuilder,
     OperationTaskBuilder,
@@ -29,6 +43,7 @@ from maasservicelayer.exceptions.constants import (
 from maasservicelayer.models.base import ListResult
 from maasservicelayer.models.operations import Operation, OperationTask
 from maasservicelayer.services.base import BaseService
+from maasservicelayer.services.temporal import TemporalService
 from maasservicelayer.utils.date import utcnow
 
 
@@ -40,9 +55,11 @@ class OperationsService(
         context: Context,
         operations_repository: OperationsRepository,
         operation_tasks_repository: OperationTasksRepository,
+        temporal_service: TemporalService,
     ):
         super().__init__(context, operations_repository)
         self.operation_tasks_repository = operation_tasks_repository
+        self.temporal_service = temporal_service
 
     async def start_task(
         self, operation_uuid: str, name: str, task_number: int
@@ -58,6 +75,48 @@ class OperationsService(
         )
         await self.set_current_task(operation_uuid, name)
         return task
+
+    async def start_operation(
+        self,
+        *,
+        op_type: OperationType,
+        workflow_name: str,
+        workflow_parameter: Any | None = None,
+        resource_id: int | None = None,
+        resource_type: str | None = None,
+        parameters: dict | None = None,
+        user_id: int | None = None,
+    ) -> Operation:
+        """Create an operation and schedule its workflow after commit."""
+        operation = await self.create(
+            builder=OperationBuilder(
+                uuid=str(uuid4()),
+                op_type=op_type,
+                status=OperationStatus.ACCEPTED,
+                resource_id=resource_id,
+                resource_type=resource_type,
+                parameters=parameters,
+                user_id=user_id,
+                is_bulk=False,
+            )
+        )
+        self.temporal_service.register_workflow_call(
+            workflow_name=workflow_name,
+            parameter=workflow_parameter,
+            workflow_id=operation.uuid,
+            wait=False,
+            search_attributes=TypedSearchAttributes(
+                [
+                    SearchAttributePair(
+                        SearchAttributeKey.for_keyword(
+                            OPERATION_UUID_SEARCH_ATTRIBUTE
+                        ),
+                        operation.uuid,
+                    )
+                ]
+            ),
+        )
+        return operation
 
     async def update_status(
         self,

--- a/src/maasservicelayer/services/operations.py
+++ b/src/maasservicelayer/services/operations.py
@@ -1,7 +1,6 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from typing import Any
 from uuid import uuid4
 
 from temporalio.common import (
@@ -15,7 +14,10 @@ from maascommon.enums.operations import (
     OperationTaskStatus,
     OperationType,
 )
-from maascommon.workflows.operation import OPERATION_UUID_SEARCH_ATTRIBUTE
+from maascommon.workflows.operation import (
+    OPERATION_TYPE_WORKFLOW_NAME,
+    OPERATION_UUID_SEARCH_ATTRIBUTE,
+)
 from maasservicelayer.builders.operations import (
     OperationBuilder,
     OperationTaskBuilder,
@@ -78,16 +80,18 @@ class OperationsService(
 
     async def create_accepted_operation(
         self,
-        *,
         op_type: OperationType,
-        workflow_name: str,
-        workflow_parameter: Any | None = None,
         resource_id: int | None = None,
         resource_type: str | None = None,
         parameters: dict | None = None,
         user_id: int | None = None,
     ) -> Operation:
-        """Create an operation and schedule its workflow after commit."""
+        """Create an ACCEPTED operation and schedule its workflow after commit."""
+        workflow_name = OPERATION_TYPE_WORKFLOW_NAME.get(op_type)
+        if workflow_name is None:
+            raise ValueError(
+                f"No workflow is mapped to operation type '{op_type}'."
+            )
         operation = await self.create(
             builder=OperationBuilder(
                 uuid=str(uuid4()),
@@ -102,7 +106,7 @@ class OperationsService(
         )
         self.temporal_service.register_workflow_call(
             workflow_name=workflow_name,
-            parameter=workflow_parameter,
+            parameter=parameters,
             workflow_id=operation.uuid,
             wait=False,
             search_attributes=TypedSearchAttributes(

--- a/src/maasservicelayer/services/temporal.py
+++ b/src/maasservicelayer/services/temporal.py
@@ -11,7 +11,6 @@ from temporalio.client import (
     WorkflowExecutionDescription,
     WorkflowExecutionStatus,
 )
-from temporalio.common import TypedSearchAttributes
 from temporalio.service import RPCError
 
 from maascommon.workflows.operation import OPERATION_UUID_SEARCH_ATTRIBUTE
@@ -110,19 +109,11 @@ class TemporalService(Service):
 
     async def post_commit(self) -> None:
         for key, arguments in self._post_commit_workflows.items():  # noqa: B007
-            (
-                workflow_name,
-                parameter,
-                workflow_id,
-                wait,
-                search_attributes,
-                args,
-                kwargs,
-            ) = arguments
+            workflow_name, parameter, workflow_id, wait, args, kwargs = (
+                arguments
+            )
             if not workflow_id:
                 workflow_id = str(uuid.uuid4())
-            if search_attributes is not None:
-                kwargs = {**kwargs, "search_attributes": search_attributes}
 
             client = await self.get_temporal_client()
             # TODO: make the task_queue a workflow parameter instead of hardcoding it here.
@@ -188,7 +179,6 @@ class TemporalService(Service):
         workflow_id: str | None = None,
         wait: bool | None = True,
         *args: list[Any],
-        search_attributes: TypedSearchAttributes | None = None,
         **kwargs: dict[str, Any],
     ) -> None:
         key = self._make_key(workflow_name, workflow_id)
@@ -197,7 +187,6 @@ class TemporalService(Service):
             parameter,
             workflow_id,
             wait,
-            search_attributes,
             args,
             kwargs,
         )

--- a/src/maasservicelayer/services/temporal.py
+++ b/src/maasservicelayer/services/temporal.py
@@ -11,6 +11,7 @@ from temporalio.client import (
     WorkflowExecutionDescription,
     WorkflowExecutionStatus,
 )
+from temporalio.common import TypedSearchAttributes
 from temporalio.service import RPCError
 
 from maascommon.workflows.operation import OPERATION_UUID_SEARCH_ATTRIBUTE
@@ -109,11 +110,19 @@ class TemporalService(Service):
 
     async def post_commit(self) -> None:
         for key, arguments in self._post_commit_workflows.items():  # noqa: B007
-            workflow_name, parameter, workflow_id, wait, args, kwargs = (
-                arguments
-            )
+            (
+                workflow_name,
+                parameter,
+                workflow_id,
+                wait,
+                search_attributes,
+                args,
+                kwargs,
+            ) = arguments
             if not workflow_id:
                 workflow_id = str(uuid.uuid4())
+            if search_attributes is not None:
+                kwargs = {**kwargs, "search_attributes": search_attributes}
 
             client = await self.get_temporal_client()
             # TODO: make the task_queue a workflow parameter instead of hardcoding it here.
@@ -179,6 +188,7 @@ class TemporalService(Service):
         workflow_id: str | None = None,
         wait: bool | None = True,
         *args: list[Any],
+        search_attributes: TypedSearchAttributes | None = None,
         **kwargs: dict[str, Any],
     ) -> None:
         key = self._make_key(workflow_name, workflow_id)
@@ -187,6 +197,7 @@ class TemporalService(Service):
             parameter,
             workflow_id,
             wait,
+            search_attributes,
             args,
             kwargs,
         )

--- a/src/maasservicelayer/services/temporal.py
+++ b/src/maasservicelayer/services/temporal.py
@@ -178,8 +178,8 @@ class TemporalService(Service):
         parameter: Any | None = None,
         workflow_id: str | None = None,
         wait: bool | None = True,
-        *args: list[Any],
-        **kwargs: dict[str, Any],
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         key = self._make_key(workflow_name, workflow_id)
         self._post_commit_workflows[key] = (

--- a/src/tests/maasservicelayer/services/test_operations.py
+++ b/src/tests/maasservicelayer/services/test_operations.py
@@ -290,7 +290,7 @@ class TestOperationsService:
             "task1"
         )
 
-    async def test_start_operation_creates_accepted_and_registers_workflow(
+    async def test_create_accepted_operation_creates_row_and_registers_workflow(
         self,
     ) -> None:
         repository = Mock(OperationsRepository)
@@ -303,7 +303,7 @@ class TestOperationsService:
             temporal_service=temporal_service,
         )
 
-        operation = await service.start_operation(
+        operation = await service.create_accepted_operation(
             op_type=OperationType.MACHINE_DEPLOY,
             workflow_name="deploy",
             workflow_parameter={"system_id": "abc123"},

--- a/src/tests/maasservicelayer/services/test_operations.py
+++ b/src/tests/maasservicelayer/services/test_operations.py
@@ -624,6 +624,7 @@ class TestOperationsService:
             context=Context(),
             operations_repository=Mock(OperationsRepository),
             operation_tasks_repository=operation_tasks_repo,
+            temporal_service=Mock(TemporalService),
         )
 
         await service.list_tasks_for_operation("op-uuid", page=1, size=10)

--- a/src/tests/maasservicelayer/services/test_operations.py
+++ b/src/tests/maasservicelayer/services/test_operations.py
@@ -294,7 +294,10 @@ class TestOperationsService:
         self,
     ) -> None:
         repository = Mock(OperationsRepository)
-        repository.create.return_value = TEST_OPERATION
+        commission_operation = TEST_OPERATION.model_copy(
+            update={"op_type": OperationType.MACHINE_COMMISSION}
+        )
+        repository.create.return_value = commission_operation
         temporal_service = Mock(TemporalService)
         service = OperationsService(
             context=Context(),
@@ -302,32 +305,31 @@ class TestOperationsService:
             operation_tasks_repository=Mock(OperationTasksRepository),
             temporal_service=temporal_service,
         )
+        parameters = {"system_id": "abc123", "queue": "region"}
 
         operation = await service.create_accepted_operation(
-            op_type=OperationType.MACHINE_DEPLOY,
-            workflow_name="deploy",
-            workflow_parameter={"system_id": "abc123"},
+            op_type=OperationType.MACHINE_COMMISSION,
             resource_id=1,
             resource_type="machine",
-            parameters={"timeout": 60},
+            parameters=parameters,
             user_id=1,
         )
 
-        assert operation == TEST_OPERATION
+        assert operation == commission_operation
         builder = repository.create.call_args.kwargs["builder"]
         populated = builder.populated_fields()
-        assert populated["op_type"] == OperationType.MACHINE_DEPLOY
+        assert populated["op_type"] == OperationType.MACHINE_COMMISSION
         assert populated["status"] == OperationStatus.ACCEPTED
         assert populated["resource_id"] == 1
         assert populated["resource_type"] == "machine"
-        assert populated["parameters"] == {"timeout": 60}
+        assert populated["parameters"] == parameters
         assert populated["user_id"] == 1
         assert populated["is_bulk"] is False
         assert "uuid" in populated
 
         temporal_service.register_workflow_call.assert_called_once_with(
-            workflow_name="deploy",
-            parameter={"system_id": "abc123"},
+            workflow_name="commission",
+            parameter=parameters,
             workflow_id=TEST_OPERATION.uuid,
             wait=False,
             search_attributes=TypedSearchAttributes(
@@ -341,6 +343,21 @@ class TestOperationsService:
                 ]
             ),
         )
+
+    async def test_create_accepted_operation_unmapped_op_type_raises(
+        self,
+    ) -> None:
+        service = OperationsService(
+            context=Context(),
+            operations_repository=Mock(OperationsRepository),
+            operation_tasks_repository=Mock(OperationTasksRepository),
+            temporal_service=Mock(TemporalService),
+        )
+
+        with pytest.raises(ValueError):
+            await service.create_accepted_operation(
+                op_type=OperationType.SELECTION_SYNC,
+            )
 
     async def test_update_status_running_sets_started(self) -> None:
         repository = Mock(OperationsRepository)

--- a/src/tests/maasservicelayer/services/test_operations.py
+++ b/src/tests/maasservicelayer/services/test_operations.py
@@ -4,12 +4,18 @@
 from unittest.mock import Mock
 
 import pytest
+from temporalio.common import (
+    SearchAttributeKey,
+    SearchAttributePair,
+    TypedSearchAttributes,
+)
 
 from maascommon.enums.operations import (
     OperationStatus,
     OperationTaskStatus,
     OperationType,
 )
+from maascommon.workflows.operation import OPERATION_UUID_SEARCH_ATTRIBUTE
 from maasservicelayer.builders.operations import OperationBuilder
 from maasservicelayer.context import Context
 from maasservicelayer.db.filters import QuerySpec
@@ -33,6 +39,7 @@ from maasservicelayer.models.base import (
 from maasservicelayer.models.operations import Operation, OperationTask
 from maasservicelayer.services.base import BaseService
 from maasservicelayer.services.operations import OperationsService
+from maasservicelayer.services.temporal import TemporalService
 from maasservicelayer.utils.date import utcnow
 from tests.maasservicelayer.services.base import ServiceCommonTests
 
@@ -77,6 +84,7 @@ class TestCommonOperationsService(ServiceCommonTests):
             context=Context(),
             operations_repository=Mock(OperationsRepository),
             operation_tasks_repository=Mock(OperationTasksRepository),
+            temporal_service=Mock(TemporalService),
         )
 
     @pytest.fixture
@@ -224,12 +232,14 @@ class TestOperationsService:
         self,
         repository: Mock,
         operation_tasks_repository: Mock | None = None,
+        temporal_service: Mock | None = None,
     ) -> OperationsService:
         return OperationsService(
             context=Context(),
             operations_repository=repository,
             operation_tasks_repository=operation_tasks_repository
             or Mock(OperationTasksRepository),
+            temporal_service=temporal_service or Mock(TemporalService),
         )
 
     @pytest.fixture
@@ -250,6 +260,7 @@ class TestOperationsService:
             context=Context(),
             operations_repository=operations_repo_mock,
             operation_tasks_repository=operation_tasks_repo_mock,
+            temporal_service=Mock(TemporalService),
         )
 
     async def test_start_task(self) -> None:
@@ -277,6 +288,58 @@ class TestOperationsService:
         )
         assert current_task_builder.populated_fields()["current_task"] == (
             "task1"
+        )
+
+    async def test_start_operation_creates_accepted_and_registers_workflow(
+        self,
+    ) -> None:
+        repository = Mock(OperationsRepository)
+        repository.create.return_value = TEST_OPERATION
+        temporal_service = Mock(TemporalService)
+        service = OperationsService(
+            context=Context(),
+            operations_repository=repository,
+            operation_tasks_repository=Mock(OperationTasksRepository),
+            temporal_service=temporal_service,
+        )
+
+        operation = await service.start_operation(
+            op_type=OperationType.MACHINE_DEPLOY,
+            workflow_name="deploy",
+            workflow_parameter={"system_id": "abc123"},
+            resource_id=1,
+            resource_type="machine",
+            parameters={"timeout": 60},
+            user_id=1,
+        )
+
+        assert operation == TEST_OPERATION
+        builder = repository.create.call_args.kwargs["builder"]
+        populated = builder.populated_fields()
+        assert populated["op_type"] == OperationType.MACHINE_DEPLOY
+        assert populated["status"] == OperationStatus.ACCEPTED
+        assert populated["resource_id"] == 1
+        assert populated["resource_type"] == "machine"
+        assert populated["parameters"] == {"timeout": 60}
+        assert populated["user_id"] == 1
+        assert populated["is_bulk"] is False
+        assert "uuid" in populated
+
+        temporal_service.register_workflow_call.assert_called_once_with(
+            workflow_name="deploy",
+            parameter={"system_id": "abc123"},
+            workflow_id=TEST_OPERATION.uuid,
+            wait=False,
+            search_attributes=TypedSearchAttributes(
+                [
+                    SearchAttributePair(
+                        SearchAttributeKey.for_keyword(
+                            OPERATION_UUID_SEARCH_ATTRIBUTE
+                        ),
+                        TEST_OPERATION.uuid,
+                    )
+                ]
+            ),
         )
 
     async def test_update_status_running_sets_started(self) -> None:

--- a/src/tests/maasservicelayer/services/test_temporal.py
+++ b/src/tests/maasservicelayer/services/test_temporal.py
@@ -12,6 +12,11 @@ from temporalio.client import (
     WorkflowExecutionStatus,
     WorkflowHandle,
 )
+from temporalio.common import (
+    SearchAttributeKey,
+    SearchAttributePair,
+    TypedSearchAttributes,
+)
 from temporalio.service import RPCError, RPCStatusCode
 
 from maascommon.workflows.operation import OPERATION_UUID_SEARCH_ATTRIBUTE
@@ -72,6 +77,36 @@ class TestTemporalService:
 
         temporal_client_mock.execute_workflow.assert_called_once_with(
             "test_workflow", id="abc", task_queue="region"
+        )
+
+    async def test_post_commit_forwards_search_attributes(
+        self, service: TemporalService, temporal_client_mock
+    ):
+        search_attributes = TypedSearchAttributes(
+            [
+                SearchAttributePair(
+                    SearchAttributeKey.for_keyword("OperationUUID"),
+                    "op-uuid",
+                )
+            ]
+        )
+
+        service.register_workflow_call(
+            "test_workflow",
+            parameter={"a": 1},
+            workflow_id="abc",
+            wait=False,
+            search_attributes=search_attributes,
+        )
+
+        await service.post_commit()
+
+        temporal_client_mock.start_workflow.assert_called_once_with(
+            "test_workflow",
+            {"a": 1},
+            id="abc",
+            task_queue="region",
+            search_attributes=search_attributes,
         )
 
     async def test_workflow_is_registered(self, service: TemporalService):

--- a/src/tests/maasservicelayer/services/test_temporal.py
+++ b/src/tests/maasservicelayer/services/test_temporal.py
@@ -12,11 +12,6 @@ from temporalio.client import (
     WorkflowExecutionStatus,
     WorkflowHandle,
 )
-from temporalio.common import (
-    SearchAttributeKey,
-    SearchAttributePair,
-    TypedSearchAttributes,
-)
 from temporalio.service import RPCError, RPCStatusCode
 
 from maascommon.workflows.operation import OPERATION_UUID_SEARCH_ATTRIBUTE
@@ -77,36 +72,6 @@ class TestTemporalService:
 
         temporal_client_mock.execute_workflow.assert_called_once_with(
             "test_workflow", id="abc", task_queue="region"
-        )
-
-    async def test_post_commit_forwards_search_attributes(
-        self, service: TemporalService, temporal_client_mock
-    ):
-        search_attributes = TypedSearchAttributes(
-            [
-                SearchAttributePair(
-                    SearchAttributeKey.for_keyword("OperationUUID"),
-                    "op-uuid",
-                )
-            ]
-        )
-
-        service.register_workflow_call(
-            "test_workflow",
-            parameter={"a": 1},
-            workflow_id="abc",
-            wait=False,
-            search_attributes=search_attributes,
-        )
-
-        await service.post_commit()
-
-        temporal_client_mock.start_workflow.assert_called_once_with(
-            "test_workflow",
-            {"a": 1},
-            id="abc",
-            task_queue="region",
-            search_attributes=search_attributes,
         )
 
     async def test_workflow_is_registered(self, service: TemporalService):


### PR DESCRIPTION
Add helper to create an `ACCEPTED` operation and register its Temporal workflow after commit. Workflow name is derived from op_type and parameters are persisted on the operation row and passed through to Temporal for reconciliation replay.