### PR TITLE
docs: fix docs build for git shallow clones

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,9 @@ extensions = []
 if (
     len(Path(__file__).parents) >= 2
     and not (Path(__file__).parents[1] / ".git").exists()
+    # A shallow clone has a .git/shallow file; sphinx_last_updated_by_git
+    # produces warnings when git log cannot traverse full history.
+    or (Path(__file__).parents[1] / ".git" / "shallow" ).exists()
 ):
     # Some surgery in order to accomodate the fact that
     # canonical_sphinx and sphinx_sitemap both require


### PR DESCRIPTION
The `sphinx_last_updated_by_git` will raise a warning when the git clone is shallow (e.g. when cloning with `git clone --depth 1`) causing the `make html` command to fail.