### PR TITLE
refactor(bootresources): better exception handling for boot resources download

### DIFF
--- a/src/maastemporalworker/workflow/bootresource.py
+++ b/src/maastemporalworker/workflow/bootresource.py
@@ -327,9 +327,16 @@ class BootResourcesActivity(ActivityBase):
                 ex.strerror if ex.strerror else str(ex),
                 type=ex.__class__.__name__,
             ) from ex
+
         except httpx.HTTPError as ex:
             await lfile.unlink()
             await self.report_progress(param.rfile_ids, 0)
+            if isinstance(ex, httpx.HTTPStatusError):
+                # 4xx and 5xx errors: most probably a misconfiguration of the images stream.
+                # Raise a non-retryable error and let the user fix it.
+                raise ApplicationError(
+                    str(ex), type=ex.__class__.__name__, non_retryable=True
+                ) from ex
             raise ApplicationError(str(ex), type=ex.__class__.__name__) from ex
         except (asyncio.CancelledError, CancelledError) as ex:
             await lfile.unlink()

--- a/src/tests/maastemporalworker/workflow/test_bootresource.py
+++ b/src/tests/maastemporalworker/workflow/test_bootresource.py
@@ -610,13 +610,29 @@ class TestDownloadBootresourcefileActivity:
         )
 
     @pytest.mark.parametrize(
-        "exception",
+        "exception,non_retryable",
         [
-            IOError(),
-            httpx.HTTPError("Error"),
-            LocalStoreInvalidHash(),
-            LocalStoreAllocationFail(),
-            LocalStoreFileSizeMismatch(),
+            (IOError(), False),
+            (
+                httpx.HTTPStatusError(
+                    "404",
+                    request=Mock(httpx.Request),
+                    response=httpx.Response(404),
+                ),
+                True,
+            ),
+            (
+                httpx.HTTPStatusError(
+                    "500",
+                    request=Mock(httpx.Request),
+                    response=httpx.Response(500),
+                ),
+                True,
+            ),
+            (httpx.HTTPError("Error"), False),
+            (LocalStoreInvalidHash(), False),
+            (LocalStoreAllocationFail(), True),
+            (LocalStoreFileSizeMismatch(), False),
         ],
     )
     async def test_download_file_raise_other_exception(
@@ -626,6 +642,7 @@ class TestDownloadBootresourcefileActivity:
         mock_apiclient: Mock,
         activity_env: ActivityEnvironment,
         exception,
+        non_retryable: bool,
     ) -> None:
         mock_local_file.valid.return_value = False
         # `store` is not the responsible of raising all these exceptions,
@@ -643,10 +660,11 @@ class TestDownloadBootresourcefileActivity:
             filename_on_disk="0" * 7,
             total_size=100,
         )
-        with pytest.raises(ApplicationError):
+        with pytest.raises(ApplicationError) as ex:
             await activity_env.run(
                 boot_activities.download_bootresourcefile, param
             )
+        assert ex.value.non_retryable is non_retryable
 
 
 class TestDeleteBootresourcefileActivity:


### PR DESCRIPTION
When downloading images, 4xx and 5xx errors were treated as retryable errors causing the activity to retry indefinitely. 