### PR TITLE
feat: add config for experimental switch provisioning

### DIFF
--- a/src/maasserver/forms/settings.py
+++ b/src/maasserver/forms/settings.py
@@ -66,6 +66,7 @@ from maasservicelayer.models.configurations import (
     EnableKernelCrashDumpConfig,
     EnableThirdPartyDriversConfig,
     EnlistCommissioningConfig,
+    ExperimentalSwitchProvisioningConfig,
     ForceV1NetworkYamlConfig,
     HardwareSyncIntervalConfig,
     HttpProxyConfig,
@@ -669,6 +670,15 @@ CONFIG_ITEMS = {
         "form_kwargs": {
             "required": False,
             "label": EnableAnalyticsConfig.description,
+        },
+    },
+    ExperimentalSwitchProvisioningConfig.name: {
+        "default": ExperimentalSwitchProvisioningConfig.default,
+        "form": forms.BooleanField,
+        "form_kwargs": {
+            "required": False,
+            "label": ExperimentalSwitchProvisioningConfig.description,
+            "help_text": ExperimentalSwitchProvisioningConfig.help_text,
         },
     },
     CompletedIntroConfig.name: {

--- a/src/maasservicelayer/models/configurations.py
+++ b/src/maasservicelayer/models/configurations.py
@@ -1029,6 +1029,18 @@ class AutoVlanCreationConfig(Config[bool | None]):
     value: bool | None = Field(default=default, description=description)
 
 
+class ExperimentalSwitchProvisioningConfig(Config[bool | None]):
+    name: ClassVar[str] = "experimental_switch_provisioning"
+    default: ClassVar[bool | None] = False
+    description: ClassVar[str] = (
+        "Enable the experimental switch provisioning feature"
+    )
+    help_text: ClassVar[str | None] = (
+        "Enables the experimental switch provisioning feature. This feature may have limited functionality."
+    )
+    value: bool | None = Field(default=default, description=description)
+
+
 # Private configs
 class ActiveDiscoveryLastScanConfig(Config[int | None]):
     is_public: ClassVar[bool] = False
@@ -1232,6 +1244,7 @@ class ConfigFactory:
         TlsCertExpirationNotificationEnabledConfig.name: TlsCertExpirationNotificationEnabledConfig,
         TLSCertExpirationNotificationIntervalConfig.name: TLSCertExpirationNotificationIntervalConfig,
         AutoVlanCreationConfig.name: AutoVlanCreationConfig,
+        ExperimentalSwitchProvisioningConfig.name: ExperimentalSwitchProvisioningConfig,
         # Private configs.
         ActiveDiscoveryLastScanConfig.name: ActiveDiscoveryLastScanConfig,
         CommissioningOSystemConfig.name: CommissioningOSystemConfig,


### PR DESCRIPTION
- Adds a config for experimental switch provisioning
- Will be used by the UI to enable/disable switch-related pages