### PR TITLE
fix(bootresources): match all lower priorities selections when deleting resources

### DIFF
--- a/src/maastemporalworker/workflow/bootresource.py
+++ b/src/maastemporalworker/workflow/bootresource.py
@@ -517,7 +517,7 @@ class BootResourcesActivity(ActivityBase):
             )
             assert selection is not None
 
-            # Remove any existing boot resources related to a selection with
+            # Remove any existing boot resources related to any selection with
             # the same os/arch/release. This can happen when there is a clash
             # between selections. (e.g. two selections for ubuntu/20.04/amd64
             # from different boot sources).
@@ -525,28 +525,27 @@ class BootResourcesActivity(ActivityBase):
             # the only one to be downloaded, i.e. we don't allow the user to
             # start a sync selection workflow for a lower priority selection.
             # This is enforced at the API level and in the master-image-sync wf.
-            if (
+            for (
                 existing_selection
-                := await services.boot_source_selections.get_one(
-                    query=QuerySpec(
-                        where=BootSourceSelectionClauseFactory.and_clauses(
-                            [
-                                BootSourceSelectionClauseFactory.with_os(
-                                    selection.os
-                                ),
-                                BootSourceSelectionClauseFactory.with_arch(
-                                    selection.arch
-                                ),
-                                BootSourceSelectionClauseFactory.with_release(
-                                    selection.release
-                                ),
-                                BootSourceSelectionClauseFactory.not_clause(
-                                    BootSourceSelectionClauseFactory.with_id(
-                                        selection.id
-                                    )
-                                ),
-                            ]
-                        )
+            ) in await services.boot_source_selections.get_many(
+                query=QuerySpec(
+                    where=BootSourceSelectionClauseFactory.and_clauses(
+                        [
+                            BootSourceSelectionClauseFactory.with_os(
+                                selection.os
+                            ),
+                            BootSourceSelectionClauseFactory.with_arch(
+                                selection.arch
+                            ),
+                            BootSourceSelectionClauseFactory.with_release(
+                                selection.release
+                            ),
+                            BootSourceSelectionClauseFactory.not_clause(
+                                BootSourceSelectionClauseFactory.with_id(
+                                    selection.id
+                                )
+                            ),
+                        ]
                     )
                 )
             ):

--- a/src/tests/maastemporalworker/workflow/test_bootresource.py
+++ b/src/tests/maastemporalworker/workflow/test_bootresource.py
@@ -824,7 +824,7 @@ class TestGetFilesToDownloadForSelectionActivity:
         services_mock.boot_source_selections.get_by_id.return_value = (
             boot_source_selection
         )
-        services_mock.boot_source_selections.get_one.return_value = (
+        services_mock.boot_source_selections.get_many.return_value = [
             BootSourceSelection(
                 id=2,
                 os="ubuntu",
@@ -833,7 +833,7 @@ class TestGetFilesToDownloadForSelectionActivity:
                 boot_source_id=2,
                 legacyselection_id=1,
             )
-        )
+        ]
 
         services_mock.boot_resources = Mock(BootResourceService)
 
@@ -867,7 +867,7 @@ class TestGetFilesToDownloadForSelectionActivity:
         services_mock.boot_source_selections.get_by_id.assert_awaited_once_with(
             1
         )
-        services_mock.boot_source_selections.get_one.assert_awaited_once_with(
+        services_mock.boot_source_selections.get_many.assert_awaited_once_with(
             query=QuerySpec(
                 where=BootSourceSelectionClauseFactory.and_clauses(
                     [


### PR DESCRIPTION
We were using `get_one`, but in fact there could be more than one selection matching the query. This resulted in an exception which caused the activity to retry indefinitely.