### PR TITLE
fix(bootresources): stop other fetch-manifest workflows when updating all the manifests

### DIFF
--- a/src/maasservicelayer/services/temporal.py
+++ b/src/maasservicelayer/services/temporal.py
@@ -70,6 +70,12 @@ class TemporalService(Service):
                 f"Failed to cancel workflow {workflow_id}"
             ) from None
 
+    async def cancel_workflows(self, query: str):
+        temporal_client = await self.get_temporal_client()
+        async for wf in temporal_client.list_workflows(query=query):
+            hdl = temporal_client.get_workflow_handle(wf.id)
+            await hdl.cancel()
+
     async def cancel_workflow_by_operation_uuid(
         self, operation_uuid: str
     ) -> None:

--- a/src/maastemporalworker/workflow/bootresource.py
+++ b/src/maastemporalworker/workflow/bootresource.py
@@ -376,6 +376,15 @@ class BootResourcesActivity(ActivityBase):
                 where_clauses.append(
                     BootSourcesClauseFactory.with_id(boot_source_id)
                 )
+            else:
+                # If we are fetching manifests for all the boot sources,
+                # cancel all the other running fetch manifest workflows
+                # to avoid serialization errors.
+                await services.temporal.cancel_workflows(
+                    query=f"WorkflowType='{FETCH_MANIFEST_AND_UPDATE_CACHE_WORKFLOW_NAME}' "
+                    "AND ExecutionStatus='Running' "
+                    f"AND WorkflowId!='{activity.info().workflow_id}'"
+                )
 
             boot_sources = await services.boot_sources.get_many(
                 query=QuerySpec(where=ClauseFactory.and_clauses(where_clauses))

--- a/src/tests/maasservicelayer/services/test_temporal.py
+++ b/src/tests/maasservicelayer/services/test_temporal.py
@@ -182,6 +182,28 @@ class TestTemporalService:
         )
         workflow_handle_mock.cancel.assert_awaited_once()
 
+    async def test_cancel_workflows(
+        self,
+        service: TemporalService,
+        temporal_client_mock,
+        workflow_handle_mock,
+    ) -> None:
+        wf = Mock()
+        wf.id = "wf-id"
+
+        async def _list_workflows():
+            yield wf
+
+        temporal_client_mock.list_workflows.return_value = _list_workflows()
+        await service.cancel_workflows("WorkflowId='wf-id'")
+        temporal_client_mock.list_workflows.assert_called_once_with(
+            query="WorkflowId='wf-id'"
+        )
+        temporal_client_mock.get_workflow_handle.assert_called_once_with(
+            "wf-id"
+        )
+        workflow_handle_mock.cancel.assert_awaited_once()
+
     async def test_terminate_workflow(
         self,
         service: TemporalService,

--- a/src/tests/maastemporalworker/workflow/test_bootresource.py
+++ b/src/tests/maastemporalworker/workflow/test_bootresource.py
@@ -763,6 +763,7 @@ class TestFetchManifestAndUpdateCacheActivity:
         services_mock.boot_source_selections = Mock(
             BootSourceSelectionsService
         )
+        services_mock.temporal = Mock(TemporalService)
 
         await activity_env.run(boot_activities.fetch_manifest_and_update_cache)
 

--- a/src/tests/maastemporalworker/workflow/test_bootresource.py
+++ b/src/tests/maastemporalworker/workflow/test_bootresource.py
@@ -711,6 +711,8 @@ class TestFetchManifestAndUpdateCacheActivity:
         )
         services_mock.notifications = Mock(NotificationsService)
         services_mock.notifications.delete_one.return_value = None
+        services_mock.temporal = Mock(TemporalService)
+        services_mock.temporal.cancel_workflows.return_value = None
 
         heartbeats = []
         activity_env.on_heartbeat = lambda *args: heartbeats.append(args[0])
@@ -730,6 +732,7 @@ class TestFetchManifestAndUpdateCacheActivity:
                 )
             ),
         )
+        services_mock.temporal.cancel_workflows.assert_awaited_once()
 
     async def test_creates_notification_if_exception_is_raised(
         self,


### PR DESCRIPTION
If the fetch-manifest workflows try to update simultaneously the manifest for the same boot source, serialization errors will happen.