### PR TITLE
feat: reconcile operations stuck in ACCEPTED

### DIFF
--- a/src/maascommon/workflows/operation.py
+++ b/src/maascommon/workflows/operation.py
@@ -8,9 +8,7 @@ OPERATION_UUID_SEARCH_ATTRIBUTE = "OperationUUID"
 
 RECONCILE_OPERATIONS_WORKFLOW_NAME = "reconcile-operations"
 
-# Single source of truth for which workflow fulfils each operation type.
-# Used when an operation is accepted and by reconciliation to restart stuck
-# ACCEPTED operations. Unmapped types are skipped during reconciliation.
+
 OPERATION_TYPE_WORKFLOW_NAME: dict[OperationType, str] = {
     OperationType.MACHINE_COMMISSION: COMMISSION_WORKFLOW_NAME,
 }

--- a/src/maascommon/workflows/operation.py
+++ b/src/maascommon/workflows/operation.py
@@ -6,6 +6,16 @@ from maascommon.workflows.commission import COMMISSION_WORKFLOW_NAME
 
 OPERATION_UUID_SEARCH_ATTRIBUTE = "OperationUUID"
 
+RECONCILE_OPERATIONS_WORKFLOW_NAME = "reconcile-operations"
+
+# Single source of truth for which workflow fulfils each operation type.
+# Used when an operation is accepted and by reconciliation to restart stuck
+# ACCEPTED operations. Unmapped types are skipped during reconciliation.
 OPERATION_TYPE_WORKFLOW_NAME: dict[OperationType, str] = {
     OperationType.MACHINE_COMMISSION: COMMISSION_WORKFLOW_NAME,
 }
+
+
+def workflow_name_for_operation_type(op_type: OperationType) -> str | None:
+    """Return the workflow name that fulfils ``op_type``, or None if unmapped."""
+    return OPERATION_TYPE_WORKFLOW_NAME.get(op_type)

--- a/src/maasservicelayer/db/repositories/operations.py
+++ b/src/maasservicelayer/db/repositories/operations.py
@@ -1,7 +1,8 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from operator import eq
+from datetime import datetime
+from operator import eq, le
 from typing import Iterable, Type
 
 from sqlalchemy import Table
@@ -37,6 +38,10 @@ class OperationsClauseFactory(ClauseFactory):
     @classmethod
     def with_user_id(cls, user_id: int) -> Clause:
         return Clause(condition=eq(OperationTable.c.user_id, user_id))
+
+    @classmethod
+    def created_before(cls, moment: datetime) -> Clause:
+        return Clause(condition=le(OperationTable.c.created, moment))
 
 
 class OperationsRepository(BaseRepository[Operation]):

--- a/src/maasservicelayer/services/operations.py
+++ b/src/maasservicelayer/services/operations.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
+from datetime import datetime
 from uuid import uuid4
 
 from temporalio.common import (
@@ -15,8 +16,8 @@ from maascommon.enums.operations import (
     OperationType,
 )
 from maascommon.workflows.operation import (
-    OPERATION_TYPE_WORKFLOW_NAME,
     OPERATION_UUID_SEARCH_ATTRIBUTE,
+    workflow_name_for_operation_type,
 )
 from maasservicelayer.builders.operations import (
     OperationBuilder,
@@ -87,7 +88,7 @@ class OperationsService(
         user_id: int | None = None,
     ) -> Operation:
         """Create an ACCEPTED operation and schedule its workflow after commit."""
-        workflow_name = OPERATION_TYPE_WORKFLOW_NAME.get(op_type)
+        workflow_name = workflow_name_for_operation_type(op_type)
         if workflow_name is None:
             raise ValueError(
                 f"No workflow is mapped to operation type '{op_type}'."
@@ -121,6 +122,23 @@ class OperationsService(
             ),
         )
         return operation
+
+    async def list_stuck_accepted_operations(
+        self, created_before: datetime
+    ) -> list[Operation]:
+        """Return ACCEPTED operations created before ``created_before``."""
+        return await self.repository.get_many(
+            query=QuerySpec(
+                where=OperationsClauseFactory.and_clauses(
+                    [
+                        OperationsClauseFactory.with_status(
+                            OperationStatus.ACCEPTED
+                        ),
+                        OperationsClauseFactory.created_before(created_before),
+                    ]
+                )
+            )
+        )
 
     async def update_status(
         self,

--- a/src/maastemporalworker/schedules.py
+++ b/src/maastemporalworker/schedules.py
@@ -21,6 +21,7 @@ from maascommon.workflows.bootresource import (
     FETCH_MANIFEST_AND_UPDATE_CACHE_WORKFLOW_NAME,
     MASTER_IMAGE_SYNC_WORKFLOW_NAME,
 )
+from maascommon.workflows.operation import RECONCILE_OPERATIONS_WORKFLOW_NAME
 from maastemporalworker.worker import REGION_TASK_QUEUE
 
 SCHEDULES: Final[dict[str, Schedule]] = {
@@ -47,6 +48,17 @@ SCHEDULES: Final[dict[str, Schedule]] = {
         # Will be updated at startup with the value from the db
         state=ScheduleState(paused=True),
         policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.CANCEL_OTHER),
+    ),
+    RECONCILE_OPERATIONS_WORKFLOW_NAME: Schedule(
+        action=ScheduleActionStartWorkflow(
+            RECONCILE_OPERATIONS_WORKFLOW_NAME,
+            id=RECONCILE_OPERATIONS_WORKFLOW_NAME,
+            task_queue=REGION_TASK_QUEUE,
+        ),
+        spec=ScheduleSpec(
+            intervals=[ScheduleIntervalSpec(every=timedelta(minutes=5))]
+        ),
+        policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
     ),
 }
 

--- a/src/maastemporalworker/temporal_script.py
+++ b/src/maastemporalworker/temporal_script.py
@@ -70,7 +70,10 @@ from maastemporalworker.workflow.msm import (
     MSMRestoreDefaultBootSourceWorkflow,
     MSMTokenRefreshWorkflow,
 )
-from maastemporalworker.workflow.operation import OperationActivity
+from maastemporalworker.workflow.operation import (
+    OperationActivity,
+    ReconcileOperationsWorkflow,
+)
 from maastemporalworker.workflow.power import (
     PowerActivity,
     PowerCycleWorkflow,
@@ -241,6 +244,8 @@ async def main() -> None:
                 PowerResetWorkflow,
                 # Tag Evaluation workflows
                 TagEvaluationWorkflow,
+                # Operation reconciliation workflows
+                ReconcileOperationsWorkflow,
             ],
             activities=[
                 # Boot resources activities
@@ -298,6 +303,9 @@ async def main() -> None:
                 # Operation status tracking activities
                 operation_activity.update_operation_status,
                 operation_activity.update_current_task,
+                # Operation reconciliation activities
+                operation_activity.get_stuck_operations,
+                operation_activity.start_operation_workflow,
             ],
         ),
         # Individual region controller worker

--- a/src/maastemporalworker/workflow/operation.py
+++ b/src/maastemporalworker/workflow/operation.py
@@ -7,10 +7,25 @@ from functools import wraps
 
 import structlog
 from temporalio import workflow
-from temporalio.common import SearchAttributeKey
-from temporalio.exceptions import ApplicationError, is_cancelled_exception
+from temporalio.common import (
+    SearchAttributeKey,
+    SearchAttributePair,
+    TypedSearchAttributes,
+    WorkflowIDReusePolicy,
+)
+from temporalio.exceptions import (
+    ApplicationError,
+    is_cancelled_exception,
+    WorkflowAlreadyStartedError,
+)
 
-from maascommon.enums.operations import OperationStatus
+from maascommon.enums.operations import OperationStatus, OperationType
+from maascommon.workflows.operation import (
+    RECONCILE_OPERATIONS_WORKFLOW_NAME,
+    workflow_name_for_operation_type,
+)
+from maasservicelayer.utils.date import utcnow
+from maastemporalworker.worker import REGION_TASK_QUEUE
 from maastemporalworker.workflow.activity import ActivityBase
 from maastemporalworker.workflow.utils import (
     activity_defn_with_context,
@@ -21,10 +36,18 @@ logger = structlog.getLogger()
 
 UPDATE_OPERATION_STATUS_TIMEOUT = timedelta(seconds=30)
 UPDATE_CURRENT_TASK_TIMEOUT = timedelta(seconds=30)
+GET_STUCK_OPERATIONS_TIMEOUT = timedelta(seconds=30)
+START_OPERATION_WORKFLOW_TIMEOUT = timedelta(seconds=30)
+
+# Operations that have been ACCEPTED for longer than 5 minutes are considered stuck
+# and are reconciled.
+STUCK_OPERATION_GRACE_PERIOD = timedelta(minutes=5)
 
 # Activities names
 UPDATE_OPERATION_STATUS_ACTIVITY_NAME = "update-operation-status"
 UPDATE_CURRENT_TASK_ACTIVITY_NAME = "update-current-task"
+GET_STUCK_OPERATIONS_ACTIVITY_NAME = "get-stuck-operations"
+START_OPERATION_WORKFLOW_ACTIVITY_NAME = "start-operation-workflow"
 
 OPERATION_UUID_SEARCH_ATTRIBUTE = SearchAttributeKey.for_keyword(
     "OperationUUID"
@@ -47,6 +70,13 @@ class UpdateCurrentTaskParam:
     task_number: int
 
 
+@dataclass
+class StuckOperation:
+    uuid: str
+    op_type: OperationType
+    parameters: dict | None = None
+
+
 class OperationActivity(ActivityBase):
     @activity_defn_with_context(name=UPDATE_OPERATION_STATUS_ACTIVITY_NAME)
     async def update_operation_status(
@@ -67,6 +97,55 @@ class OperationActivity(ActivityBase):
                 operation_uuid=param.operation_uuid,
                 name=param.name,
                 task_number=param.task_number,
+            )
+
+    @activity_defn_with_context(name=GET_STUCK_OPERATIONS_ACTIVITY_NAME)
+    async def get_stuck_operations(self) -> list[StuckOperation]:
+        cutoff = utcnow() - STUCK_OPERATION_GRACE_PERIOD
+        async with self.start_transaction() as services:
+            operations = (
+                await services.operations.list_stuck_accepted_operations(
+                    created_before=cutoff
+                )
+            )
+        return [
+            StuckOperation(
+                uuid=operation.uuid,
+                op_type=operation.op_type,
+                parameters=operation.parameters,
+            )
+            for operation in operations
+        ]
+
+    @activity_defn_with_context(name=START_OPERATION_WORKFLOW_ACTIVITY_NAME)
+    async def start_operation_workflow(self, param: StuckOperation) -> None:
+        workflow_name = workflow_name_for_operation_type(param.op_type)
+        if workflow_name is None:
+            logger.warning(
+                "Cannot reconcile operation with no mapped workflow",
+                operation_uuid=param.uuid,
+                op_type=param.op_type,
+            )
+            return
+        try:
+            await self.temporal_client.start_workflow(
+                workflow_name,
+                param.parameters,
+                id=param.uuid,
+                task_queue=REGION_TASK_QUEUE,
+                id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
+                search_attributes=TypedSearchAttributes(
+                    [
+                        SearchAttributePair(
+                            OPERATION_UUID_SEARCH_ATTRIBUTE, param.uuid
+                        )
+                    ]
+                ),
+            )
+        except WorkflowAlreadyStartedError:
+            logger.debug(
+                "Operation workflow already exists; skipping reconciliation",
+                operation_uuid=param.uuid,
             )
 
 
@@ -168,3 +247,24 @@ def workflow_run_with_tracked_operation(func):
     on operation-tracked workflows.
     """
     return workflow_run_with_context(track_operation_status(func))
+
+
+@workflow.defn(name=RECONCILE_OPERATIONS_WORKFLOW_NAME, sandboxed=False)
+class ReconcileOperationsWorkflow:
+    """Restart the workflow of operations stuck in ACCEPTED."""
+
+    @workflow_run_with_context
+    async def run(self) -> int:
+        stuck_operations: list[
+            StuckOperation
+        ] = await workflow.execute_activity(
+            GET_STUCK_OPERATIONS_ACTIVITY_NAME,
+            start_to_close_timeout=GET_STUCK_OPERATIONS_TIMEOUT,
+        )
+        for operation in stuck_operations:
+            await workflow.execute_activity(
+                START_OPERATION_WORKFLOW_ACTIVITY_NAME,
+                operation,
+                start_to_close_timeout=START_OPERATION_WORKFLOW_TIMEOUT,
+            )
+        return len(stuck_operations)

--- a/src/tests/maasservicelayer/services/test_operations.py
+++ b/src/tests/maasservicelayer/services/test_operations.py
@@ -359,6 +359,29 @@ class TestOperationsService:
                 op_type=OperationType.SELECTION_SYNC,
             )
 
+    async def test_list_stuck_accepted_operations(self) -> None:
+        repository = Mock(OperationsRepository)
+        repository.get_many.return_value = [TEST_OPERATION]
+        service = self._service(repository)
+        cutoff = utcnow()
+
+        operations = await service.list_stuck_accepted_operations(
+            created_before=cutoff
+        )
+
+        assert operations == [TEST_OPERATION]
+        query = repository.get_many.call_args.kwargs["query"]
+        assert query == QuerySpec(
+            where=OperationsClauseFactory.and_clauses(
+                [
+                    OperationsClauseFactory.with_status(
+                        OperationStatus.ACCEPTED
+                    ),
+                    OperationsClauseFactory.created_before(cutoff),
+                ]
+            )
+        )
+
     async def test_update_status_running_sets_started(self) -> None:
         repository = Mock(OperationsRepository)
         repository.get_one.return_value = TEST_OPERATION

--- a/src/tests/maastemporalworker/workflow/test_operation.py
+++ b/src/tests/maastemporalworker/workflow/test_operation.py
@@ -6,18 +6,30 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
 from temporalio.client import Client
-from temporalio.exceptions import ApplicationError, CancelledError
+from temporalio.common import WorkflowIDReusePolicy
+from temporalio.exceptions import (
+    ApplicationError,
+    CancelledError,
+    WorkflowAlreadyStartedError,
+)
 
-from maascommon.enums.operations import OperationStatus
+from maascommon.enums.operations import OperationStatus, OperationType
 from maasservicelayer.db import Database
 from maasservicelayer.exceptions.catalog import NotFoundException
+from maasservicelayer.models.operations import Operation
 from maasservicelayer.services import CacheForServices, ServiceCollectionV3
 from maasservicelayer.services.operations import OperationsService
 from maasservicelayer.services.temporal import TemporalService
+from maasservicelayer.utils.date import utcnow
+from maastemporalworker.worker import REGION_TASK_QUEUE
 import maastemporalworker.workflow.activity as activity_module
 import maastemporalworker.workflow.operation as operation_module
 from maastemporalworker.workflow.operation import (
+    GET_STUCK_OPERATIONS_ACTIVITY_NAME,
     OperationActivity,
+    ReconcileOperationsWorkflow,
+    START_OPERATION_WORKFLOW_ACTIVITY_NAME,
+    StuckOperation,
     track_operation_status,
     update_current_task,
     UpdateCurrentTaskParam,
@@ -282,3 +294,139 @@ class TestUpdateCurrentTask:
         with pytest.raises(ApplicationError):
             await update_current_task("task1", 1)
         local_activity_mock.assert_not_called()
+
+
+def _make_operation(uuid: str, parameters: dict | None = None) -> Operation:
+    return Operation(
+        id=1,
+        uuid=uuid,
+        op_type=OperationType.MACHINE_COMMISSION,
+        status=OperationStatus.ACCEPTED,
+        is_bulk=False,
+        parameters=parameters,
+        created=utcnow(),
+        updated=utcnow(),
+        user_id=1,
+    )
+
+
+@pytest.mark.asyncio
+class TestReconcileOperationsActivities:
+    def _operation_activity(self, temporal_client) -> OperationActivity:
+        return OperationActivity(
+            Mock(Database),
+            CacheForServices(),
+            connection=Mock(AsyncConnection),
+            temporal_client=temporal_client,
+        )
+
+    async def test_get_stuck_operations(
+        self, services_mock: ServiceCollectionV3, monkeypatch
+    ) -> None:
+        services_mock.temporal = Mock(TemporalService)
+        services_mock.operations = Mock(OperationsService)
+        services_mock.operations.list_stuck_accepted_operations = AsyncMock(
+            return_value=[_make_operation("op-uuid", {"system_id": "abc"})]
+        )
+        services_mock.produce.return_value = services_mock
+        monkeypatch.setattr(
+            activity_module, "ServiceCollectionV3", services_mock
+        )
+
+        activity = self._operation_activity(Mock(Client))
+        result = await activity.get_stuck_operations()
+
+        assert result == [
+            StuckOperation(
+                uuid="op-uuid",
+                op_type=OperationType.MACHINE_COMMISSION,
+                parameters={"system_id": "abc"},
+            )
+        ]
+        services_mock.operations.list_stuck_accepted_operations.assert_awaited_once()
+
+    async def test_start_operation_workflow_starts_mapped(self) -> None:
+        activity = self._operation_activity(Mock(Client))
+
+        await activity.start_operation_workflow(
+            StuckOperation(
+                uuid="op-uuid",
+                op_type=OperationType.MACHINE_COMMISSION,
+                parameters={"system_id": "abc"},
+            )
+        )
+
+        activity.temporal_client.start_workflow.assert_awaited_once()
+        call = activity.temporal_client.start_workflow.call_args
+        assert call.args[0] == "commission"
+        assert call.args[1] == {"system_id": "abc"}
+        assert call.kwargs["id"] == "op-uuid"
+        assert call.kwargs["task_queue"] == REGION_TASK_QUEUE
+        assert (
+            call.kwargs["id_reuse_policy"]
+            == WorkflowIDReusePolicy.REJECT_DUPLICATE
+        )
+
+    async def test_start_operation_workflow_skips_unmapped(self) -> None:
+        activity = self._operation_activity(Mock(Client))
+
+        await activity.start_operation_workflow(
+            StuckOperation(
+                uuid="op-uuid",
+                op_type=OperationType.SELECTION_SYNC,
+            )
+        )
+
+        activity.temporal_client.start_workflow.assert_not_awaited()
+
+    async def test_start_operation_workflow_swallows_already_started(
+        self,
+    ) -> None:
+        temporal_client = Mock(Client)
+        temporal_client.start_workflow = AsyncMock(
+            side_effect=WorkflowAlreadyStartedError("op-uuid", "commission")
+        )
+        activity = self._operation_activity(temporal_client)
+
+        await activity.start_operation_workflow(
+            StuckOperation(
+                uuid="op-uuid",
+                op_type=OperationType.MACHINE_COMMISSION,
+                parameters={"system_id": "abc"},
+            )
+        )
+
+
+@pytest.mark.asyncio
+class TestReconcileOperationsWorkflow:
+    async def test_starts_workflow_for_each_stuck_operation(
+        self, monkeypatch
+    ) -> None:
+        stuck = [
+            StuckOperation(
+                uuid="op-1", op_type=OperationType.MACHINE_COMMISSION
+            ),
+            StuckOperation(
+                uuid="op-2", op_type=OperationType.MACHINE_COMMISSION
+            ),
+        ]
+
+        async def fake_execute_activity(name, *args, **kwargs):
+            if name == GET_STUCK_OPERATIONS_ACTIVITY_NAME:
+                return stuck
+            return None
+
+        execute_activity = AsyncMock(side_effect=fake_execute_activity)
+        monkeypatch.setattr(
+            operation_module.workflow, "execute_activity", execute_activity
+        )
+
+        result = await ReconcileOperationsWorkflow().run()
+
+        assert result == 2
+        start_calls = [
+            call
+            for call in execute_activity.call_args_list
+            if call.args[0] == START_OPERATION_WORKFLOW_ACTIVITY_NAME
+        ]
+        assert [call.args[1] for call in start_calls] == stuck

--- a/src/tests/maastemporalworker/workflow/test_operation.py
+++ b/src/tests/maastemporalworker/workflow/test_operation.py
@@ -20,7 +20,6 @@ from maasservicelayer.models.operations import Operation
 from maasservicelayer.services import CacheForServices, ServiceCollectionV3
 from maasservicelayer.services.operations import OperationsService
 from maasservicelayer.services.temporal import TemporalService
-from maasservicelayer.utils.date import utcnow
 from maastemporalworker.worker import REGION_TASK_QUEUE
 import maastemporalworker.workflow.activity as activity_module
 import maastemporalworker.workflow.operation as operation_module
@@ -304,9 +303,6 @@ def _make_operation(uuid: str, parameters: dict | None = None) -> Operation:
         status=OperationStatus.ACCEPTED,
         is_bulk=False,
         parameters=parameters,
-        created=utcnow(),
-        updated=utcnow(),
-        user_id=1,
     )
 
 


### PR DESCRIPTION
Add a scheduled reconcile-operations workflow that retries workflow start for ACCEPTED operations whose post-commit start failed, using persisted parameters and OperationUUID.