### PR TITLE
fix(bootresources): don't block the API handler when importing boot resources

### DIFF
--- a/src/maasserver/bootresources.py
+++ b/src/maasserver/bootresources.py
@@ -18,6 +18,7 @@ from django.db.models import F
 from temporalio.client import WorkflowExecutionStatus
 from temporalio.common import WorkflowIDReusePolicy
 from twisted.application.internet import TimerService
+from twisted.internet import reactor
 from twisted.internet.defer import inlineCallbacks
 
 from maascommon.constants import BOOTLOADERS_DIR
@@ -56,19 +57,24 @@ log = LegacyLogger()
 
 def import_resources():
     """Starts the master image sync workflow."""
-    d = execute_workflow(
-        workflow_name=FETCH_MANIFEST_AND_UPDATE_CACHE_WORKFLOW_NAME,
-        workflow_id="fetch-manifest",
-        id_reuse_policy=WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
-    )
-    d.addCallback(
-        lambda _: start_workflow(
-            MASTER_IMAGE_SYNC_WORKFLOW_NAME,
-            "master-image-sync",
+
+    def _start():
+        d = execute_workflow(
+            workflow_name=FETCH_MANIFEST_AND_UPDATE_CACHE_WORKFLOW_NAME,
+            workflow_id="fetch-manifest",
             id_reuse_policy=WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
         )
-    )
-    return d
+        d.addCallback(
+            lambda _: start_workflow(
+                MASTER_IMAGE_SYNC_WORKFLOW_NAME,
+                "master-image-sync",
+                id_reuse_policy=WorkflowIDReusePolicy.TERMINATE_IF_RUNNING,
+            )
+        )
+        d.addErrback(log.err, "Failure importing boot resources.")
+        return d
+
+    reactor.callFromThread(_start)
 
 
 def is_import_resources_running():

--- a/src/tests/maasserver/test_bootresources.py
+++ b/src/tests/maasserver/test_bootresources.py
@@ -7,6 +7,7 @@ import shutil
 from django.db import connection
 import pytest
 
+from maasserver import bootresources
 from maasserver.bootresources import (
     export_images_from_db,
     initialize_image_storage,
@@ -404,3 +405,15 @@ class TestInitialiseImageStorage:
             "grubx64.efi",
             "bootx64.efi",
         }
+
+
+class TestImportResources:
+    def test_schedules_start_on_reactor_and_returns_immediately(self, mocker):
+        mock_reactor = mocker.patch("maasserver.bootresources.reactor")
+
+        result = bootresources.import_resources()
+
+        assert result is None
+        mock_reactor.callFromThread.assert_called_once()
+        [scheduled], _ = mock_reactor.callFromThread.call_args
+        assert callable(scheduled)


### PR DESCRIPTION
When you do `maas <profile> boot-resources import` the API response is not returned until the fetch manifest workflow terminates. To avoid this, we schedule this to be called in a thread and return immediately.