### PR TITLE
fix: MAASENG-6647 - Notification api/cli currently doesn't accept username…

### DIFF
--- a/src/maasserver/api/notification.py
+++ b/src/maasserver/api/notification.py
@@ -80,9 +80,10 @@ class NotificationsHandler(OperationsHandler):
         @param (string) "ident" [required=false] Unique identifier for this
         notification.
 
-        @param (string) "user" [required=false] User ID this notification is
-        intended for. By default it will not be targeted to any individual
-        user.
+        @param (string) "user" [required=false] User ID or username this
+        notification is intended for. Numeric values are treated as user IDs;
+        non-numeric values are treated as usernames. By default, it will not be
+        targeted to any individual user.
 
         @param (boolean) "users" [required=false] True to notify all users,
         defaults to false, i.e. not targeted to all users.
@@ -163,9 +164,10 @@ class NotificationHandler(OperationsHandler):
         @param (string) "ident" [required=false] Unique identifier for this
         notification.
 
-        @param (string) "user" [required=false] User ID this notification is
-        intended for. By default it will not be targeted to any individual
-        user.
+        @param (string) "user" [required=false] User ID or username this
+        notification is intended for. Numeric values are treated as user IDs;
+        non-numeric values are treated as usernames. By default, it will not be
+        targeted to any individual user.
 
         @param (boolean) "users" [required=false] True to notify all users,
         defaults to false, i.e. not targeted to all users.

--- a/src/maasserver/api/tests/test_notification.py
+++ b/src/maasserver/api/tests/test_notification.py
@@ -252,6 +252,45 @@ class TestNotificationAPI(
         else:
             self.assertEqual(response.status_code, http.client.FORBIDDEN)
 
+
+    def test_update_with_username_user_field(self):
+        notification = factory.make_Notification()
+        recipient = factory.make_User()
+        uri = get_notification_uri(notification)
+        response = self.client.put(
+            uri,
+            {
+                "message": factory.make_name("message"),
+                "user": recipient.username,
+            },
+        )
+        if self.user.is_superuser:
+            self.assertEqual(response.status_code, http.client.OK)
+            self.assertEqual(
+                response.json().get("user").get("username"), recipient.username
+            )
+        else:
+            self.assertEqual(response.status_code, http.client.FORBIDDEN)
+
+    def test_update_rejects_unknown_username_user_field(self):
+        notification = factory.make_Notification()
+        uri = get_notification_uri(notification)
+        response = self.client.put(
+            uri,
+            {
+                "message": factory.make_name("message"),
+                "user": "no-such-user",
+            },
+        )
+        if self.user.is_superuser:
+            self.assertEqual(response.status_code, http.client.BAD_REQUEST)
+            self.assertEqual(
+                response.json().get("user"),
+                ["Enter a valid user id or username."],
+            )
+        else:
+            self.assertEqual(response.status_code, http.client.FORBIDDEN)
+
     def test_delete_is_for_admins_only(self):
         notification = factory.make_Notification()
         uri = get_notification_uri(notification)

--- a/src/maasserver/api/tests/test_notification.py
+++ b/src/maasserver/api/tests/test_notification.py
@@ -151,6 +151,43 @@ class TestNotificationsAPI(
         else:
             self.assertEqual(response.status_code, http.client.FORBIDDEN)
 
+    def test_create_with_username_user_field(self):
+        recipient = factory.make_User()
+        uri = get_notifications_uri()
+        response = self.client.post(
+            uri,
+            {
+                "message": factory.make_name("message"),
+                "user": recipient.username,
+            },
+        )
+        if self.user.is_superuser:
+            self.assertEqual(response.status_code, http.client.OK)
+            notification = response.json()
+            self.assertEqual(
+                notification.get("user").get("username"), recipient.username
+            )
+        else:
+            self.assertEqual(response.status_code, http.client.FORBIDDEN)
+
+    def test_create_rejects_unknown_username_user_field(self):
+        uri = get_notifications_uri()
+        response = self.client.post(
+            uri,
+            {
+                "message": factory.make_name("message"),
+                "user": "no-such-user",
+            },
+        )
+        if self.user.is_superuser:
+            self.assertEqual(response.status_code, http.client.BAD_REQUEST)
+            self.assertEqual(
+                response.json().get("user"),
+                ["Enter a valid user id or username."],
+            )
+        else:
+            self.assertEqual(response.status_code, http.client.FORBIDDEN)
+
 
 class TestNotificationsAPI_Anonymous(APITestCase.ForAnonymous):
     def test_read(self):

--- a/src/maasserver/api/tests/test_notification.py
+++ b/src/maasserver/api/tests/test_notification.py
@@ -252,7 +252,6 @@ class TestNotificationAPI(
         else:
             self.assertEqual(response.status_code, http.client.FORBIDDEN)
 
-
     def test_update_with_username_user_field(self):
         notification = factory.make_Notification()
         recipient = factory.make_User()

--- a/src/maasserver/forms/notification.py
+++ b/src/maasserver/forms/notification.py
@@ -3,12 +3,21 @@
 
 """Notification form."""
 
+from django import forms
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+
 from maasserver.forms import MAASModelForm
 from maasserver.models.notification import Notification
 
 
 class NotificationForm(MAASModelForm):
     """Notification creation/edit form."""
+
+    # Override user ForeignKey field with CharField to accept both numeric IDs
+    # and alphanumeric usernames. Django's auto-generated ModelChoiceField would
+    # reject non-numeric strings before clean_user() could resolve them.
+    user = forms.CharField(required=False)
 
     class Meta:
         model = Notification
@@ -22,6 +31,29 @@ class NotificationForm(MAASModelForm):
             "category",
             "dismissable",
         )
+
+    def clean_user(self):
+        raw_user = self.cleaned_data.get("user", "").strip()
+
+        if not raw_user:
+            return None
+
+        # If numeric, treat as user ID (existing behavior).
+        if raw_user.isdigit():
+            try:
+                return User.objects.get(pk=int(raw_user))
+            except User.DoesNotExist:
+                raise ValidationError(
+                    "Enter a valid user id or username."
+                ) from None
+
+        # Non-numeric: treat as username.
+        try:
+            return User.objects.get(username=raw_user)
+        except User.DoesNotExist:
+            raise ValidationError(
+                "Enter a valid user id or username."
+            ) from None
 
     def clean_context(self):
         data = self.cleaned_data.get("context")

--- a/src/maasserver/forms/tests/test_notification.py
+++ b/src/maasserver/forms/tests/test_notification.py
@@ -86,6 +86,26 @@ class TestNotificationForm(MAASServerTestCase):
             self.assertFalse(notification.dismissable)
         self.assertEqual(notification.category, data["category"])
 
+    def test_notification_can_be_created_with_username(self):
+        user = factory.make_User()
+        data = {
+            "message": factory.make_name("message"),
+            "user": user.username,
+        }
+        form = NotificationForm(data)
+        self.assertTrue(form.is_valid(), form.errors)
+        notification = form.save()
+        self.assertEqual(notification.user, user)
+
+    def test_notification_rejects_unknown_username(self):
+        form = NotificationForm(
+            {"message": factory.make_name("message"), "user": "no-such-user"}
+        )
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            ["Enter a valid user id or username."], form.errors["user"]
+        )
+
     def test_notification_can_be_updated(self):
         notification = factory.make_Notification()
         user = factory.make_User()


### PR DESCRIPTION
[MAASENG-6647](https://warthogs.atlassian.net/browse/MAASENG-6647) - Notification api/cli currently doesn't accept username, it only accepts userid, which is difficult for end users. So we are supporting username too using the same field.

More details here: https://docs.google.com/document/d/1-Ht7BJyO4cqcN5j-jzq0Hej3zjw68Ricyw3LLr4dUMc/edit?usp=sharing

[MAASENG-6647]: https://warthogs.atlassian.net/browse/MAASENG-6647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ