### PR TITLE
fix(ci): bump setup-node action node version to 22 (match maas-ui)

### DIFF
--- a/.github/workflows/api-client-sync.yaml
+++ b/.github/workflows/api-client-sync.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
           cache-dependency-path: fe-repo/yarn.lock
 

--- a/.github/workflows/maas-ui-sync.yaml
+++ b/.github/workflows/maas-ui-sync.yaml
@@ -93,7 +93,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Test
         run: |


### PR DESCRIPTION
## Done

Bumped the Node version used in CI jobs to 22 to match MAAS UI's .nvmrc.