### PR TITLE
feat: add client credentials flow for OIDC CLI adaption

### DIFF
--- a/src/maasapiserver/v3/api/public/models/requests/external_auth.py
+++ b/src/maasapiserver/v3/api/public/models/requests/external_auth.py
@@ -46,7 +46,6 @@ class OAuthProviderRequest(BaseModel):
         description="The type of access tokens issued by the OIDC provider (e.g., JWT or opaque).",
     )
     vendor: OAuthVendorChoices = Field(
-        default=OAuthVendorChoices.GENERIC,
         description="The OIDC provider vendor. Select from predefined vendors or use 'Generic' for other providers.",
     )
     scopes: str = Field(

--- a/src/maasapiserver/v3/api/public/models/requests/external_auth.py
+++ b/src/maasapiserver/v3/api/public/models/requests/external_auth.py
@@ -8,12 +8,22 @@ from pydantic import BaseModel, Field, field_validator, ValidationInfo
 
 from maasservicelayer.builders.external_auth import OAuthProviderBuilder
 from maasservicelayer.exceptions.catalog import ValidationException
-from maasservicelayer.models.external_auth import AccessTokenType
+from maasservicelayer.models.external_auth import (
+    AccessTokenType,
+    ProviderVendorType,
+)
 
 
 class OAuthTokenTypeChoices(StrEnum):
     JWT = "JWT"
     OPAQUE = "Opaque"
+
+
+class OAuthVendorChoices(StrEnum):
+    GENERIC = "Generic"
+    ENTRAID = "EntraID"
+    AUTH0 = "Auth0"
+    KEYCLOAK = "Keycloak"
 
 
 class OAuthProviderRequest(BaseModel):
@@ -34,6 +44,10 @@ class OAuthProviderRequest(BaseModel):
     )
     token_type: OAuthTokenTypeChoices = Field(
         description="The type of access tokens issued by the OIDC provider (e.g., JWT or opaque).",
+    )
+    vendor: OAuthVendorChoices = Field(
+        default=OAuthVendorChoices.GENERIC,
+        description="The OIDC provider vendor. Select from predefined vendors or use 'Generic' for other providers.",
     )
     scopes: str = Field(
         description="A space-separated list of OIDC scopes defining the information requested from the provider.",
@@ -60,6 +74,7 @@ class OAuthProviderRequest(BaseModel):
             if self.token_type == OAuthTokenTypeChoices.JWT
             else AccessTokenType.OPAQUE
         )
+        vendor = ProviderVendorType[self.vendor.name]
         return OAuthProviderBuilder(
             name=self.name,
             client_id=self.client_id,
@@ -67,6 +82,7 @@ class OAuthProviderRequest(BaseModel):
             issuer_url=self.issuer_url,
             redirect_uri=self.redirect_uri,
             token_type=token_type,
+            vendor=vendor,
             scopes=self.scopes,
             enabled=self.enabled,
         )

--- a/src/maasapiserver/v3/api/public/models/responses/oauth2.py
+++ b/src/maasapiserver/v3/api/public/models/responses/oauth2.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 
 from maasapiserver.v3.api.public.models.requests.external_auth import (
     OAuthTokenTypeChoices,
+    OAuthVendorChoices,
 )
 from maasapiserver.v3.api.public.models.responses.base import PaginatedResponse
 from maasservicelayer.models.external_auth import (
@@ -73,6 +74,7 @@ class OAuthProviderResponse(BaseModel):
     metadata: ProviderMetadata
     user_count: int | None = None
     token_type: OAuthTokenTypeChoices
+    vendor: OAuthVendorChoices
 
     @classmethod
     def from_model(
@@ -92,6 +94,7 @@ class OAuthProviderResponse(BaseModel):
             token_type=OAuthTokenTypeChoices.JWT
             if provider.token_type == AccessTokenType.JWT
             else OAuthTokenTypeChoices.OPAQUE,
+            vendor=OAuthVendorChoices[provider.vendor.name],
         )
 
 

--- a/src/maasserver/api/auth.py
+++ b/src/maasserver/api/auth.py
@@ -20,6 +20,7 @@ from maasserver.macaroon_auth import (
     validate_user_external_auth,
 )
 from maasserver.models.user import SYSTEM_USERS
+from maasserver.sqlalchemy import service_layer
 
 _NECESSARY_OAUTH_PARAMS = [
     "oauth_" + s
@@ -207,7 +208,12 @@ class MAASAPIAuthentication(OAuthAuthentication):
                         ):
                             return False
                     elif not is_local_user:
-                        return False
+                        # Verify this is an OIDC user and is still
+                        # active at the OIDC provider before granting access.
+                        if not service_layer.services.external_oauth.is_active_oidc_user(
+                            user.username
+                        ):
+                            return False
 
                 request.user = user
                 request.consumer = consumer

--- a/src/maasserver/api/examples/oidc-providers.json
+++ b/src/maasserver/api/examples/oidc-providers.json
@@ -7,6 +7,7 @@
         "client_secret": "example-client-secret",
         "enabled": true,
         "token_type": "JWT",
+        "vendor": "Generic",
         "redirect_uri": "https://maas.example.com/MAAS/r/login/oidc/callback",
         "scopes": "openid profile email offline_access"
     },
@@ -18,6 +19,7 @@
         "client_secret": "example-client-secret",
         "enabled": true,
         "token_type": "JWT",
+        "vendor": "Generic",
         "redirect_uri": "https://maas.example.com/MAAS/r/login/oidc/callback",
         "scopes": "openid profile email offline_access"
     },
@@ -29,6 +31,7 @@
         "client_secret": "some-client-secret",
         "enabled": false,
         "token_type": "Opaque",
+        "vendor": "EntraID",
         "redirect_uri": "https://maas.example.com/MAAS/r/login/oidc/callback",
         "scopes": "openid profile email offline_access"
     },
@@ -41,6 +44,7 @@
             "client_secret": "example-client-secret",
             "enabled": true,
             "token_type": "JWT",
+            "vendor": "Generic",
             "redirect_uri": "https://maas.example.com/MAAS/r/login/oidc/callback",
             "scopes": "openid profile email offline_access"
         },
@@ -52,6 +56,7 @@
             "client_secret": "second-client-secret",
             "enabled": false,
             "token_type": "Opaque",
+            "vendor": "Keycloak",
             "redirect_uri": "https://maas.example.com/MAAS/r/login/oidc/callback",
             "scopes": "openid profile email"
         }

--- a/src/maasserver/api/oidc_providers.py
+++ b/src/maasserver/api/oidc_providers.py
@@ -32,6 +32,7 @@ from maasservicelayer.exceptions.catalog import (
 from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
+    ProviderVendorType,
 )
 
 UPDATABLE_FIELDS = (
@@ -41,9 +42,21 @@ UPDATABLE_FIELDS = (
     "client_secret",
     "enabled",
     "token_type",
+    "vendor",
     "redirect_uri",
     "scopes",
 )
+
+VENDOR_NAME_BY_TYPE = {
+    ProviderVendorType.GENERIC: "Generic",
+    ProviderVendorType.ENTRAID: "EntraID",
+    ProviderVendorType.AUTH0: "Auth0",
+    ProviderVendorType.KEYCLOAK: "Keycloak",
+}
+
+VENDOR_TYPE_BY_NAME = {
+    name.upper(): vendor for vendor, name in VENDOR_NAME_BY_TYPE.items()
+}
 
 
 def provider_to_dict(provider: OAuthProvider) -> dict:
@@ -55,6 +68,7 @@ def provider_to_dict(provider: OAuthProvider) -> dict:
         "client_secret": provider.client_secret,
         "enabled": provider.enabled,
         "token_type": "JWT" if provider.token_type == 0 else "Opaque",
+        "vendor": VENDOR_NAME_BY_TYPE[provider.vendor],
         "redirect_uri": provider.redirect_uri,
         "scopes": provider.scopes,
     }
@@ -70,6 +84,16 @@ def parse_token_type(token_type: str) -> AccessTokenType:
         raise MAASAPIBadRequest(
             f"Invalid token type: {token_type}. Must be 'JWT' or 'Opaque'."
         )
+
+
+def parse_vendor(vendor: str) -> ProviderVendorType:
+    try:
+        return VENDOR_TYPE_BY_NAME[vendor.upper()]
+    except KeyError:
+        valid = ", ".join(VENDOR_NAME_BY_TYPE.values())
+        raise MAASAPIBadRequest(
+            f"Invalid vendor: {vendor}. Must be one of: {valid}."
+        ) from None
 
 
 def validate_http_urls(value: str, field: str) -> None:
@@ -154,6 +178,7 @@ class OidcProviderHandler(OperationsHandler):
         @param (string) "client_secret" [required=false] New client secret for the OIDC provider.
         @param (boolean) "enabled" [required=false] Whether the OIDC provider should be enabled.
         @param (string) "token_type" [required=false] New token type for the OIDC provider (JWT or Opaque).
+        @param (string) "vendor" [required=false] New vendor for the OIDC provider (Generic, EntraID, Auth0, or Keycloak).
         @param (string) "redirect_uri" [required=false] New redirect URI for the OIDC provider.
         @param (string) "scopes" [required=false] Space-separated list of scopes for the OIDC provider.
 
@@ -175,6 +200,8 @@ class OidcProviderHandler(OperationsHandler):
             validate_http_urls(fields["redirect_uri"], "Redirect URI")
         if "token_type" in fields:
             fields["token_type"] = parse_token_type(fields["token_type"])
+        if "vendor" in fields:
+            fields["vendor"] = parse_vendor(fields["vendor"])
 
         builder = OAuthProviderBuilder(**fields)
         try:
@@ -263,6 +290,7 @@ class OidcProvidersHandler(OperationsHandler):
         @param (string) "client_secret" [required=true] Client secret for the new OIDC provider.
         @param (boolean) "enabled" [required=false] Whether the OIDC provider is enabled. Defaults to false.
         @param (string) "token_type" [required=false] Token type for the OIDC provider (JWT or Opaque). Defaults to JWT.
+        @param (string) "vendor" [required=false] Vendor for the OIDC provider (Generic, EntraID, Auth0, or Keycloak). Defaults to Generic.
         @param (string) "redirect_uri" [required=false] Redirect URI for the OIDC provider.
         @param (string) "scopes" [required=false] Space-separated list of scopes for the OIDC provider.
 
@@ -280,12 +308,14 @@ class OidcProvidersHandler(OperationsHandler):
         client_secret = request.POST.get("client_secret", None)
         enabled = request.POST.get("enabled", "false").lower() == "true"
         token_type = request.POST.get("token_type", "JWT")
+        vendor = request.POST.get("vendor", "Generic")
         redirect_uri = request.POST.get("redirect_uri", None)
         scopes = request.POST.get("scopes", "")
 
         validate_http_urls(issuer_url, "Issuer URL")
         validate_http_urls(redirect_uri, "Redirect URI")
         token_type = parse_token_type(token_type)
+        vendor = parse_vendor(vendor)
 
         builder = OAuthProviderBuilder(
             name=name,
@@ -294,6 +324,7 @@ class OidcProvidersHandler(OperationsHandler):
             client_secret=client_secret,
             enabled=enabled,
             token_type=token_type,
+            vendor=vendor,
             redirect_uri=redirect_uri,
             scopes=scopes,
         )

--- a/src/maasserver/api/oidc_providers.py
+++ b/src/maasserver/api/oidc_providers.py
@@ -288,11 +288,11 @@ class OidcProvidersHandler(OperationsHandler):
         @param (string) "issuer_url" [required=true] Issuer URL for the new OIDC provider.
         @param (string) "client_id" [required=true] Client ID for the new OIDC provider.
         @param (string) "client_secret" [required=true] Client secret for the new OIDC provider.
-        @param (boolean) "enabled" [required=false] Whether the OIDC provider is enabled. Defaults to false.
-        @param (string) "token_type" [required=false] Token type for the OIDC provider (JWT or Opaque). Defaults to JWT.
-        @param (string) "vendor" [required=false] Vendor for the OIDC provider (Generic, EntraID, Auth0, or Keycloak). Defaults to Generic.
-        @param (string) "redirect_uri" [required=false] Redirect URI for the OIDC provider.
-        @param (string) "scopes" [required=false] Space-separated list of scopes for the OIDC provider.
+        @param (boolean) "enabled" [required=true] Whether the OIDC provider is enabled.
+        @param (string) "token_type" [required=true] Token type for the OIDC provider (JWT or Opaque).
+        @param (string) "vendor" [required=true] Vendor for the OIDC provider (Generic, EntraID, Auth0, or Keycloak).
+        @param (string) "redirect_uri" [required=true] Redirect URI for the OIDC provider.
+        @param (string) "scopes" [required=true] Space-separated list of scopes for the OIDC provider.
 
         @success (http-status-code) "server-success" 201
         @success (json) "success-json" A JSON object representing the newly created OIDC provider.
@@ -306,11 +306,11 @@ class OidcProvidersHandler(OperationsHandler):
         issuer_url = request.POST.get("issuer_url", None)
         client_id = request.POST.get("client_id", None)
         client_secret = request.POST.get("client_secret", None)
-        enabled = request.POST.get("enabled", "false").lower() == "true"
-        token_type = request.POST.get("token_type", "JWT")
-        vendor = request.POST.get("vendor", "Generic")
+        enabled = request.POST.get("enabled", None)
+        token_type = request.POST.get("token_type", None)
+        vendor = request.POST.get("vendor", None)
         redirect_uri = request.POST.get("redirect_uri", None)
-        scopes = request.POST.get("scopes", "")
+        scopes = request.POST.get("scopes", None)
 
         validate_http_urls(issuer_url, "Issuer URL")
         validate_http_urls(redirect_uri, "Redirect URI")

--- a/src/maasserver/api/tests/test_auth.py
+++ b/src/maasserver/api/tests/test_auth.py
@@ -130,6 +130,60 @@ class TestMAASAPIAuthentication(MAASServerTestCase):
             ),
         )
 
+    def test_is_authenticated_oidc_user_active(self):
+        SecretManager().delete_secret("external-auth")
+        mock_service_layer = self.patch(api_auth, "service_layer")
+        mock_service_layer.services.external_oauth.is_active_oidc_user.return_value = True
+
+        auth = MAASAPIAuthentication()
+        user = factory.make_User()
+        user.userprofile.is_local = False
+        user.userprofile.save()
+        mock_token = mock.Mock(user=user)
+        request = self.make_request()
+        auth.check_validity = lambda request: RequestValidityReport({}, {}, {})
+        auth.validate_token = lambda request: (mock.Mock(), mock_token, None)
+
+        self.assertTrue(auth.is_authenticated(request))
+        mock_service_layer.services.external_oauth.is_active_oidc_user.assert_called_once_with(
+            user.username
+        )
+
+    def test_is_authenticated_oidc_user_inactive(self):
+        SecretManager().delete_secret("external-auth")
+        mock_service_layer = self.patch(api_auth, "service_layer")
+        mock_service_layer.services.external_oauth.is_active_oidc_user.return_value = False
+
+        auth = MAASAPIAuthentication()
+        user = factory.make_User()
+        user.userprofile.is_local = False
+        user.userprofile.save()
+        mock_token = mock.Mock(user=user)
+        request = self.make_request()
+        auth.check_validity = lambda request: RequestValidityReport({}, {}, {})
+        auth.validate_token = lambda request: (mock.Mock(), mock_token, None)
+
+        self.assertFalse(auth.is_authenticated(request))
+        mock_service_layer.services.external_oauth.is_active_oidc_user.assert_called_once_with(
+            user.username
+        )
+
+    def test_is_authenticated_local_user_skips_oidc_check(self):
+        SecretManager().delete_secret("external-auth")
+        mock_service_layer = self.patch(api_auth, "service_layer")
+
+        auth = MAASAPIAuthentication()
+        user = factory.make_User()
+        user.userprofile.is_local = True
+        user.userprofile.save()
+        mock_token = mock.Mock(user=user)
+        request = self.make_request()
+        auth.check_validity = lambda request: RequestValidityReport({}, {}, {})
+        auth.validate_token = lambda request: (mock.Mock(), mock_token, None)
+
+        self.assertTrue(auth.is_authenticated(request))
+        mock_service_layer.services.external_oauth.is_active_oidc_user.assert_not_called()
+
     def test_validity_report(self):
         params = product(["AUTH_HEADER", "GET", "POST"], [True, False])
         valid_auth_headers = {

--- a/src/maasserver/api/tests/test_oidc_providers.py
+++ b/src/maasserver/api/tests/test_oidc_providers.py
@@ -221,6 +221,7 @@ class TestOidcProviders(APITestCase.ForUser):
         "scopes": "openid profile email",
         "enabled": True,
         "token_type": "JWT",
+        "vendor": "Generic",
     }
 
     def setUp(self):

--- a/src/maasserver/api/tests/test_oidc_providers.py
+++ b/src/maasserver/api/tests/test_oidc_providers.py
@@ -15,6 +15,7 @@ from maasservicelayer.exceptions.catalog import (
     PreconditionFailedException,
 )
 from maasservicelayer.models.base import ListResult
+from maasservicelayer.models.external_auth import ProviderVendorType
 
 
 def get_oidc_provider_uri(provider):
@@ -155,6 +156,48 @@ class TestOidcProvider(APITestCase.ForUser):
             provider_to_dict(updated_provider),
         )
 
+    def test_PUT_invalid_vendor(self):
+        self.become_admin()
+        provider = factory.make_OidcProvider()
+        self.external_oauth.get_by_id.return_value = provider
+
+        response = self.client.put(
+            get_oidc_provider_uri(provider),
+            data={
+                "vendor": "INVALID",
+            },
+        )
+
+        self.assertEqual(http.client.BAD_REQUEST, response.status_code)
+        self.assertEqual(
+            str(response.content, "utf-8"),
+            "Invalid vendor: INVALID. Must be one of: "
+            "Generic, EntraID, Auth0, Keycloak.",
+        )
+        self.external_oauth.update_provider.assert_not_called()
+
+    def test_PUT_updates_vendor(self):
+        self.become_admin()
+        provider = factory.make_OidcProvider(vendor=ProviderVendorType.GENERIC)
+        updated_provider = provider.copy()
+        updated_provider.vendor = ProviderVendorType.AUTH0
+        self.external_oauth.get_by_id.return_value = provider
+        self.external_oauth.update_provider.return_value = updated_provider
+
+        response = self.client.put(
+            get_oidc_provider_uri(provider),
+            data={
+                "vendor": "Auth0",
+            },
+        )
+
+        self.assertEqual(http.client.OK, response.status_code)
+        builder = self.external_oauth.update_provider.call_args.kwargs[
+            "builder"
+        ]
+        self.assertEqual(builder.vendor, ProviderVendorType.AUTH0)
+        self.assertEqual(json_load_bytes(response.content)["vendor"], "Auth0")
+
     def test_PUT_requires_admin(self):
         provider = factory.make_OidcProvider()
 
@@ -287,6 +330,22 @@ class TestOidcProviders(APITestCase.ForUser):
             "Invalid token type: INVALID. Must be 'JWT' or 'Opaque'.",
         )
 
+    def test_CREATE_invalid_vendor(self):
+        self.become_admin()
+        data = self.SAMPLE_PROVIDER_DATA.copy()
+        data["vendor"] = "INVALID"
+
+        response = self.client.post(
+            reverse("oidc_providers_handler"),
+            data=data,
+        )
+        self.assertEqual(http.client.BAD_REQUEST, response.status_code)
+        self.assertEqual(
+            str(response.content, "utf-8"),
+            "Invalid vendor: INVALID. Must be one of: "
+            "Generic, EntraID, Auth0, Keycloak.",
+        )
+
     def test_CREATE_bad_gateway(self):
         self.become_admin()
         self.external_oauth.create.side_effect = BadGatewayException()
@@ -341,6 +400,39 @@ class TestOidcProviders(APITestCase.ForUser):
         self.assertEqual(http.client.CREATED, response.status_code)
         self.assertEqual(
             json_load_bytes(response.content), provider_to_dict(provider)
+        )
+
+    def test_CREATE_defaults_vendor_to_generic(self):
+        self.become_admin()
+        provider = factory.make_OidcProvider(vendor=ProviderVendorType.GENERIC)
+        self.external_oauth.create.return_value = provider
+
+        response = self.client.post(
+            reverse("oidc_providers_handler"),
+            data=self.SAMPLE_PROVIDER_DATA,
+        )
+        self.assertEqual(http.client.CREATED, response.status_code)
+        builder = self.external_oauth.create.call_args.kwargs["builder"]
+        self.assertEqual(builder.vendor, ProviderVendorType.GENERIC)
+
+    def test_CREATE_with_vendor(self):
+        self.become_admin()
+        provider = factory.make_OidcProvider(
+            vendor=ProviderVendorType.KEYCLOAK
+        )
+        self.external_oauth.create.return_value = provider
+        data = self.SAMPLE_PROVIDER_DATA.copy()
+        data["vendor"] = "Keycloak"
+
+        response = self.client.post(
+            reverse("oidc_providers_handler"),
+            data=data,
+        )
+        self.assertEqual(http.client.CREATED, response.status_code)
+        builder = self.external_oauth.create.call_args.kwargs["builder"]
+        self.assertEqual(builder.vendor, ProviderVendorType.KEYCLOAK)
+        self.assertEqual(
+            json_load_bytes(response.content)["vendor"], "Keycloak"
         )
 
     def test_CREATE_requires_admin(self):

--- a/src/maasserver/testing/factory.py
+++ b/src/maasserver/testing/factory.py
@@ -132,6 +132,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
 )
 from maasservicelayer.models.openfga_tuple import OpenFGATuple
 from maasservicelayer.models.usergroups import UserGroup
@@ -3886,6 +3887,7 @@ class Factory(maastesting.factory.Factory):
         redirect_uri=None,
         token_type=None,
         enabled=None,
+        vendor=None,
     ):
         if name is None:
             name = self.make_name("oidc_provider")
@@ -3903,6 +3905,8 @@ class Factory(maastesting.factory.Factory):
             token_type = self.pick_choice([(0, "JWT"), (1, "Opaque")])
         if enabled is None:
             enabled = self.pick_bool()
+        if vendor is None:
+            vendor = ProviderVendorType.GENERIC
         metadata = ProviderMetadata(
             authorization_endpoint=self.make_url(scheme="https"),
             token_endpoint=self.make_url(scheme="https"),
@@ -3918,6 +3922,7 @@ class Factory(maastesting.factory.Factory):
             scopes=scopes,
             redirect_uri=redirect_uri,
             token_type=AccessTokenType(token_type),
+            vendor=vendor,
             metadata=metadata,
             enabled=enabled,
         )

--- a/src/maasservicelayer/auth/oidc_adapters.py
+++ b/src/maasservicelayer/auth/oidc_adapters.py
@@ -7,7 +7,10 @@ from urllib.parse import urlparse
 
 from httpx import AsyncClient
 
-from maasservicelayer.models.external_auth import OAuthProvider
+from maasservicelayer.models.external_auth import (
+    OAuthProvider,
+    ProviderVendorType,
+)
 from maasservicelayer.utils.date import utcnow
 
 # Refresh the cached token slightly before it expires to avoid races.
@@ -161,3 +164,19 @@ class KeycloakAdapter(BaseProviderAdapter):
         )
         users = result or []
         return bool(users) and bool(users[0].get("enabled"))
+
+
+ADAPTER_BY_VENDOR: dict[ProviderVendorType, type[BaseProviderAdapter]] = {
+    ProviderVendorType.ENTRAID: EntraIDAdapter,
+    ProviderVendorType.AUTH0: Auth0Adapter,
+    ProviderVendorType.KEYCLOAK: KeycloakAdapter,
+}
+
+
+def get_provider_adapter(
+    provider: OAuthProvider, http_client: AsyncClient
+) -> BaseProviderAdapter | None:
+    adapter_cls = ADAPTER_BY_VENDOR.get(provider.vendor)
+    if adapter_cls is None:
+        return None
+    return adapter_cls(provider, http_client)

--- a/src/maasservicelayer/auth/oidc_adapters.py
+++ b/src/maasservicelayer/auth/oidc_adapters.py
@@ -5,8 +5,15 @@ from abc import ABC, abstractmethod
 from typing import Any
 from urllib.parse import urlparse
 
-from httpx import AsyncClient
+from httpx import AsyncClient, HTTPError
 
+from maasservicelayer.exceptions.catalog import (
+    BadGatewayException,
+    BaseExceptionDetail,
+)
+from maasservicelayer.exceptions.constants import (
+    PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE,
+)
 from maasservicelayer.models.external_auth import (
     OAuthProvider,
     ProviderVendorType,
@@ -36,6 +43,19 @@ class BaseProviderAdapter(ABC):
         result = await self._token_request(
             self._token_endpoint(), self._token_request_body()
         )
+        if "access_token" not in result:
+            raise BadGatewayException(
+                details=[
+                    BaseExceptionDetail(
+                        type=PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE,
+                        message=(
+                            "The OIDC provider did not return an access "
+                            "token. Please ensure the provider is configured "
+                            "correctly."
+                        ),
+                    )
+                ]
+            )
         token: str = result["access_token"]
         self._token = token
         self._token_expiry = now + result.get("expires_in", DEFAULT_TOKEN_TTL)
@@ -51,9 +71,23 @@ class BaseProviderAdapter(ABC):
     async def _token_request(
         self, url: str, data: dict[str, str]
     ) -> dict[str, Any]:
-        response = await self._http.post(url, data=data)
-        response.raise_for_status()
-        return response.json()
+        try:
+            response = await self._http.post(url, data=data)
+            response.raise_for_status()
+            return response.json()
+        except HTTPError as e:
+            raise BadGatewayException(
+                details=[
+                    BaseExceptionDetail(
+                        type=PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE,
+                        message=(
+                            "Failed to retrieve a token from the OIDC "
+                            "provider. Please ensure the provider is "
+                            "configured correctly."
+                        ),
+                    )
+                ]
+            ) from e
 
     async def _get(
         self,
@@ -65,13 +99,27 @@ class BaseProviderAdapter(ABC):
         request_headers = {"Authorization": f"Bearer {token}"}
         if headers:
             request_headers.update(headers)
-        response = await self._http.get(
-            url,
-            params=params,
-            headers=request_headers,
-        )
-        response.raise_for_status()
-        return response.json()
+        try:
+            response = await self._http.get(
+                url,
+                params=params,
+                headers=request_headers,
+            )
+            response.raise_for_status()
+            return response.json()
+        except HTTPError as e:
+            raise BadGatewayException(
+                details=[
+                    BaseExceptionDetail(
+                        type=PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE,
+                        message=(
+                            "The OIDC provider rejected the request. "
+                            "Please ensure the provider is configured "
+                            "correctly."
+                        ),
+                    )
+                ]
+            ) from e
 
     @abstractmethod
     async def user_is_active(self, email: str) -> bool:

--- a/src/maasservicelayer/auth/oidc_adapters.py
+++ b/src/maasservicelayer/auth/oidc_adapters.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Canonical Ltd.  This software is licensed under the
+# GNU Affero General Public License version 3 (see the file LICENSE).
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+from httpx import AsyncClient
+
+from maasservicelayer.models.external_auth import OAuthProvider
+from maasservicelayer.utils.date import utcnow
+
+# Refresh the cached token slightly before it expires to avoid races.
+TOKEN_EXPIRY_LEEWAY = 30
+DEFAULT_TOKEN_TTL = 3600
+
+
+class BaseProviderAdapter(ABC):
+    """Queries a provider's user-management API using the client credentials
+    (machine-to-machine) flow, to verify whether a user is still valid.
+    """
+
+    def __init__(self, provider: OAuthProvider, http_client: AsyncClient):
+        self.provider = provider
+        self._http = http_client
+        self._token: str | None = None
+        self._token_expiry: float = 0.0
+
+    async def get_token(self) -> str:
+        now = utcnow().timestamp()
+        if self._token and now < self._token_expiry - TOKEN_EXPIRY_LEEWAY:
+            return self._token
+        result = await self._token_request(
+            self._token_endpoint(), self._token_request_body()
+        )
+        token: str = result["access_token"]
+        self._token = token
+        self._token_expiry = now + result.get("expires_in", DEFAULT_TOKEN_TTL)
+        return token
+
+    def _token_endpoint(self) -> str:
+        return self.provider.metadata.token_endpoint
+
+    @abstractmethod
+    def _token_request_body(self) -> dict[str, str]:
+        """Provider-specific body for the client credentials token request."""
+
+    async def _token_request(
+        self, url: str, data: dict[str, str]
+    ) -> dict[str, Any]:
+        response = await self._http.post(url, data=data)
+        response.raise_for_status()
+        return response.json()
+
+    async def _get(
+        self,
+        url: str,
+        params: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> Any:
+        token = await self.get_token()
+        request_headers = {"Authorization": f"Bearer {token}"}
+        if headers:
+            request_headers.update(headers)
+        response = await self._http.get(
+            url,
+            params=params,
+            headers=request_headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    @abstractmethod
+    async def user_is_active(self, email: str) -> bool:
+        """Whether a user with the given email exists and is active."""
+
+
+class EntraIDAdapter(BaseProviderAdapter):
+    """Microsoft Entra ID (Azure AD), via the Microsoft Graph API."""
+
+    GRAPH_SCOPE = "https://graph.microsoft.com/.default"
+    GRAPH_URL = "https://graph.microsoft.com/v1.0"
+
+    def _token_request_body(self) -> dict[str, str]:
+        return {
+            "grant_type": "client_credentials",
+            "client_id": self.provider.client_id,
+            "client_secret": self.provider.client_secret,
+            "scope": self.GRAPH_SCOPE,
+        }
+
+    async def user_is_active(self, email: str) -> bool:
+        filter_expr = (
+            f"(startswith(mail,'{email}') or "
+            f"startswith(userPrincipalName,'{email}'))"
+        )
+        result = await self._get(
+            f"{self.GRAPH_URL}/users",
+            params={
+                "$filter": filter_expr,
+                "$select": "accountEnabled",
+                "$count": "true",
+                "$top": "1",
+            },
+            headers={"ConsistencyLevel": "eventual"},
+        )
+        users = result.get("value") or []
+        return bool(users) and bool(users[0].get("accountEnabled"))
+
+
+class Auth0Adapter(BaseProviderAdapter):
+    """Auth0, via the Management API."""
+
+    def _token_request_body(self) -> dict[str, str]:
+        default_audience = f"{self.provider.issuer_url}/api/v2/"
+        return {
+            "grant_type": "client_credentials",
+            "client_id": self.provider.client_id,
+            "client_secret": self.provider.client_secret,
+            "audience": default_audience,
+        }
+
+    async def user_is_active(self, email: str) -> bool:
+        result = await self._get(
+            f"{self.provider.issuer_url}/api/v2/users",
+            params={
+                "q": f'email:"{email}"',
+                "search_engine": "v3",
+            },
+        )
+        users = result or []
+        return bool(users) and not users[0].get("blocked", False)

--- a/src/maasservicelayer/auth/oidc_adapters.py
+++ b/src/maasservicelayer/auth/oidc_adapters.py
@@ -3,6 +3,7 @@
 
 from abc import ABC, abstractmethod
 from typing import Any
+from urllib.parse import urlparse
 
 from httpx import AsyncClient
 
@@ -129,3 +130,34 @@ class Auth0Adapter(BaseProviderAdapter):
         )
         users = result or []
         return bool(users) and not users[0].get("blocked", False)
+
+
+class KeycloakAdapter(BaseProviderAdapter):
+    """Keycloak, via the admin REST API."""
+
+    DEFAULT_SCOPE = "profile email"
+
+    def _realm(self) -> str:
+        # issuer_url looks like "{root}/realms/{realm}".
+        path = urlparse(self.provider.issuer_url).path.rstrip("/")
+        return path.rsplit("/", 1)[-1]
+
+    def _root_url(self) -> str:
+        parsed = urlparse(self.provider.issuer_url)
+        return f"{parsed.scheme}://{parsed.netloc}"
+
+    def _token_request_body(self) -> dict[str, str]:
+        return {
+            "grant_type": "client_credentials",
+            "client_id": self.provider.client_id,
+            "client_secret": self.provider.client_secret,
+            "scope": self.DEFAULT_SCOPE,
+        }
+
+    async def user_is_active(self, email: str) -> bool:
+        result = await self._get(
+            f"{self._root_url()}/admin/realms/{self._realm()}/users",
+            params={"email": email, "exact": "true"},
+        )
+        users = result or []
+        return bool(users) and bool(users[0].get("enabled"))

--- a/src/maasservicelayer/auth/oidc_adapters.py
+++ b/src/maasservicelayer/auth/oidc_adapters.py
@@ -97,6 +97,7 @@ class EntraIDAdapter(BaseProviderAdapter):
             f"(startswith(mail,'{email}') or "
             f"startswith(userPrincipalName,'{email}'))"
         )
+        # See https://learn.microsoft.com/en-us/graph/api/user-list?view=graph-rest-1.0&tabs=http
         result = await self._get(
             f"{self.GRAPH_URL}/users",
             params={
@@ -124,6 +125,7 @@ class Auth0Adapter(BaseProviderAdapter):
         }
 
     async def user_is_active(self, email: str) -> bool:
+        # See https://auth0.com/docs/api/management/v2#!/Users/get_users
         result = await self._get(
             f"{self.provider.issuer_url}/api/v2/users",
             params={
@@ -158,6 +160,7 @@ class KeycloakAdapter(BaseProviderAdapter):
         }
 
     async def user_is_active(self, email: str) -> bool:
+        # See https://www.keycloak.org/docs-api/latest/rest-api/index.html#_get_adminrealmsrealmusers
         result = await self._get(
             f"{self._root_url()}/admin/realms/{self._realm()}/users",
             params={"email": email, "exact": "true"},

--- a/src/maasservicelayer/builders/external_auth.py
+++ b/src/maasservicelayer/builders/external_auth.py
@@ -9,6 +9,7 @@ from maasservicelayer.models.base import ResourceBuilder, UNSET, Unset
 from maasservicelayer.models.external_auth import (
     AccessTokenType,
     ProviderMetadata,
+    ProviderVendorType,
 )
 
 
@@ -30,3 +31,4 @@ class OAuthProviderBuilder(ResourceBuilder):
     scopes: str | Unset = Field(default=UNSET)
     token_type: AccessTokenType | Unset = Field(default=UNSET)
     updated: datetime | Unset = Field(default=UNSET)
+    vendor: ProviderVendorType | Unset = Field(default=UNSET)

--- a/src/maasservicelayer/db/alembic/versions/0024_add_provider_vendor_column.py
+++ b/src/maasservicelayer/db/alembic/versions/0024_add_provider_vendor_column.py
@@ -1,0 +1,42 @@
+"""add provider vendor column
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-06-26 12:13:41.571567+00:00
+
+"""
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "0024"
+down_revision: str | None = "0023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Add the column with a temporary server_default so existing providers are
+    # backfilled with the GENERIC vendor (ProviderVendorType.GENERIC = 0)
+    op.add_column(
+        "maasserver_oidc_provider",
+        sa.Column(
+            "vendor",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.alter_column(
+        "maasserver_oidc_provider",
+        "vendor",
+        server_default=None,
+    )
+
+
+def downgrade() -> None:
+    # we don't support migration downgrade
+    pass

--- a/src/maasservicelayer/db/alembic/versions/0024_add_provider_vendor_column.py
+++ b/src/maasservicelayer/db/alembic/versions/0024_add_provider_vendor_column.py
@@ -19,21 +19,13 @@ depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:
-    # Add the column with a temporary server_default so existing providers are
-    # backfilled with the GENERIC vendor
     op.add_column(
         "maasserver_oidc_provider",
         sa.Column(
             "vendor",
             sa.Integer(),
             nullable=False,
-            server_default="0",
         ),
-    )
-    op.alter_column(
-        "maasserver_oidc_provider",
-        "vendor",
-        server_default=None,
     )
 
 

--- a/src/maasservicelayer/db/alembic/versions/0024_add_provider_vendor_column.py
+++ b/src/maasservicelayer/db/alembic/versions/0024_add_provider_vendor_column.py
@@ -20,7 +20,7 @@ depends_on: str | Sequence[str] | None = None
 
 def upgrade() -> None:
     # Add the column with a temporary server_default so existing providers are
-    # backfilled with the GENERIC vendor (ProviderVendorType.GENERIC = 0)
+    # backfilled with the GENERIC vendor
     op.add_column(
         "maasserver_oidc_provider",
         sa.Column(

--- a/src/maasservicelayer/db/tables.py
+++ b/src/maasservicelayer/db/tables.py
@@ -1697,6 +1697,7 @@ OIDCProviderTable = Table(
     "maasserver_oidc_provider",
     METADATA,
     Column("id", BigInteger, Identity(), primary_key=True),
+    Column("vendor", Integer, nullable=False),
     Column("created", DateTime(timezone=True), nullable=False),
     Column("updated", DateTime(timezone=True), nullable=False),
     Column("name", String(255), nullable=False, unique=True),

--- a/src/maasservicelayer/models/external_auth.py
+++ b/src/maasservicelayer/models/external_auth.py
@@ -32,10 +32,18 @@ class AccessTokenType(IntEnum):
     OPAQUE = 1
 
 
+class ProviderVendorType(IntEnum):
+    GENERIC = 0
+    ENTRAID = 1
+    AUTH0 = 2
+    KEYCLOAK = 3
+
+
 @generate_builder()
 class OAuthProvider(MaasTimestampedBaseModel):
     issuer_url: str
     name: str
+    vendor: ProviderVendorType
     client_id: str
     client_secret: str
     redirect_uri: str

--- a/src/maasservicelayer/services/external_auth.py
+++ b/src/maasservicelayer/services/external_auth.py
@@ -41,6 +41,10 @@ from maasservicelayer.auth.macaroons.macaroon_client import (
     RbacAsyncClient,
 )
 from maasservicelayer.auth.macaroons.oven import AsyncOven
+from maasservicelayer.auth.oidc_adapters import (
+    BaseProviderAdapter,
+    get_provider_adapter,
+)
 from maasservicelayer.builders.external_auth import OAuthProviderBuilder
 from maasservicelayer.builders.users import UserBuilder, UserProfileBuilder
 from maasservicelayer.context import Context
@@ -658,6 +662,27 @@ class ExternalOAuthService(
                 ]
             )
         return OAuth2Client(provider)
+
+    async def get_provider_adapter(self) -> BaseProviderAdapter | None:
+        client = await self.get_client()
+        return get_provider_adapter(
+            provider=client.provider,
+            http_client=self.get_httpx_client(),
+        )
+
+    async def is_active_oidc_user(self, email: str) -> bool:
+        provider = await self.get_provider()
+        if provider is None:
+            return False
+        user_profile = await self.users_service.get_user_profile(email)
+        if user_profile is None or user_profile.provider_id != provider.id:
+            return False
+        adapter = get_provider_adapter(
+            provider=provider, http_client=self.get_httpx_client()
+        )
+        if adapter is None:
+            return True
+        return await adapter.user_is_active(email)
 
     @Service.from_cache_or_execute(attr="httpx_client")
     def get_httpx_client(self) -> AsyncClient:

--- a/src/tests/fixtures/factories/external_auth.py
+++ b/src/tests/fixtures/factories/external_auth.py
@@ -8,6 +8,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
     RootKey,
 )
 from maasservicelayer.utils.date import utcnow
@@ -48,6 +49,7 @@ async def create_provider(
         "redirect_uri": "https://example.com/callback",
         "scopes": "openid email profile",
         "token_type": AccessTokenType.JWT,
+        "vendor": ProviderVendorType.GENERIC,
         "enabled": True,
         "metadata": ProviderMetadata(
             authorization_endpoint="",

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_auth.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_auth.py
@@ -978,6 +978,7 @@ class TestAuthApi:
             "metadata": created_provider.metadata.model_dump(),
             "token_type": "JWT",
             "user_count": 5,
+            "vendor": "Generic",
         }
 
     async def test_get_active_oauth_provider_not_found(

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_auth.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_auth.py
@@ -16,6 +16,7 @@ from maasapiserver.common.api.models.responses.errors import ErrorBodyResponse
 from maasapiserver.v3.api.public.models.requests.external_auth import (
     OAuthProviderRequest,
     OAuthTokenTypeChoices,
+    OAuthVendorChoices,
 )
 from maasapiserver.v3.api.public.models.responses.oauth2 import (
     CallbackTargetResponse,
@@ -623,6 +624,7 @@ class TestAuthApi:
             scopes="openid email profile",
             token_type=OAuthTokenTypeChoices.JWT,
             enabled=True,
+            vendor=OAuthVendorChoices.GENERIC,
         )
         updated_provider = OAuthProvider(
             id=1,
@@ -683,6 +685,7 @@ class TestAuthApi:
             scopes="openid email profile",
             enabled=True,
             token_type=OAuthTokenTypeChoices.JWT,
+            vendor=OAuthVendorChoices.GENERIC,
         )
         services_mock.external_oauth.update_provider.return_value = None
         response = await client.put(
@@ -742,6 +745,7 @@ class TestAuthApi:
             scopes="openid email profile",
             enabled=True,
             token_type=OAuthTokenTypeChoices.JWT,
+            vendor=OAuthVendorChoices.GENERIC,
         )
         created_provider = TEST_PROVIDER_1
         services_mock.external_oauth.create.return_value = created_provider
@@ -782,6 +786,7 @@ class TestAuthApi:
             scopes="openid email profile",
             enabled=True,
             token_type=OAuthTokenTypeChoices.JWT,
+            vendor=OAuthVendorChoices.GENERIC,
         )
 
         response = await client.post(
@@ -819,6 +824,7 @@ class TestAuthApi:
             scopes="openid email profile",
             enabled=True,
             token_type=OAuthTokenTypeChoices.JWT,
+            vendor=OAuthVendorChoices.GENERIC,
         )
 
         response = await client.post(
@@ -856,6 +862,7 @@ class TestAuthApi:
             scopes="openid email profile",
             enabled=True,
             token_type=OAuthTokenTypeChoices.JWT,
+            vendor=OAuthVendorChoices.GENERIC,
         )
 
         response = await client.post(

--- a/src/tests/maasapiserver/v3/api/public/handlers/test_auth.py
+++ b/src/tests/maasapiserver/v3/api/public/handlers/test_auth.py
@@ -65,6 +65,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
 )
 from maasservicelayer.models.users import UserProfile
 from maasservicelayer.services import ServiceCollectionV3
@@ -90,6 +91,7 @@ TEST_PROVIDER_1 = OAuthProvider(
     scopes="openid email profile",
     enabled=True,
     token_type=AccessTokenType.JWT,
+    vendor=ProviderVendorType.GENERIC,
     metadata=ProviderMetadata(
         authorization_endpoint="",
         token_endpoint="",
@@ -109,6 +111,7 @@ TEST_PROVIDER_2 = OAuthProvider(
     scopes="openid email profile",
     enabled=True,
     token_type=AccessTokenType.OPAQUE,
+    vendor=ProviderVendorType.GENERIC,
     metadata=ProviderMetadata(
         authorization_endpoint="https://example2.com/authorize",
         token_endpoint="https://example2.com/token",
@@ -633,6 +636,7 @@ class TestAuthApi:
             scopes="openid email profile",
             token_type=AccessTokenType.JWT,
             enabled=True,
+            vendor=ProviderVendorType.GENERIC,
             metadata=ProviderMetadata(
                 authorization_endpoint="",
                 token_endpoint="",
@@ -944,6 +948,7 @@ class TestAuthApi:
             scopes="openid email profile",
             enabled=True,
             token_type=AccessTokenType.JWT,
+            vendor=ProviderVendorType.GENERIC,
             metadata=ProviderMetadata(
                 authorization_endpoint="",
                 token_endpoint="",

--- a/src/tests/maasservicelayer/auth/test_external_oauth.py
+++ b/src/tests/maasservicelayer/auth/test_external_oauth.py
@@ -33,6 +33,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
 )
 from maasservicelayer.utils.date import utcnow
 
@@ -48,6 +49,7 @@ TEST_PROVIDER = OAuthProvider(
     updated=utcnow(),
     enabled=True,
     token_type=AccessTokenType.JWT,
+    vendor=ProviderVendorType.GENERIC,
     metadata=ProviderMetadata(
         authorization_endpoint="https://issuer.com/authorize",
         token_endpoint="https://issuer.com/token",

--- a/src/tests/maasservicelayer/auth/test_oidc_adapters.py
+++ b/src/tests/maasservicelayer/auth/test_oidc_adapters.py
@@ -1,0 +1,120 @@
+#  Copyright 2026 Canonical Ltd.  This software is licensed under the
+#  GNU Affero General Public License version 3 (see the file LICENSE).
+
+from unittest.mock import AsyncMock
+
+from httpx import AsyncClient, Request, Response
+
+from maasservicelayer.auth.oidc_adapters import Auth0Adapter, EntraIDAdapter
+from maasservicelayer.models.external_auth import (
+    AccessTokenType,
+    OAuthProvider,
+    ProviderMetadata,
+)
+
+TOKEN_RESPONSE = {"access_token": "m2m-token", "expires_in": 3600}
+
+_REQUEST = Request("GET", "https://provider.example")
+
+
+def _provider(issuer_url: str) -> OAuthProvider:
+    return OAuthProvider(
+        id=1,
+        issuer_url=issuer_url,
+        name="provider",
+        client_id="client123",
+        client_secret="secret456",
+        redirect_uri="https://maas.example/callback",
+        token_type=AccessTokenType.JWT,
+        scopes="openid email",
+        enabled=True,
+        metadata=ProviderMetadata(
+            authorization_endpoint=f"{issuer_url}/authorize",
+            token_endpoint=f"{issuer_url}/token",
+            jwks_uri=f"{issuer_url}/jwks",
+        ),
+    )
+
+
+def _http_client(get_response: Response) -> AsyncClient:
+    client = AsyncMock(spec=AsyncClient)
+    client.post.return_value = Response(
+        200, json=TOKEN_RESPONSE, request=_REQUEST
+    )
+    get_response.request = _REQUEST
+    client.get.return_value = get_response
+    return client
+
+
+class TestEntraIDAdapter:
+    def _adapter(self, get_response: Response) -> EntraIDAdapter:
+        provider = _provider("https://login.microsoftonline.com/tenant")
+        return EntraIDAdapter(provider, _http_client(get_response))
+
+    async def test_token_request_uses_graph_scope(self):
+        adapter = self._adapter(Response(200, json={"value": []}))
+
+        await adapter.get_token()
+
+        _, kwargs = adapter._http.post.call_args
+        assert kwargs["data"] == {
+            "grant_type": "client_credentials",
+            "client_id": "client123",
+            "client_secret": "secret456",
+            "scope": EntraIDAdapter.GRAPH_SCOPE,
+        }
+
+    async def test_user_is_active_true_when_account_enabled(self):
+        adapter = self._adapter(
+            Response(200, json={"value": [{"accountEnabled": True}]})
+        )
+
+        assert await adapter.user_is_active("user@example.com") is True
+
+    async def test_user_is_active_false_when_account_disabled(self):
+        adapter = self._adapter(
+            Response(200, json={"value": [{"accountEnabled": False}]})
+        )
+
+        assert await adapter.user_is_active("user@example.com") is False
+
+    async def test_user_is_active_false_when_not_found(self):
+        adapter = self._adapter(Response(200, json={"value": []}))
+
+        assert await adapter.user_is_active("user@example.com") is False
+
+
+class TestAuth0Adapter:
+    def _adapter(self, get_response: Response) -> Auth0Adapter:
+        provider = _provider("https://dev-tenant.us.auth0.com")
+        return Auth0Adapter(provider, _http_client(get_response))
+
+    async def test_token_request_uses_management_audience(self):
+        adapter = self._adapter(Response(200, json=[]))
+
+        await adapter.get_token()
+
+        _, kwargs = adapter._http.post.call_args
+        assert kwargs["data"] == {
+            "grant_type": "client_credentials",
+            "client_id": "client123",
+            "client_secret": "secret456",
+            "audience": "https://dev-tenant.us.auth0.com/api/v2/",
+        }
+
+    async def test_user_is_active_true_when_not_blocked(self):
+        adapter = self._adapter(
+            Response(200, json=[{"email": "user@example.com"}])
+        )
+
+        assert await adapter.user_is_active("user@example.com") is True
+
+    async def test_user_is_active_false_when_blocked(self):
+        adapter = self._adapter(Response(200, json=[{"blocked": True}]))
+
+        assert await adapter.user_is_active("user@example.com") is False
+
+    async def test_user_is_active_false_when_not_found(self):
+        adapter = self._adapter(Response(200, json=[]))
+
+        assert await adapter.user_is_active("user@example.com") is False

--- a/src/tests/maasservicelayer/auth/test_oidc_adapters.py
+++ b/src/tests/maasservicelayer/auth/test_oidc_adapters.py
@@ -14,6 +14,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
 )
 
 TOKEN_RESPONSE = {"access_token": "m2m-token", "expires_in": 3600}
@@ -32,6 +33,7 @@ def _provider(issuer_url: str) -> OAuthProvider:
         token_type=AccessTokenType.JWT,
         scopes="openid email",
         enabled=True,
+        vendor=ProviderVendorType.GENERIC,
         metadata=ProviderMetadata(
             authorization_endpoint=f"{issuer_url}/authorize",
             token_endpoint=f"{issuer_url}/token",

--- a/src/tests/maasservicelayer/auth/test_oidc_adapters.py
+++ b/src/tests/maasservicelayer/auth/test_oidc_adapters.py
@@ -5,7 +5,11 @@ from unittest.mock import AsyncMock
 
 from httpx import AsyncClient, Request, Response
 
-from maasservicelayer.auth.oidc_adapters import Auth0Adapter, EntraIDAdapter
+from maasservicelayer.auth.oidc_adapters import (
+    Auth0Adapter,
+    EntraIDAdapter,
+    KeycloakAdapter,
+)
 from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
@@ -111,6 +115,50 @@ class TestAuth0Adapter:
 
     async def test_user_is_active_false_when_blocked(self):
         adapter = self._adapter(Response(200, json=[{"blocked": True}]))
+
+        assert await adapter.user_is_active("user@example.com") is False
+
+    async def test_user_is_active_false_when_not_found(self):
+        adapter = self._adapter(Response(200, json=[]))
+
+        assert await adapter.user_is_active("user@example.com") is False
+
+
+class TestKeycloakAdapter:
+    def _adapter(self, get_response: Response) -> KeycloakAdapter:
+        provider = _provider("http://keycloak.example:8080/realms/master")
+        return KeycloakAdapter(provider, _http_client(get_response))
+
+    async def test_token_request_uses_default_scope(self):
+        adapter = self._adapter(Response(200, json=[]))
+
+        await adapter.get_token()
+
+        _, kwargs = adapter._http.post.call_args
+        assert kwargs["data"] == {
+            "grant_type": "client_credentials",
+            "client_id": "client123",
+            "client_secret": "secret456",
+            "scope": KeycloakAdapter.DEFAULT_SCOPE,
+        }
+
+    async def test_user_is_active_queries_realm_admin_endpoint(self):
+        adapter = self._adapter(Response(200, json=[{"enabled": True}]))
+
+        await adapter.user_is_active("user@example.com")
+
+        args, _ = adapter._http.get.call_args
+        assert args[0] == (
+            "http://keycloak.example:8080/admin/realms/master/users"
+        )
+
+    async def test_user_is_active_true_when_enabled(self):
+        adapter = self._adapter(Response(200, json=[{"enabled": True}]))
+
+        assert await adapter.user_is_active("user@example.com") is True
+
+    async def test_user_is_active_false_when_disabled(self):
+        adapter = self._adapter(Response(200, json=[{"enabled": False}]))
 
         assert await adapter.user_is_active("user@example.com") is False
 

--- a/src/tests/maasservicelayer/auth/test_oidc_adapters.py
+++ b/src/tests/maasservicelayer/auth/test_oidc_adapters.py
@@ -4,11 +4,16 @@
 from unittest.mock import AsyncMock
 
 from httpx import AsyncClient, Request, Response
+import pytest
 
 from maasservicelayer.auth.oidc_adapters import (
     Auth0Adapter,
     EntraIDAdapter,
     KeycloakAdapter,
+)
+from maasservicelayer.exceptions.catalog import BadGatewayException
+from maasservicelayer.exceptions.constants import (
+    PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE,
 )
 from maasservicelayer.models.external_auth import (
     AccessTokenType,
@@ -168,3 +173,57 @@ class TestKeycloakAdapter:
         adapter = self._adapter(Response(200, json=[]))
 
         assert await adapter.user_is_active("user@example.com") is False
+
+
+class BaseAdapterErrorHandling:
+    def _adapter(self, http_client: AsyncClient) -> EntraIDAdapter:
+        provider = _provider("https://login.microsoftonline.com/tenant")
+        return EntraIDAdapter(provider, http_client)
+
+    async def test_get_token_raises_when_access_token_missing(self):
+        client = AsyncMock(spec=AsyncClient)
+        client.post.return_value = Response(
+            200, json={"expires_in": 3600}, request=_REQUEST
+        )
+        adapter = self._adapter(client)
+
+        with pytest.raises(BadGatewayException) as exc_info:
+            await adapter.get_token()
+
+        assert (
+            exc_info.value.details[0].type
+            == PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE
+        )
+
+    async def test_token_request_raises_on_http_status_error(self):
+        client = AsyncMock(spec=AsyncClient)
+        client.post.return_value = Response(
+            401, json={"error": "invalid_client"}, request=_REQUEST
+        )
+        adapter = self._adapter(client)
+
+        with pytest.raises(BadGatewayException) as exc_info:
+            await adapter.get_token()
+
+        assert (
+            exc_info.value.details[0].type
+            == PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE
+        )
+
+    async def test_get_raises_on_http_status_error(self):
+        client = AsyncMock(spec=AsyncClient)
+        client.post.return_value = Response(
+            200, json=TOKEN_RESPONSE, request=_REQUEST
+        )
+        client.get.return_value = Response(
+            403, json={"error": "forbidden"}, request=_REQUEST
+        )
+        adapter = self._adapter(client)
+
+        with pytest.raises(BadGatewayException) as exc_info:
+            await adapter.user_is_active("user@example.com")
+
+        assert (
+            exc_info.value.details[0].type
+            == PROVIDER_COMMUNICATION_FAILED_VIOLATION_TYPE
+        )

--- a/src/tests/maasservicelayer/auth/test_oidc_jwt.py
+++ b/src/tests/maasservicelayer/auth/test_oidc_jwt.py
@@ -23,6 +23,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
 )
 from maasservicelayer.utils.date import utcnow
 
@@ -38,6 +39,7 @@ TEST_PROVIDER = OAuthProvider(
     updated=utcnow(),
     enabled=True,
     token_type=AccessTokenType.JWT,
+    vendor=ProviderVendorType.GENERIC,
     metadata=ProviderMetadata(
         authorization_endpoint="https://issuer.com/authorize",
         token_endpoint="https://issuer.com/token",

--- a/src/tests/maasservicelayer/db/repositories/test_external_auth.py
+++ b/src/tests/maasservicelayer/db/repositories/test_external_auth.py
@@ -18,6 +18,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
 )
 from maasservicelayer.utils.date import utcnow
 from tests.fixtures.factories.external_auth import (
@@ -204,6 +205,7 @@ class TestExternalOAuthRepository(RepositoryCommonTests[OAuthProvider]):
             redirect_uri="https://myapp.com/oauth/callback",
             scopes="openid profile email",
             token_type=AccessTokenType.JWT,
+            vendor=ProviderVendorType.GENERIC,
             metadata=ProviderMetadata(
                 authorization_endpoint="",
                 token_endpoint="",

--- a/src/tests/maasservicelayer/services/test_external_auth.py
+++ b/src/tests/maasservicelayer/services/test_external_auth.py
@@ -66,6 +66,7 @@ from maasservicelayer.models.external_auth import (
     AccessTokenType,
     OAuthProvider,
     ProviderMetadata,
+    ProviderVendorType,
     RootKey,
 )
 from maasservicelayer.models.secrets import RootKeyMaterialSecret
@@ -870,6 +871,7 @@ class TestExternalOAuthService(ServiceCommonTests):
             created=utcnow(),
             updated=utcnow(),
             token_type=AccessTokenType.JWT,
+            vendor=ProviderVendorType.GENERIC,
             metadata=ProviderMetadata(
                 authorization_endpoint="https://example.com/auth",
                 token_endpoint="https://example.com/token",
@@ -1307,6 +1309,49 @@ class TestExternalOAuthService(ServiceCommonTests):
         client1 = service_instance.get_httpx_client()
         client2 = service_instance.get_httpx_client()
         assert client1 is client2
+
+    async def test_is_active_oidc_user_no_provider(
+        self,
+        service_instance: ExternalOAuthService,
+    ) -> None:
+        service_instance.get_provider = AsyncMock(return_value=None)
+
+        assert (
+            await service_instance.is_active_oidc_user("user@example.com")
+            is False
+        )
+
+    @patch("maasservicelayer.services.external_auth.get_provider_adapter")
+    async def test_is_active_oidc_user_queries_adapter(
+        self,
+        mock_get_provider_adapter: Mock,
+        service_instance: ExternalOAuthService,
+        test_instance: OAuthProvider,
+    ) -> None:
+        test_instance.vendor = ProviderVendorType.ENTRAID
+        service_instance.get_provider = AsyncMock(return_value=test_instance)
+        service_instance.users_service.get_user_profile = AsyncMock(
+            return_value=UserProfile(
+                id=1,
+                completed_intro=True,
+                is_local=False,
+                user_id=1,
+                provider_id=test_instance.id,
+            )
+        )
+        httpx_client = Mock()
+        service_instance.get_httpx_client = Mock(return_value=httpx_client)
+        adapter = Mock()
+        adapter.user_is_active = AsyncMock(return_value=False)
+        mock_get_provider_adapter.return_value = adapter
+
+        result = await service_instance.is_active_oidc_user("user@example.com")
+
+        assert result is False
+        mock_get_provider_adapter.assert_called_once_with(
+            provider=test_instance, http_client=httpx_client
+        )
+        adapter.user_is_active.assert_awaited_once_with("user@example.com")
 
     @patch("maasservicelayer.services.external_auth.logger")
     async def test_get_callback_user_exists(


### PR DESCRIPTION
This PR introduces the [client credentials flow](https://auth0.com/docs/authenticate/login/oidc-conformant-authentication/oidc-adoption-client-credentials-flow) in order to solve the problem of OIDC users unable to sign in via the CLI. The approach is the following:
1. An OIDC user tries to sign in via the CLI/APIv2
2. v2 forwards the request to the service layer in v3
3. If the user is indeed an OIDC user, we get the corresponding adapter for the enabled provider
4. MAAS makes a machine-to-machine request to the provider for an access token
5. MAAS queries the provider's `/users` endpoint using the access token to check if the user actually exists and is enabled on the provider side
6. If a generic provider is enabled (i.e. not one of EntraID, Auth0 or Keycloak), it is the admin's responsibility to ensure the user exists and is enabled. MAAS will not perform this check in this case.

To verify this, a QA with Auth0 as a provider might be helpful:
1. See steps for setting up Auth0 and adding it to MAAS [here](https://pastebin.canonical.com/p/3p3P4Y9Q3P/)
2. Ensure you have pulled this branch and have done `make snap-tree-sync && snap restart maas`
3. First, sign in via the UI as an OIDC user. This will ensure a new user is created in the DB. If you've already done this step before and have an existing OIDC user, you can go to step 4.
4. Generate an API key for the OIDC user.
5. Sign in via the CLI as the OIDC user:
```sh
maas login -k \
  '<YOUR_EMAIL>' \
  https://localhost:5443/MAAS \
  '<API_KEY>'
```
6. Ensure you are signed in and can use the CLI normally

## Notes
- [This](https://docs.google.com/document/d/1AVFwdXHIJDsFLr7A8BXOB0UzVh_yUrfn_00LEsAExg8/edit?usp=sharing) document containing notes on provider API formats could be useful