### PR TITLE
feat: reconcile operations when Temporal workflow has terminated

### DIFF
--- a/src/maasservicelayer/db/repositories/operations.py
+++ b/src/maasservicelayer/db/repositories/operations.py
@@ -28,6 +28,10 @@ class OperationsClauseFactory(ClauseFactory):
         return Clause(condition=eq(OperationTable.c.status, status))
 
     @classmethod
+    def with_statuses(cls, statuses: Iterable[OperationStatus]) -> Clause:
+        return Clause(condition=OperationTable.c.status.in_(statuses))
+
+    @classmethod
     def with_op_type(cls, op_type: OperationType) -> Clause:
         return Clause(condition=eq(OperationTable.c.op_type, op_type))
 

--- a/src/maasservicelayer/services/operations.py
+++ b/src/maasservicelayer/services/operations.py
@@ -140,6 +140,16 @@ class OperationsService(
             )
         )
 
+    async def list_in_progress_operations(self) -> list[Operation]:
+        """Return operations that are RUNNING or CANCELLING."""
+        return await self.repository.get_many(
+            query=QuerySpec(
+                where=OperationsClauseFactory.with_statuses(
+                    [OperationStatus.RUNNING, OperationStatus.CANCELLING]
+                )
+            )
+        )
+
     async def update_status(
         self,
         operation_uuid: str,
@@ -153,6 +163,7 @@ class OperationsService(
         elif status in (
             OperationStatus.COMPLETED,
             OperationStatus.FAILED,
+            OperationStatus.CANCELLED,
         ):
             builder.finished = utcnow()
         # On success the operation is no longer running any task; on failure we

--- a/src/maastemporalworker/temporal_script.py
+++ b/src/maastemporalworker/temporal_script.py
@@ -304,8 +304,8 @@ async def main() -> None:
                 operation_activity.update_operation_status,
                 operation_activity.update_current_task,
                 # Operation reconciliation activities
-                operation_activity.get_stuck_operations,
-                operation_activity.start_operation_workflow,
+                operation_activity.reconcile_stuck_accepted_operations,
+                operation_activity.reconcile_in_progress_operations,
             ],
         ),
         # Individual region controller worker

--- a/src/maastemporalworker/workflow/operation.py
+++ b/src/maastemporalworker/workflow/operation.py
@@ -142,32 +142,32 @@ class OperationActivity(ActivityBase):
             operations = (
                 await services.operations.list_in_progress_operations()
             )
-        for operation in operations:
-            handle = self.temporal_client.get_workflow_handle(operation.uuid)
-            try:
-                description = await handle.describe()
-            except RPCError as e:
-                if e.status == RPCStatusCode.NOT_FOUND:
-                    if operation.status == OperationStatus.CANCELLING:
-                        status = OperationStatus.CANCELLED
-                        error = None
-                    else:
-                        status = OperationStatus.FAILED
-                        error = "Workflow execution not found in Temporal."
-                    async with self.start_transaction() as services:
+            for operation in operations:
+                handle = self.temporal_client.get_workflow_handle(
+                    operation.uuid
+                )
+                try:
+                    description = await handle.describe()
+                except RPCError as e:
+                    if e.status == RPCStatusCode.NOT_FOUND:
+                        if operation.status == OperationStatus.CANCELLING:
+                            status = OperationStatus.CANCELLED
+                            error = None
+                        else:
+                            status = OperationStatus.FAILED
+                            error = "Workflow execution not found in Temporal."
                         await services.operations.update_status(
                             operation_uuid=operation.uuid,
                             status=status,
                             error=error,
                         )
+                        continue
+                    raise
+                status = TEMPORAL_STATUS_TO_OPERATION_STATUS.get(
+                    description.status  # pyright: ignore[reportArgumentType]
+                )
+                if status is None:
                     continue
-                raise
-            status = TEMPORAL_STATUS_TO_OPERATION_STATUS.get(
-                description.status
-            )
-            if status is None:
-                continue
-            async with self.start_transaction() as services:
                 await services.operations.update_status(
                     operation_uuid=operation.uuid,
                     status=status,

--- a/src/maastemporalworker/workflow/operation.py
+++ b/src/maastemporalworker/workflow/operation.py
@@ -148,14 +148,23 @@ class OperationActivity(ActivityBase):
                 description = await handle.describe()
             except RPCError as e:
                 if e.status == RPCStatusCode.NOT_FOUND:
+                    if operation.status == OperationStatus.CANCELLING:
+                        status = OperationStatus.CANCELLED
+                        error = None
+                    else:
+                        status = OperationStatus.FAILED
+                        error = "Workflow execution not found in Temporal."
+                    async with self.start_transaction() as services:
+                        await services.operations.update_status(
+                            operation_uuid=operation.uuid,
+                            status=status,
+                            error=error,
+                        )
                     continue
                 raise
-            temporal_status = description.status
-            if temporal_status is None:
-                raise ValueError(
-                    f"Workflow {operation.uuid} has no execution status."
-                )
-            status = TEMPORAL_STATUS_TO_OPERATION_STATUS.get(temporal_status)
+            status = TEMPORAL_STATUS_TO_OPERATION_STATUS.get(
+                description.status
+            )
             if status is None:
                 continue
             async with self.start_transaction() as services:

--- a/src/maastemporalworker/workflow/operation.py
+++ b/src/maastemporalworker/workflow/operation.py
@@ -7,6 +7,7 @@ from functools import wraps
 
 import structlog
 from temporalio import workflow
+from temporalio.client import WorkflowExecutionStatus
 from temporalio.common import (
     SearchAttributeKey,
     SearchAttributePair,
@@ -18,8 +19,9 @@ from temporalio.exceptions import (
     is_cancelled_exception,
     WorkflowAlreadyStartedError,
 )
+from temporalio.service import RPCError, RPCStatusCode
 
-from maascommon.enums.operations import OperationStatus, OperationType
+from maascommon.enums.operations import OperationStatus
 from maascommon.workflows.operation import (
     RECONCILE_OPERATIONS_WORKFLOW_NAME,
     workflow_name_for_operation_type,
@@ -36,22 +38,26 @@ logger = structlog.getLogger()
 
 UPDATE_OPERATION_STATUS_TIMEOUT = timedelta(seconds=30)
 UPDATE_CURRENT_TASK_TIMEOUT = timedelta(seconds=30)
-GET_STUCK_OPERATIONS_TIMEOUT = timedelta(seconds=30)
-START_OPERATION_WORKFLOW_TIMEOUT = timedelta(seconds=30)
+RECONCILE_STUCK_ACCEPTED_TIMEOUT = timedelta(seconds=60)
+RECONCILE_IN_PROGRESS_TIMEOUT = timedelta(seconds=60)
 
-# Operations that have been ACCEPTED for longer than 5 minutes are considered stuck
-# and are reconciled.
 STUCK_OPERATION_GRACE_PERIOD = timedelta(minutes=5)
 
-# Activities names
 UPDATE_OPERATION_STATUS_ACTIVITY_NAME = "update-operation-status"
 UPDATE_CURRENT_TASK_ACTIVITY_NAME = "update-current-task"
-GET_STUCK_OPERATIONS_ACTIVITY_NAME = "get-stuck-operations"
-START_OPERATION_WORKFLOW_ACTIVITY_NAME = "start-operation-workflow"
+RECONCILE_STUCK_ACCEPTED_ACTIVITY_NAME = "reconcile-stuck-accepted-operations"
+RECONCILE_IN_PROGRESS_ACTIVITY_NAME = "reconcile-in-progress-operations"
 
 OPERATION_UUID_SEARCH_ATTRIBUTE = SearchAttributeKey.for_keyword(
     "OperationUUID"
 )
+
+TEMPORAL_STATUS_TO_OPERATION_STATUS = {
+    WorkflowExecutionStatus.COMPLETED: OperationStatus.COMPLETED,
+    WorkflowExecutionStatus.FAILED: OperationStatus.FAILED,
+    WorkflowExecutionStatus.CANCELED: OperationStatus.CANCELLED,
+    WorkflowExecutionStatus.TERMINATED: OperationStatus.CANCELLED,
+}
 
 
 # Activities parameters
@@ -68,13 +74,6 @@ class UpdateCurrentTaskParam:
     operation_uuid: str
     name: str
     task_number: int
-
-
-@dataclass
-class StuckOperation:
-    uuid: str
-    op_type: OperationType
-    parameters: dict | None = None
 
 
 class OperationActivity(ActivityBase):
@@ -99,8 +98,8 @@ class OperationActivity(ActivityBase):
                 task_number=param.task_number,
             )
 
-    @activity_defn_with_context(name=GET_STUCK_OPERATIONS_ACTIVITY_NAME)
-    async def get_stuck_operations(self) -> list[StuckOperation]:
+    @activity_defn_with_context(name=RECONCILE_STUCK_ACCEPTED_ACTIVITY_NAME)
+    async def reconcile_stuck_accepted_operations(self) -> None:
         cutoff = utcnow() - STUCK_OPERATION_GRACE_PERIOD
         async with self.start_transaction() as services:
             operations = (
@@ -108,45 +107,62 @@ class OperationActivity(ActivityBase):
                     created_before=cutoff
                 )
             )
-        return [
-            StuckOperation(
-                uuid=operation.uuid,
-                op_type=operation.op_type,
-                parameters=operation.parameters,
-            )
-            for operation in operations
-        ]
+        for operation in operations:
+            workflow_name = workflow_name_for_operation_type(operation.op_type)
+            if workflow_name is None:
+                raise ApplicationError(
+                    f"No workflow is mapped to operation type "
+                    f"'{operation.op_type}'.",
+                    non_retryable=True,
+                )
+            try:
+                await self.temporal_client.start_workflow(
+                    workflow_name,
+                    operation.parameters,
+                    id=operation.uuid,
+                    task_queue=REGION_TASK_QUEUE,
+                    id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
+                    search_attributes=TypedSearchAttributes(
+                        [
+                            SearchAttributePair(
+                                OPERATION_UUID_SEARCH_ATTRIBUTE, operation.uuid
+                            )
+                        ]
+                    ),
+                )
+            except WorkflowAlreadyStartedError:
+                logger.debug(
+                    "Operation workflow already exists; skipping reconciliation",
+                    operation_uuid=operation.uuid,
+                )
 
-    @activity_defn_with_context(name=START_OPERATION_WORKFLOW_ACTIVITY_NAME)
-    async def start_operation_workflow(self, param: StuckOperation) -> None:
-        workflow_name = workflow_name_for_operation_type(param.op_type)
-        if workflow_name is None:
-            logger.warning(
-                "Cannot reconcile operation with no mapped workflow",
-                operation_uuid=param.uuid,
-                op_type=param.op_type,
+    @activity_defn_with_context(name=RECONCILE_IN_PROGRESS_ACTIVITY_NAME)
+    async def reconcile_in_progress_operations(self) -> None:
+        async with self.start_transaction() as services:
+            operations = (
+                await services.operations.list_in_progress_operations()
             )
-            return
-        try:
-            await self.temporal_client.start_workflow(
-                workflow_name,
-                param.parameters,
-                id=param.uuid,
-                task_queue=REGION_TASK_QUEUE,
-                id_reuse_policy=WorkflowIDReusePolicy.REJECT_DUPLICATE,
-                search_attributes=TypedSearchAttributes(
-                    [
-                        SearchAttributePair(
-                            OPERATION_UUID_SEARCH_ATTRIBUTE, param.uuid
-                        )
-                    ]
-                ),
-            )
-        except WorkflowAlreadyStartedError:
-            logger.debug(
-                "Operation workflow already exists; skipping reconciliation",
-                operation_uuid=param.uuid,
-            )
+        for operation in operations:
+            handle = self.temporal_client.get_workflow_handle(operation.uuid)
+            try:
+                description = await handle.describe()
+            except RPCError as e:
+                if e.status == RPCStatusCode.NOT_FOUND:
+                    continue
+                raise
+            temporal_status = description.status
+            if temporal_status is None:
+                raise ValueError(
+                    f"Workflow {operation.uuid} has no execution status."
+                )
+            status = TEMPORAL_STATUS_TO_OPERATION_STATUS.get(temporal_status)
+            if status is None:
+                continue
+            async with self.start_transaction() as services:
+                await services.operations.update_status(
+                    operation_uuid=operation.uuid,
+                    status=status,
+                )
 
 
 def _get_operation_uuid() -> str:
@@ -251,20 +267,15 @@ def workflow_run_with_tracked_operation(func):
 
 @workflow.defn(name=RECONCILE_OPERATIONS_WORKFLOW_NAME, sandboxed=False)
 class ReconcileOperationsWorkflow:
-    """Restart the workflow of operations stuck in ACCEPTED."""
+    """Reconcile operations whose state has drifted from Temporal."""
 
     @workflow_run_with_context
-    async def run(self) -> int:
-        stuck_operations: list[
-            StuckOperation
-        ] = await workflow.execute_activity(
-            GET_STUCK_OPERATIONS_ACTIVITY_NAME,
-            start_to_close_timeout=GET_STUCK_OPERATIONS_TIMEOUT,
+    async def run(self) -> None:
+        await workflow.execute_activity(
+            RECONCILE_STUCK_ACCEPTED_ACTIVITY_NAME,
+            start_to_close_timeout=RECONCILE_STUCK_ACCEPTED_TIMEOUT,
         )
-        for operation in stuck_operations:
-            await workflow.execute_activity(
-                START_OPERATION_WORKFLOW_ACTIVITY_NAME,
-                operation,
-                start_to_close_timeout=START_OPERATION_WORKFLOW_TIMEOUT,
-            )
-        return len(stuck_operations)
+        await workflow.execute_activity(
+            RECONCILE_IN_PROGRESS_ACTIVITY_NAME,
+            start_to_close_timeout=RECONCILE_IN_PROGRESS_TIMEOUT,
+        )

--- a/src/tests/maasservicelayer/services/test_operations.py
+++ b/src/tests/maasservicelayer/services/test_operations.py
@@ -382,6 +382,21 @@ class TestOperationsService:
             )
         )
 
+    async def test_list_in_progress_operations(self) -> None:
+        repository = Mock(OperationsRepository)
+        repository.get_many.return_value = [TEST_OPERATION]
+        service = self._service(repository)
+
+        operations = await service.list_in_progress_operations()
+
+        assert operations == [TEST_OPERATION]
+        query = repository.get_many.call_args.kwargs["query"]
+        assert query == QuerySpec(
+            where=OperationsClauseFactory.with_statuses(
+                [OperationStatus.RUNNING, OperationStatus.CANCELLING]
+            )
+        )
+
     async def test_update_status_running_sets_started(self) -> None:
         repository = Mock(OperationsRepository)
         repository.get_one.return_value = TEST_OPERATION
@@ -446,6 +461,22 @@ class TestOperationsService:
         # On failure current_task is left untouched so the user can see where
         # the operation stopped.
         assert "current_task" not in populated
+
+    async def test_update_status_cancelled_sets_finished(self) -> None:
+        repository = Mock(OperationsRepository)
+        repository.get_one.return_value = TEST_OPERATION
+        repository.update_by_id.return_value = TEST_OPERATION.model_copy(
+            update={"status": OperationStatus.CANCELLED}
+        )
+        service = self._service(repository)
+
+        await service.update_status("op-uuid", OperationStatus.CANCELLED)
+
+        builder = repository.update_by_id.call_args.kwargs["builder"]
+        populated = builder.populated_fields()
+        assert populated["status"] == OperationStatus.CANCELLED
+        assert "finished" in populated
+        assert "started" not in populated
 
     async def test_set_current_task(self) -> None:
         repository = Mock(OperationsRepository)

--- a/src/tests/maastemporalworker/workflow/test_operation.py
+++ b/src/tests/maastemporalworker/workflow/test_operation.py
@@ -465,9 +465,7 @@ class TestReconcileOperationsActivities:
         services_mock.temporal = Mock(TemporalService)
         services_mock.operations = Mock(OperationsService)
         services_mock.operations.list_in_progress_operations = AsyncMock(
-            return_value=[
-                _make_operation("op-uuid", status=operation_status)
-            ]
+            return_value=[_make_operation("op-uuid", status=operation_status)]
         )
         services_mock.operations.update_status = AsyncMock()
         services_mock.produce.return_value = services_mock

--- a/src/tests/maastemporalworker/workflow/test_operation.py
+++ b/src/tests/maastemporalworker/workflow/test_operation.py
@@ -5,13 +5,14 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
-from temporalio.client import Client
+from temporalio.client import Client, WorkflowExecutionStatus
 from temporalio.common import WorkflowIDReusePolicy
 from temporalio.exceptions import (
     ApplicationError,
     CancelledError,
     WorkflowAlreadyStartedError,
 )
+from temporalio.service import RPCError, RPCStatusCode
 
 from maascommon.enums.operations import OperationStatus, OperationType
 from maasservicelayer.db import Database
@@ -24,11 +25,10 @@ from maastemporalworker.worker import REGION_TASK_QUEUE
 import maastemporalworker.workflow.activity as activity_module
 import maastemporalworker.workflow.operation as operation_module
 from maastemporalworker.workflow.operation import (
-    GET_STUCK_OPERATIONS_ACTIVITY_NAME,
     OperationActivity,
+    RECONCILE_IN_PROGRESS_ACTIVITY_NAME,
+    RECONCILE_STUCK_ACCEPTED_ACTIVITY_NAME,
     ReconcileOperationsWorkflow,
-    START_OPERATION_WORKFLOW_ACTIVITY_NAME,
-    StuckOperation,
     track_operation_status,
     update_current_task,
     UpdateCurrentTaskParam,
@@ -295,12 +295,17 @@ class TestUpdateCurrentTask:
         local_activity_mock.assert_not_called()
 
 
-def _make_operation(uuid: str, parameters: dict | None = None) -> Operation:
+def _make_operation(
+    uuid: str,
+    op_type: OperationType = OperationType.MACHINE_COMMISSION,
+    status: OperationStatus = OperationStatus.ACCEPTED,
+    parameters: dict | None = None,
+) -> Operation:
     return Operation(
         id=1,
         uuid=uuid,
-        op_type=OperationType.MACHINE_COMMISSION,
-        status=OperationStatus.ACCEPTED,
+        op_type=op_type,
+        status=status,
         is_bulk=False,
         parameters=parameters,
     )
@@ -316,13 +321,15 @@ class TestReconcileOperationsActivities:
             temporal_client=temporal_client,
         )
 
-    async def test_get_stuck_operations(
+    async def test_reconcile_stuck_accepted_starts_mapped(
         self, services_mock: ServiceCollectionV3, monkeypatch
     ) -> None:
         services_mock.temporal = Mock(TemporalService)
         services_mock.operations = Mock(OperationsService)
         services_mock.operations.list_stuck_accepted_operations = AsyncMock(
-            return_value=[_make_operation("op-uuid", {"system_id": "abc"})]
+            return_value=[
+                _make_operation("op-uuid", parameters={"system_id": "abc"})
+            ]
         )
         services_mock.produce.return_value = services_mock
         monkeypatch.setattr(
@@ -330,27 +337,7 @@ class TestReconcileOperationsActivities:
         )
 
         activity = self._operation_activity(Mock(Client))
-        result = await activity.get_stuck_operations()
-
-        assert result == [
-            StuckOperation(
-                uuid="op-uuid",
-                op_type=OperationType.MACHINE_COMMISSION,
-                parameters={"system_id": "abc"},
-            )
-        ]
-        services_mock.operations.list_stuck_accepted_operations.assert_awaited_once()
-
-    async def test_start_operation_workflow_starts_mapped(self) -> None:
-        activity = self._operation_activity(Mock(Client))
-
-        await activity.start_operation_workflow(
-            StuckOperation(
-                uuid="op-uuid",
-                op_type=OperationType.MACHINE_COMMISSION,
-                parameters={"system_id": "abc"},
-            )
-        )
+        await activity.reconcile_stuck_accepted_operations()
 
         activity.temporal_client.start_workflow.assert_awaited_once()
         call = activity.temporal_client.start_workflow.call_args
@@ -363,66 +350,140 @@ class TestReconcileOperationsActivities:
             == WorkflowIDReusePolicy.REJECT_DUPLICATE
         )
 
-    async def test_start_operation_workflow_skips_unmapped(self) -> None:
-        activity = self._operation_activity(Mock(Client))
-
-        await activity.start_operation_workflow(
-            StuckOperation(
-                uuid="op-uuid",
-                op_type=OperationType.SELECTION_SYNC,
-            )
+    async def test_reconcile_stuck_accepted_swallows_already_started(
+        self, services_mock: ServiceCollectionV3, monkeypatch
+    ) -> None:
+        services_mock.temporal = Mock(TemporalService)
+        services_mock.operations = Mock(OperationsService)
+        services_mock.operations.list_stuck_accepted_operations = AsyncMock(
+            return_value=[
+                _make_operation("op-uuid", parameters={"system_id": "abc"})
+            ]
+        )
+        services_mock.produce.return_value = services_mock
+        monkeypatch.setattr(
+            activity_module, "ServiceCollectionV3", services_mock
         )
 
-        activity.temporal_client.start_workflow.assert_not_awaited()
-
-    async def test_start_operation_workflow_swallows_already_started(
-        self,
-    ) -> None:
         temporal_client = Mock(Client)
         temporal_client.start_workflow = AsyncMock(
             side_effect=WorkflowAlreadyStartedError("op-uuid", "commission")
         )
         activity = self._operation_activity(temporal_client)
+        await activity.reconcile_stuck_accepted_operations()
 
-        await activity.start_operation_workflow(
-            StuckOperation(
-                uuid="op-uuid",
-                op_type=OperationType.MACHINE_COMMISSION,
-                parameters={"system_id": "abc"},
-            )
+    @pytest.mark.parametrize(
+        "temporal_status, expected_status",
+        [
+            (WorkflowExecutionStatus.COMPLETED, OperationStatus.COMPLETED),
+            (WorkflowExecutionStatus.FAILED, OperationStatus.FAILED),
+            (WorkflowExecutionStatus.CANCELED, OperationStatus.CANCELLED),
+            (WorkflowExecutionStatus.TERMINATED, OperationStatus.CANCELLED),
+        ],
+    )
+    async def test_reconcile_in_progress_updates_terminal(
+        self,
+        services_mock: ServiceCollectionV3,
+        monkeypatch,
+        temporal_status,
+        expected_status,
+    ) -> None:
+        services_mock.temporal = Mock(TemporalService)
+        services_mock.operations = Mock(OperationsService)
+        services_mock.operations.list_in_progress_operations = AsyncMock(
+            return_value=[
+                _make_operation("op-uuid", status=OperationStatus.RUNNING)
+            ]
         )
+        services_mock.operations.update_status = AsyncMock()
+        services_mock.produce.return_value = services_mock
+        monkeypatch.setattr(
+            activity_module, "ServiceCollectionV3", services_mock
+        )
+
+        temporal_client = Mock(Client)
+        handle = Mock()
+        handle.describe = AsyncMock(return_value=Mock(status=temporal_status))
+        temporal_client.get_workflow_handle.return_value = handle
+        activity = self._operation_activity(temporal_client)
+
+        await activity.reconcile_in_progress_operations()
+
+        temporal_client.get_workflow_handle.assert_called_once_with("op-uuid")
+        services_mock.operations.update_status.assert_awaited_once_with(
+            operation_uuid="op-uuid",
+            status=expected_status,
+        )
+
+    async def test_reconcile_in_progress_skips_running(
+        self, services_mock: ServiceCollectionV3, monkeypatch
+    ) -> None:
+        services_mock.temporal = Mock(TemporalService)
+        services_mock.operations = Mock(OperationsService)
+        services_mock.operations.list_in_progress_operations = AsyncMock(
+            return_value=[
+                _make_operation("op-uuid", status=OperationStatus.RUNNING)
+            ]
+        )
+        services_mock.operations.update_status = AsyncMock()
+        services_mock.produce.return_value = services_mock
+        monkeypatch.setattr(
+            activity_module, "ServiceCollectionV3", services_mock
+        )
+
+        temporal_client = Mock(Client)
+        handle = Mock()
+        handle.describe = AsyncMock(
+            return_value=Mock(status=WorkflowExecutionStatus.RUNNING)
+        )
+        temporal_client.get_workflow_handle.return_value = handle
+        activity = self._operation_activity(temporal_client)
+
+        await activity.reconcile_in_progress_operations()
+
+        services_mock.operations.update_status.assert_not_awaited()
+
+    async def test_reconcile_in_progress_skips_missing_workflow(
+        self, services_mock: ServiceCollectionV3, monkeypatch
+    ) -> None:
+        services_mock.temporal = Mock(TemporalService)
+        services_mock.operations = Mock(OperationsService)
+        services_mock.operations.list_in_progress_operations = AsyncMock(
+            return_value=[
+                _make_operation("op-uuid", status=OperationStatus.RUNNING)
+            ]
+        )
+        services_mock.operations.update_status = AsyncMock()
+        services_mock.produce.return_value = services_mock
+        monkeypatch.setattr(
+            activity_module, "ServiceCollectionV3", services_mock
+        )
+
+        temporal_client = Mock(Client)
+        handle = Mock()
+        handle.describe = AsyncMock(
+            side_effect=RPCError("not found", RPCStatusCode.NOT_FOUND, b"")
+        )
+        temporal_client.get_workflow_handle.return_value = handle
+        activity = self._operation_activity(temporal_client)
+
+        await activity.reconcile_in_progress_operations()
+
+        services_mock.operations.update_status.assert_not_awaited()
 
 
 @pytest.mark.asyncio
 class TestReconcileOperationsWorkflow:
-    async def test_starts_workflow_for_each_stuck_operation(
-        self, monkeypatch
-    ) -> None:
-        stuck = [
-            StuckOperation(
-                uuid="op-1", op_type=OperationType.MACHINE_COMMISSION
-            ),
-            StuckOperation(
-                uuid="op-2", op_type=OperationType.MACHINE_COMMISSION
-            ),
-        ]
-
-        async def fake_execute_activity(name, *args, **kwargs):
-            if name == GET_STUCK_OPERATIONS_ACTIVITY_NAME:
-                return stuck
-            return None
-
-        execute_activity = AsyncMock(side_effect=fake_execute_activity)
+    async def test_run_executes_both_phases(self, monkeypatch) -> None:
+        execute_activity = AsyncMock()
         monkeypatch.setattr(
             operation_module.workflow, "execute_activity", execute_activity
         )
 
-        result = await ReconcileOperationsWorkflow().run()
+        await ReconcileOperationsWorkflow().run()
 
-        assert result == 2
-        start_calls = [
-            call
-            for call in execute_activity.call_args_list
-            if call.args[0] == START_OPERATION_WORKFLOW_ACTIVITY_NAME
+        names = [call.args[0] for call in execute_activity.call_args_list]
+        assert names == [
+            RECONCILE_STUCK_ACCEPTED_ACTIVITY_NAME,
+            RECONCILE_IN_PROGRESS_ACTIVITY_NAME,
         ]
-        assert [call.args[1] for call in start_calls] == stuck

--- a/src/tests/maastemporalworker/workflow/test_operation.py
+++ b/src/tests/maastemporalworker/workflow/test_operation.py
@@ -443,14 +443,30 @@ class TestReconcileOperationsActivities:
 
         services_mock.operations.update_status.assert_not_awaited()
 
-    async def test_reconcile_in_progress_skips_missing_workflow(
-        self, services_mock: ServiceCollectionV3, monkeypatch
+    @pytest.mark.parametrize(
+        "operation_status, expected_status, expected_error",
+        [
+            (
+                OperationStatus.RUNNING,
+                OperationStatus.FAILED,
+                "Workflow execution not found in Temporal.",
+            ),
+            (OperationStatus.CANCELLING, OperationStatus.CANCELLED, None),
+        ],
+    )
+    async def test_reconcile_in_progress_when_workflow_not_found(
+        self,
+        services_mock: ServiceCollectionV3,
+        monkeypatch,
+        operation_status,
+        expected_status,
+        expected_error,
     ) -> None:
         services_mock.temporal = Mock(TemporalService)
         services_mock.operations = Mock(OperationsService)
         services_mock.operations.list_in_progress_operations = AsyncMock(
             return_value=[
-                _make_operation("op-uuid", status=OperationStatus.RUNNING)
+                _make_operation("op-uuid", status=operation_status)
             ]
         )
         services_mock.operations.update_status = AsyncMock()
@@ -469,7 +485,11 @@ class TestReconcileOperationsActivities:
 
         await activity.reconcile_in_progress_operations()
 
-        services_mock.operations.update_status.assert_not_awaited()
+        services_mock.operations.update_status.assert_awaited_once_with(
+            operation_uuid="op-uuid",
+            status=expected_status,
+            error=expected_error,
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Extend the scheduled reconcile-operations workflow to fix RUNNING and CANCELLING operations when the linked Temporal execution has already finished or been terminated externally. I also refactored so both reconciliation phases run as batch activities.