### PR TITLE
fix: enable maas-agent metrics endpoint by default

### DIFF
--- a/src/provisioningserver/agent/config.py
+++ b/src/provisioningserver/agent/config.py
@@ -43,6 +43,11 @@ class AgentLogConfig:
 
 
 @dataclass(frozen=True)
+class AgentMetricsConfig:
+    enabled: bool
+
+
+@dataclass(frozen=True)
 class AgentServicesConfig:
     http_proxy: AgentHTTPProxyConfig
 
@@ -50,6 +55,7 @@ class AgentServicesConfig:
 @dataclass(frozen=True)
 class AgentObservabilityConfig:
     logging: AgentLogConfig
+    metrics: AgentMetricsConfig
 
 
 @dataclass(frozen=True)

--- a/src/provisioningserver/rackdservices/external.py
+++ b/src/provisioningserver/rackdservices/external.py
@@ -381,6 +381,7 @@ class RackAgent(RackOnlyExternalService):
                 logging=agent_config.AgentLogConfig(
                     "debug" if debug_enabled else "info",
                 ),
+                metrics=agent_config.AgentMetricsConfig(enabled=True),
             ),
             tls=agent_config.AgentTLSConfig(
                 key_file=key_file, cert_file=cert_file, ca_file=ca_file

--- a/src/provisioningserver/rackdservices/tests/test_external.py
+++ b/src/provisioningserver/rackdservices/tests/test_external.py
@@ -706,6 +706,7 @@ class TestRackAgent(MAASTestCase):
         self.assertEqual(observed.system_id, system_id)
         self.assertEqual(observed.controller, "https://127.0.0.1:5242")
         self.assertEqual(observed.observability.logging.level, "info")
+        self.assertTrue(observed.observability.metrics.enabled)
 
     @inlineCallbacks
     def test_maybeApplyConfiguration_only_restarts_when_new_config(self):


### PR DESCRIPTION
The agent daemon rewrite gated `/metrics` behind `observability.metrics.enabled`, but the rackd-managed `agent.yaml` writer never emitted that flag, so `:5248/metrics/agent` returned 404. Emit `metrics.enabled=true` from RackAgent to restore the 3.7 behavior of the agent always serving `/metrics`.

This is a regression introduced after 3.7. On 3.7 `setupMetrics()` ran `mux.Handle("/metrics", ...)` unconditionally and was called unconditionally at startup (`Metrics.Enabled` was an unused placeholder): https://github.com/canonical/maas/blob/5aa0e0c1d9d4b88b812c8986795acd57669e5f55/src/maasagent/cmd/maas-agent/main.go#L271-L294 https://github.com/canonical/maas/blob/5aa0e0c1d9d4b88b812c8986795acd57669e5f55/src/maasagent/cmd/maas-agent/main.go#L413

The daemon rewrite changed this:

- commit 661491c7e defaulted observability.metrics.enabled to false, and
- commit 06652ce74 made setupMetrics gate registration on that flag, so the endpoint now 404s by default.
 
This fix targets the rackd-managed agent, whose agent.yaml is generated by RackAgent and never included the metrics flag.