### PR TITLE
chore: change PPA to 3.8-next

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ VENV := .ve
 # This uses an explicit empty check (rather than ?=) since Jenkins defines
 # variables for parameters even when not passed.
 ifeq ($(MAAS_PPA),)
-	MAAS_PPA = ppa:maas-committers/latest-deps
+	MAAS_PPA = ppa:maas/3.8-next
 endif
 
 export PATH := $(PWD)/$(BIN_DIR):$(PATH)

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ epoch: 4*
 
 package-repositories:
   - type: apt
-    ppa: maas-committers/latest-deps
+    ppa: maas/3.8-next
 
 environment:
   PYTHONPATH: $SNAP/usr/lib/python3/dist-packages


### PR DESCRIPTION
Change PPA to actually track 3.8-next, in preparation for the 3.8 releases.