### PR TITLE
fix: use the request() method to make requests from authlib

### DIFF
--- a/src/maasservicelayer/auth/external_oauth.py
+++ b/src/maasservicelayer/auth/external_oauth.py
@@ -416,7 +416,9 @@ class OAuth2Client:
         headers = {}
         if access_token:
             headers["Authorization"] = f"Bearer {access_token}"
-        response = await self.client.get(url=url, headers=headers)  # pyright: ignore [reportAttributeAccessIssue]
+        response = await self.client.request(
+            method="GET", url=url, headers=headers, withhold_token=True
+        )
         response.raise_for_status()
         return response.json()
 
@@ -427,5 +429,7 @@ class OAuth2Client:
             "client_id": self.provider.client_id,
             "client_secret": self.provider.client_secret,
         }
-        response = await self.client.post(url=url, data=data)  # pyright: ignore [reportAttributeAccessIssue]
+        response = await self.client.request(
+            method="POST", url=url, data=data, withhold_token=True
+        )
         response.raise_for_status()

--- a/src/tests/maasservicelayer/auth/test_external_oauth.py
+++ b/src/tests/maasservicelayer/auth/test_external_oauth.py
@@ -569,12 +569,17 @@ class TestOauth2Client:
             request=Request("GET", url="https://issuer.com/some_endpoint"),
         )
 
-        client.client.get = AsyncMock(return_value=test_response)
+        client.client.request = AsyncMock(return_value=test_response)
 
         response = await client._request(
             url="https://issuer.com/some_endpoint",
         )
-        client.client.get.assert_awaited_once()
+        client.client.request.assert_awaited_once_with(
+            method="GET",
+            url="https://issuer.com/some_endpoint",
+            headers={},
+            withhold_token=True,
+        )
         assert response == {"key": "value"}
 
     async def test__client_request_failure(self) -> None:
@@ -585,13 +590,13 @@ class TestOauth2Client:
             request=Request("GET", url="https://issuer.com/some_endpoint"),
         )
 
-        client.client.get = AsyncMock(return_value=test_response)
+        client.client.request = AsyncMock(return_value=test_response)
 
         with pytest.raises(HTTPStatusError):
             await client._request(
                 url="https://issuer.com/some_endpoint",
             )
-        client.client.get.assert_awaited_once()
+        client.client.request.assert_awaited_once()
 
     async def test_revoke_token_no_endpoint(self) -> None:
         client = OAuth2Client(TEST_PROVIDER)
@@ -630,14 +635,17 @@ class TestOauth2Client:
             "client_id": TEST_PROVIDER.client_id,
             "client_secret": TEST_PROVIDER.client_secret,
         }
-        client.client.post = AsyncMock(return_value=test_response)
+        client.client.request = AsyncMock(return_value=test_response)
 
         await client._revoke_token(
             url="https://issuer.com/revoke", token="abc123"
         )
 
-        client.client.post.assert_awaited_once_with(
-            url="https://issuer.com/revoke", data=req_data
+        client.client.request.assert_awaited_once_with(
+            method="POST",
+            url="https://issuer.com/revoke",
+            data=req_data,
+            withhold_token=True,
         )
 
     async def test__revoke_token_failure(self) -> None:
@@ -647,7 +655,7 @@ class TestOauth2Client:
             content="Internal Server Error",
             request=Request("POST", url="https://issuer.com/some_endpoint"),
         )
-        client.client.post = AsyncMock(return_value=test_response)
+        client.client.request = AsyncMock(return_value=test_response)
 
         with pytest.raises(HTTPStatusError):
             await client._revoke_token(
@@ -771,7 +779,7 @@ class TestOauth2Client:
         TEST_PROVIDER.metadata.userinfo_endpoint = (
             "https://issuer.com/userinfo"
         )
-        client.client.get = AsyncMock(
+        client.client.request = AsyncMock(
             return_value=Response(
                 status_code=200,
                 content='{"sub": "user123", "email": "user@example.com"}',
@@ -779,8 +787,10 @@ class TestOauth2Client:
             )
         )
         response = await client._userinfo_request(access_token="opaque_token")
-        client.client.get.assert_awaited_once_with(
+        client.client.request.assert_awaited_once_with(
+            method="GET",
             url=TEST_PROVIDER.metadata.userinfo_endpoint,
             headers={"Authorization": "Bearer opaque_token"},
+            withhold_token=True,
         )
         assert response == {"sub": "user123", "email": "user@example.com"}


### PR DESCRIPTION
- Authlib's `AsyncOAuth2Client` attaches tokens to requests when using `client.get()` and `client.post()`. For requests that don't require authentication (like fetching the JWKS), this is unnecessary
- Instead, we can use `client.request(withhold_token=True)` which will not add any tokens. Unfortunately, `client.get()` does not have a `withhold_token` param so we cannot call it directly.