### PR TITLE
fix: add missing pkg_resources dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -154,6 +154,7 @@ parts:
       - python3-rfc3339 # for macaroonbakery
       - python3-seamicroclient
       - python3-setuptools
+      - python3-pkg-resources
       - python3-simplestreams
       - python3-tempita
       - python3-twisted


### PR DESCRIPTION
The `3.4/edge` snap was unavailable due to:
```
ubuntu@maas-3-4-snap-testing:~$ sudo snap refresh maas --channel=3.4/edge
error: cannot perform the following tasks:
- Run post-refresh hook of "maas" snap if present (run hook "post-refresh": 
-----
Traceback (most recent call last):
  File "/snap/maas/42249/bin/maas", line 6, in <module>
    sys.exit(main())
  File "/snap/maas/42249/lib/python3.10/site-packages/maascli/__init__.py", line 34, in main
    parser = prepare_parser(argv)
  File "/snap/maas/42249/lib/python3.10/site-packages/maascli/parser.py", line 87, in prepare_parser
    register_cli_commands(parser)
  File "/snap/maas/42249/lib/python3.10/site-packages/maascli/cli.py", line 321, in register_cli_commands
    django_setup()
  File "/snap/maas/42249/usr/lib/python3/dist-packages/django/__init__.py", line 19, in setup
    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
  File "/snap/maas/42249/usr/lib/python3/dist-packages/django/conf/__init__.py", line 82, in __getattr__
    self._setup(name)
  File "/snap/maas/42249/usr/lib/python3/dist-packages/django/conf/__init__.py", line 69, in _setup
    self._wrapped = Settings(settings_module)
  File "/snap/maas/42249/usr/lib/python3/dist-packages/django/conf/__init__.py", line 170, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 992, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/snap/maas/42249/lib/python3.10/site-packages/maasserver/__init__.py", line 9, in <module>
    from provisioningserver.utils.version import DISTRIBUTION
  File "/snap/maas/42249/lib/python3.10/site-packages/provisioningserver/__init__.py", line 7, in <module>
    from twisted.application.service import MultiService
  File "/snap/maas/42249/usr/lib/python3/dist-packages/twisted/application/service.py", line 18, in <module>
    from zope.interface import Attribute, Interface, implementer
  File "/snap/maas/42249/usr/lib/python3/dist-packages/zope/__init__.py", line 1, in <module>
    __import__('pkg_resources').declare_namespace(__name__)
ModuleNotFoundError: No module named 'pkg_resources'
-----)
```

This PR adds `python3-pkg-resources` to  stage-packages in snapcraft.yaml which fixes the issue.