### PR TITLE
fix(network): don't convert STICKY IPs to DISCOVERED if machine receives same IP

### DIFF
--- a/src/maasserver/dns/tests/test_config.py
+++ b/src/maasserver/dns/tests/test_config.py
@@ -34,6 +34,7 @@ from maasserver.models.dnspublication import DNSPublication
 from maasserver.testing.config import RegionConfigurationFixture
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
+from maasserver.utils.orm import post_commit_hooks
 from provisioningserver.dns.commands import get_named_conf, setup_dns
 from provisioningserver.dns.config import (
     compose_config_path,
@@ -854,7 +855,8 @@ class TestProcessDNSUpdateNotify(MAASServerTestCase):
         )
         resource.ip_addresses.add(ip2)
         message = f"DELETE-IP {domain.name} {resource.name} A {resource.address_ttl if resource.address_ttl else 60} {ip}"
-        resource.ip_addresses.first().delete()
+        with post_commit_hooks:
+            resource.ip_addresses.first().delete()
 
         result, _ = process_dns_update_notify(message)
         self.assertCountEqual(

--- a/src/maasserver/models/staticipaddress.py
+++ b/src/maasserver/models/staticipaddress.py
@@ -735,12 +735,14 @@ class StaticIPAddress(CleanSave, TimestampedModel):
         subnet_id = self.subnet_id
         alloc_type = self.alloc_type
         temp_expires = self.temp_expires_on
+        ip = self.ip
 
         super().delete(*args, **kwargs)
 
         if (
             alloc_type != IPADDRESS_TYPE.DISCOVERED
-            and temp_expires is not None
+            and ip is not None
+            and temp_expires is None
         ):
             post_commit_do(
                 start_workflow,

--- a/src/maasserver/models/tests/test_dnsresource.py
+++ b/src/maasserver/models/tests/test_dnsresource.py
@@ -12,7 +12,7 @@ from maasserver.models.dnsresource import DNSResource, separate_fqdn
 from maasserver.permissions import NodePermission
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
-from maasserver.utils.orm import reload_object
+from maasserver.utils.orm import post_commit_hooks, reload_object
 
 
 class TestDNSResourceManagerGetDNSResourceOr404(MAASServerTestCase):
@@ -279,7 +279,8 @@ class TestDNSResource(MAASServerTestCase):
             alloc_type=IPADDRESS_TYPE.USER_RESERVED
         )
         dnsresource.ip_addresses.add(sip2)
-        dnsresource.delete()
+        with post_commit_hooks:
+            dnsresource.delete()
         assert StaticIPAddress.objects.filter(ip=sip1.get_ip()).exists()
         assert not StaticIPAddress.objects.filter(ip=sip2.get_ip()).exists()
 
@@ -314,7 +315,8 @@ class TestStaticIPAddressSignals(MAASServerTestCase):
     def test_non_orphaned_record_not_deleted(self):
         dnsrr = factory.make_DNSResource(ip_addresses=["8.8.8.8", "8.8.4.4"])
         sip = StaticIPAddress.objects.get(ip="8.8.4.4")
-        sip.delete()
+        with post_commit_hooks:
+            sip.delete()
         dnsrr = reload_object(dnsrr)
         sip = StaticIPAddress.objects.get(ip="8.8.8.8")
         self.assertIn(sip, dnsrr.ip_addresses.all())

--- a/src/maasserver/models/tests/test_staticipaddress.py
+++ b/src/maasserver/models/tests/test_staticipaddress.py
@@ -1722,7 +1722,7 @@ class TestStaticIPAddress(MAASServerTestCase):
             alloc_type=IPADDRESS_TYPE.AUTO,
             ip="10.0.0.1",
             subnet=subnet,
-            temp_expires_on=timezone.now(),
+            temp_expires_on=None,
         )
 
         with post_commit_hooks:
@@ -1737,6 +1737,28 @@ class TestStaticIPAddress(MAASServerTestCase):
             ),
             mock_start_workflow.mock_calls,
         )
+
+    def test_delete_temp_ip_does_not_call_dhcp_configure_workflow(self):
+        mock_start_workflow = self.patch(
+            static_ip_address_module, "start_workflow"
+        )
+        subnet = factory.make_Subnet(cidr="10.0.0.0/24")
+        ip = StaticIPAddress(
+            alloc_type=IPADDRESS_TYPE.AUTO,
+            ip="10.0.0.1",
+            subnet=subnet,
+            temp_expires_on=timezone.now(),
+        )
+
+        with post_commit_hooks:
+            ip.save()
+
+        mock_start_workflow.reset_mock()
+
+        with post_commit_hooks:
+            ip.delete()
+
+        mock_start_workflow.assert_not_called()
 
     def test_discovered_ips_do_not_call_dhcp_configure_workflow(self):
         mock_start_workflow = self.patch(
@@ -1758,17 +1780,16 @@ class TestStaticIPAddress(MAASServerTestCase):
         )
         subnet = factory.make_Subnet(cidr="10.0.0.0/24")
         ip = StaticIPAddress(
-            alloc_type=IPADDRESS_TYPE.USER_RESERVED,
-            ip="10.0.0.1",
+            alloc_type=IPADDRESS_TYPE.STICKY,
+            ip=None,
             subnet=subnet,
-            temp_expires_on=None,
         )
 
         with post_commit_hooks:
             ip.save()
             ip.delete()
 
-        assert len(mock_start_workflow.mock_calls) == 1
+        mock_start_workflow.assert_not_called()
 
 
 class TestUserReservedStaticIPAddress(MAASServerTestCase):


### PR DESCRIPTION
Backport for [LP#2152681](https://bugs.launchpad.net/maas/+bug/2152681)

See [original PR](https://github.com/canonical/maas/pull/272)
(Cherry picked from commit [575665b](https://github.com/canonical/maas/commit/575665bc867785cb0b31d7a195e245215c349027))