### PR TITLE
fix: restrict get_or_create to get_or_create_on_node

### DIFF
--- a/src/maasserver/models/interface.py
+++ b/src/maasserver/models/interface.py
@@ -507,6 +507,7 @@ class InterfaceManager(Manager, InterfaceQueriesMixin):
                 # current links because they are completely wrong.
                 interface.ip_addresses.all().delete()
                 interface.node_config = node.current_config
+            interface.save()
             created = False
         else:
             interface = self.create(

--- a/src/maasserver/models/interface.py
+++ b/src/maasserver/models/interface.py
@@ -507,6 +507,7 @@ class InterfaceManager(Manager, InterfaceQueriesMixin):
                 # current links because they are completely wrong.
                 interface.ip_addresses.all().delete()
                 interface.node_config = node.current_config
+                interface.vlan = None
             interface.save()
             created = False
         else:

--- a/src/maasserver/models/interface.py
+++ b/src/maasserver/models/interface.py
@@ -507,6 +507,7 @@ class InterfaceManager(Manager, InterfaceQueriesMixin):
                 # current links because they are completely wrong.
                 interface.ip_addresses.all().delete()
                 interface.node_config = node.current_config
+            created = False
         else:
             interface = self.create(
                 name=name,
@@ -518,7 +519,8 @@ class InterfaceManager(Manager, InterfaceQueriesMixin):
                 InterfaceRelationship(
                     child=interface, parent=parent_nic
                 ).save()
-        return interface
+            created = True
+        return interface, created
 
     def resolve_missing_mac_address(self, iface):
         if iface.mac_address is None:

--- a/src/metadataserver/builtin_scripts/network.py
+++ b/src/metadataserver/builtin_scripts/network.py
@@ -235,32 +235,19 @@ def update_physical_interface(
     PhysicalInterface.objects.filter(
         node_config=node.current_config, name=name
     ).exclude(mac_address=mac_address).delete()
-    interface, created = PhysicalInterface.objects.get_or_create(
-        mac_address=mac_address,
-        defaults={
-            "node_config": node.current_config,
-            "name": name,
-            "enabled": True,
-            # actual physical interfaces are to be considered non-acquired in hw sync to be preserved on release
-            "acquired": not (
-                node.is_commissioning()
-                or (node.enable_hw_sync and port is not None)
-            ),
-        },
+
+    acquired = not (
+        node.is_commissioning() or (node.enable_hw_sync and port is not None)
+    )
+
+    interface, created = PhysicalInterface.objects.get_or_create_on_node(
+        node, name, mac_address, [], acquired=acquired
     )
     if created:
         _hardware_sync_network_device_notify(
             node, interface, HARDWARE_SYNC_ACTIONS.ADDED
         )
 
-    if not created and interface.node_config_id != node.current_config_id:
-        # MAC address was on a different node. We need to move
-        # it to its new owner. In the process we delete all of its
-        # current links because they are completely wrong.
-        PhysicalInterface.objects.filter(id=interface.id).delete()
-        return update_physical_interface(
-            node, name, network, links, card=card, port=port, hints=hints
-        )
     # Don't update the VLAN unless:
     # (1) The interface's VLAN wasn't previously known.
     # (2) The interface is connected
@@ -272,17 +259,6 @@ def update_physical_interface(
         if new_vlan is not None:
             interface.vlan = new_vlan
             update_fields.add("vlan")
-    if not created:
-        if interface.node_config_id != node.current_config_id:
-            # MAC address was on a different node. We need to move
-            # it to its new owner. In the process we delete all of its
-            # current links because they are completely wrong.
-            interface.ip_addresses.all().delete()
-            interface.node_config = node.current_config
-            update_fields.add("node_config")
-        if interface.name != name:
-            interface.name = name
-            update_fields.add("name")
     if interface.link_connected != is_connected:
         interface.link_connected = is_connected
         update_fields.add("link_connected")
@@ -474,7 +450,7 @@ def update_child_interface(node, name, network, links):
         return None
 
     mac_address = network["hwaddr"]
-    interface = child_type.objects.get_or_create_on_node(
+    interface, _ = child_type.objects.get_or_create_on_node(
         node,
         name,
         mac_address,

--- a/src/metadataserver/builtin_scripts/tests/test_hooks.py
+++ b/src/metadataserver/builtin_scripts/tests/test_hooks.py
@@ -4993,6 +4993,27 @@ class TestUpdateNodeNetworkInformation(MAASServerTestCase):
             Interface.objects.get(id=interface_id).node_config,
         )
 
+    def test_reassign_interfaces_recomputes_vlan_for_new_node(self):
+        node1 = factory.make_Node()
+        stale_vlan = factory.make_VLAN()
+        eth0 = factory.make_Interface(
+            name="eth0",
+            mac_address=self.EXPECTED_INTERFACES["eth0"],
+            node=node1,
+            vlan=stale_vlan,
+        )
+
+        node2 = factory.make_Node()
+
+        with post_commit_hooks:
+            update_node_network_information(
+                node2, make_lxd_output(), create_numa_nodes(node2)
+            )
+
+        moved_eth0 = Interface.objects.get(id=eth0.id)
+        self.assertEqual(node2.current_config, moved_eth0.node_config)
+        self.assertNotEqual(stale_vlan, moved_eth0.vlan)
+
     def test_deletes_virtual_interfaces_with_shared_mac(self):
         # Note: since this VLANInterface will be linked to the default VLAN
         # ("vid 0", which is actually invalid) the VLANInterface will

--- a/src/metadataserver/builtin_scripts/tests/test_hooks.py
+++ b/src/metadataserver/builtin_scripts/tests/test_hooks.py
@@ -4986,8 +4986,12 @@ class TestUpdateNodeNetworkInformation(MAASServerTestCase):
             [], Interface.objects.filter(node_config=node1.current_config)
         )
 
-        # ... and ensure that the interface was deleted.
-        self.assertCountEqual([], Interface.objects.filter(id=interface_id))
+        # ... and ensure that the interface was reassigned to the second
+        # node.
+        self.assertEqual(
+            node2.current_config,
+            Interface.objects.get(id=interface_id).node_config,
+        )
 
     def test_deletes_virtual_interfaces_with_shared_mac(self):
         # Note: since this VLANInterface will be linked to the default VLAN


### PR DESCRIPTION
[LP:2147706](https://bugs.launchpad.net/maas/+bug/2147706) reports that `get_or_create` is erroring with multiple entries after commissioning an initial set of servers. The only way that this seems possible is if there are multiple interfaces with the same mac address, likely on different nodes since the issue happens after creating a first set of nodes and not on a clean environment.

The code in `update_physical_interface` does not account for this, but accounts for the possibility of the interface being in the incorrect node and does some cleanup related to this. This cleanup has duplicated logic in `get_or_create_on_node`, so we just use that instead (which should avoid the multiple entries issues due to the restriction on the node).

I took the liberty of also returning the information of whether the interface was created from `get_or_create_on_node`, to mirror what `get_or_create` does instead of having to do extra queries to check if something was added.

Resolves: [LP:2147706](https://bugs.launchpad.net/maas/+bug/2147706)