### PR TITLE
fix: remove catch-all make target

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -182,8 +182,3 @@ allmetrics: html
 update: install
 	@. $(VENV); .sphinx/update_sp.py
 
-# Catch-all target: route all unknown targets to Sphinx using the new
-# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
-%:
-	$(MAKE) --no-print-directory install
-	. $(VENV); $(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
This block seems to be a clever way to pipe commands through to sphinx in case they are not defined in the Makefile. (This was inherited from the [sphinx-stack repo](https://github.com/canonical/sphinx-stack/blob/main/docs/Makefile#L190).)

However, it is seemingly causing a recursion when trying to expand things with a make dry-run inside the TICS workflow. I downloaded the artifacts and verified that there are 270000 lines of log containing `/usr/bin/make --no-print-directory install`. I couldn't reproduce it locally, but it makes sense that for some reason make is capturing an install, entering the catchall instead of the install target that is defined, having a sub-make install again, and it repeats itself. It might not be make itself, but rather "DryMake", which seems to be something TICS is running and might contain some extra logic.

In any case, we don't really need the extra cleverness of the block. Any command we need from sphinx can just be set explicitly (like we already do for `html`), and we already use only the ones we specify. So I propose we simply remove it.

PS: It is unclear if the issues with TICS are due to this alone (for instance, another run failure happened due to problems in the Python tests themselves: https://github.com/canonical/maas/actions/runs/28690202663), but it certainly does not help. 