### PR TITLE
fix(dns): remove deprecated named -S socket-limit flag

### DIFF
--- a/snap/local/tree/usr/bin/run-named
+++ b/snap/local/tree/usr/bin/run-named
@@ -16,13 +16,6 @@ MAAS_ZONE_FILE_CONFIG_DIR="$SNAP_DATA/bind" \
   MAAS_DNS_CONFIG_DIR="$SNAP_DATA/bind" \
   "$SNAP/usr/bin/maas-rack" setup-dns --no-clobber
 
-# named default socket limit (21k) can be higher than current limits.
-# Increase the limit to the max allowed and restrict named to this.
-# LP:1901999
-ulimit -n "$(ulimit -Hn)"
-MAAS_DNS_SOCK_LIMIT=$(ulimit -n)
-
 exec "$SNAP/usr/sbin/named" \
   -c "$SNAP_DATA/bind/named.conf" \
-  -S "$MAAS_DNS_SOCK_LIMIT" \
   -g


### PR DESCRIPTION
The -S flag and the reserved-sockets mechanism were deprecated in BIND 9 and cause warnings or errors on newer releases. The ulimit workaround for LP:1901999 is no longer needed as BIND now handles socket limits internally.