### PR TITLE
chore: bump snapcraft epoch

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,7 +21,8 @@ system-usernames:
 # 2: (2.8) move MAAS data to $SNAP_COMMON
 # 3: (2.9) drop "all" mode and builtin PostgresSQL server
 # 4: (3.5) supervisord -> Pebble migration
-epoch: 4*
+# 5: (3.8) MAAS LTS, last version with image migration from database and django migrations
+epoch: 5*
 
 package-repositories:
   - type: apt


### PR DESCRIPTION
Bump the snapcraft epoch to 5 for MAAS 3.8 LTS. This way, we can start cleaning up some of logics we have around migrations of existing environments (django migrations, moving images from DB to the disk and others)

(cherry picked from commit 2c23d849d2ab49da8dcef54a8880ff52a643ee8b)