### PR TITLE
perf: default vlan perf improvements

### DIFF
--- a/src/maasserver/api/tests/test_vlans.py
+++ b/src/maasserver/api/tests/test_vlans.py
@@ -74,22 +74,24 @@ class TestVlansAPI(APITestCase.ForUser):
 
         fabric = factory.make_Fabric()
 
-        def make_vlan():
+        def make_vlan(with_relay: bool):
             space = factory.make_Space()
             subnet = factory.make_Subnet(fabric=fabric, space=space)
             primary_rack = factory.make_RackController()
             factory.make_Interface(node=primary_rack, subnet=subnet)
             secondary_rack = factory.make_RackController()
             factory.make_Interface(node=secondary_rack, subnet=subnet)
-            relay_vlan = factory.make_VLAN()
             vlan = subnet.vlan
             vlan.dhcp_on = True
             vlan.primary_rack = primary_rack
             vlan.secondary_rack = secondary_rack
-            vlan.relay_vlan = relay_vlan
+
+            if with_relay:
+                relay_vlan = factory.make_VLAN()
+                vlan.relay_vlan = relay_vlan
             vlan.save()
 
-        make_vlan()
+        make_vlan(with_relay=True)
 
         uri = get_vlans_uri(fabric)
         with CountQueries() as counter:
@@ -108,12 +110,24 @@ class TestVlansAPI(APITestCase.ForUser):
             vlan = vlans[serialized_vlan["id"]]
             self.assertEqual(serialize_vlan(vlan), serialized_vlan)
 
-        make_vlan()
+        make_vlan(with_relay=True)
         with CountQueries() as counter:
             response = self.client.get(uri)
-        # XXX: These really should be equal.
-        self.assertEqual(base_count + 7, counter.count)
-        self.assertEqual((base_count, counter.count), (25, 32))
+
+        # These should ideally be equal, but each VLAN's relay_vlan lives on
+        # its own Fabric instance, so get_default_vlan() re-queries once per
+        # additional relay_vlan instead of reusing a shared instance cache.
+        # If there is no relay_vlan, they are indeed equal.
+        self.assertEqual(base_count + 1, counter.count)
+
+        make_vlan(with_relay=False)
+        with CountQueries() as counter:
+            response = self.client.get(uri)
+
+        # Validating that adding a VLAN without a relay_vlan doesn't add
+        # further overhead: the count stays the same as after adding the
+        # second relay_vlan above.
+        self.assertEqual(base_count + 1, counter.count)
 
     def test_create(self):
         self.become_admin()

--- a/src/maasserver/api/tests/test_vlans.py
+++ b/src/maasserver/api/tests/test_vlans.py
@@ -112,6 +112,7 @@ class TestVlansAPI(APITestCase.ForUser):
             response = self.client.get(uri)
 
         self.assertEqual(base_count, counter.count)
+        self.assertEqual(base_count, 19)
 
     def test_create(self):
         self.become_admin()

--- a/src/maasserver/api/tests/test_vlans.py
+++ b/src/maasserver/api/tests/test_vlans.py
@@ -45,21 +45,6 @@ class TestVlansAPI(APITestCase.ForUser):
         )
 
     def test_read(self):
-        def make_vlan():
-            space = factory.make_Space()
-            subnet = factory.make_Subnet(fabric=fabric, space=space)
-            primary_rack = factory.make_RackController()
-            factory.make_Interface(node=primary_rack, subnet=subnet)
-            secondary_rack = factory.make_RackController()
-            factory.make_Interface(node=secondary_rack, subnet=subnet)
-            relay_vlan = factory.make_VLAN()
-            vlan = subnet.vlan
-            vlan.dhcp_on = True
-            vlan.primary_rack = primary_rack
-            vlan.secondary_rack = secondary_rack
-            vlan.relay_vlan = relay_vlan
-            vlan.save()
-
         def serialize_vlan(vlan):
             return {
                 "id": vlan.id,
@@ -88,6 +73,22 @@ class TestVlansAPI(APITestCase.ForUser):
             }
 
         fabric = factory.make_Fabric()
+
+        def make_vlan():
+            space = factory.make_Space()
+            subnet = factory.make_Subnet(fabric=fabric, space=space)
+            primary_rack = factory.make_RackController()
+            factory.make_Interface(node=primary_rack, subnet=subnet)
+            secondary_rack = factory.make_RackController()
+            factory.make_Interface(node=secondary_rack, subnet=subnet)
+            relay_vlan = factory.make_VLAN()
+            vlan = subnet.vlan
+            vlan.dhcp_on = True
+            vlan.primary_rack = primary_rack
+            vlan.secondary_rack = secondary_rack
+            vlan.relay_vlan = relay_vlan
+            vlan.save()
+
         make_vlan()
 
         uri = get_vlans_uri(fabric)

--- a/src/maasserver/api/tests/test_vlans.py
+++ b/src/maasserver/api/tests/test_vlans.py
@@ -74,7 +74,7 @@ class TestVlansAPI(APITestCase.ForUser):
 
         fabric = factory.make_Fabric()
 
-        def make_vlan(with_relay: bool):
+        def make_vlan():
             space = factory.make_Space()
             subnet = factory.make_Subnet(fabric=fabric, space=space)
             primary_rack = factory.make_RackController()
@@ -85,13 +85,10 @@ class TestVlansAPI(APITestCase.ForUser):
             vlan.dhcp_on = True
             vlan.primary_rack = primary_rack
             vlan.secondary_rack = secondary_rack
-
-            if with_relay:
-                relay_vlan = factory.make_VLAN()
-                vlan.relay_vlan = relay_vlan
+            vlan.relay_vlan = factory.make_VLAN()
             vlan.save()
 
-        make_vlan(with_relay=True)
+        make_vlan()
 
         uri = get_vlans_uri(fabric)
         with CountQueries() as counter:
@@ -110,24 +107,11 @@ class TestVlansAPI(APITestCase.ForUser):
             vlan = vlans[serialized_vlan["id"]]
             self.assertEqual(serialize_vlan(vlan), serialized_vlan)
 
-        make_vlan(with_relay=True)
+        make_vlan()
         with CountQueries() as counter:
             response = self.client.get(uri)
 
-        # These should ideally be equal, but each VLAN's relay_vlan lives on
-        # its own Fabric instance, so get_default_vlan() re-queries once per
-        # additional relay_vlan instead of reusing a shared instance cache.
-        # If there is no relay_vlan, they are indeed equal.
-        self.assertEqual(base_count + 1, counter.count)
-
-        make_vlan(with_relay=False)
-        with CountQueries() as counter:
-            response = self.client.get(uri)
-
-        # Validating that adding a VLAN without a relay_vlan doesn't add
-        # further overhead: the count stays the same as after adding the
-        # second relay_vlan above.
-        self.assertEqual(base_count + 1, counter.count)
+        self.assertEqual(base_count, counter.count)
 
     def test_create(self):
         self.become_admin()

--- a/src/maasserver/api/vlans.py
+++ b/src/maasserver/api/vlans.py
@@ -61,7 +61,16 @@ class VlansHandler(OperationsHandler):
         fabric = Fabric.objects.get_fabric_or_404(
             fabric_id, request.user, NodePermission.view
         )
-        return fabric.vlan_set.all()
+        return fabric.vlan_set.select_related(
+            "space",
+            "primary_rack",
+            "secondary_rack",
+            "relay_vlan",
+            "relay_vlan__fabric",
+            "relay_vlan__space",
+            "relay_vlan__primary_rack",
+            "relay_vlan__secondary_rack",
+        ).prefetch_related("fabric__vlan_set")
 
     def create(self, request, fabric_id):
         """@description-title Create a VLAN

--- a/src/maasserver/api/vlans.py
+++ b/src/maasserver/api/vlans.py
@@ -70,7 +70,7 @@ class VlansHandler(OperationsHandler):
             "relay_vlan__space",
             "relay_vlan__primary_rack",
             "relay_vlan__secondary_rack",
-        ).prefetch_related("fabric__vlan_set")
+        ).prefetch_related("fabric__vlan_set", "relay_vlan__fabric__vlan_set")
 
     def create(self, request, fabric_id):
         """@description-title Create a VLAN

--- a/src/maasserver/models/fabric.py
+++ b/src/maasserver/models/fabric.py
@@ -157,6 +157,7 @@ class Fabric(CleanSave, TimestampedModel):
         return self.id == 0
 
     def get_default_vlan(self):
+        # Fabrics always have at least one vlan. See `.save`.
         return min(self.vlan_set.all(), key=attrgetter("id"))
 
     def get_name(self):

--- a/src/maasserver/models/fabric.py
+++ b/src/maasserver/models/fabric.py
@@ -157,9 +157,7 @@ class Fabric(CleanSave, TimestampedModel):
         return self.id == 0
 
     def get_default_vlan(self):
-        # This logic is replicated in the dehydrate() function of the
-        # websockets handler.
-        return sorted(self.vlan_set.all(), key=attrgetter("id"))[0]
+        return min(self.vlan_set.all(), key=attrgetter("id"))
 
     def get_name(self):
         """Return the name of the fabric."""


### PR DESCRIPTION
After taking a look at some of our profiling, there are some CPU spikes related to piston3's serializing/deserializing process. Not specifically due to the serialization/deserialization per se, but rather due to how it has to compute the attributes like the name of a vlan.

If we look at VLAN's `get_name`, we see that it asks to check if it is the default vlan of the fabric, and that incurs a db query. The major problem is: when serializing a list of vlans for the same fabric, for example, every one of them is doing a  redundant db query to see if they are the default one for the fabric.

Not only that, but the query itself was fetching all of the vlans and sorting then in Python (there was even no need for the sort, it could have been a `min` to avoid `O(nlogn)`, but that is minor).

This PR implements two things:
- We eagerly fetch all that is necessary for the serialization. 
- A change in the tests, essentially fixing an issue by fulfilling the expectation that the query count shouldn't change when you add more vlans. 