### PR TITLE
fix: Update Redfish boot config for iDRAC10

### DIFF
--- a/src/provisioningserver/drivers/power/redfish.py
+++ b/src/provisioningserver/drivers/power/redfish.py
@@ -50,6 +50,9 @@ REDFISH_POWER_CONTROL_ENDPOINT = (
 
 REDFISH_SYSTEMS_ENDPOINT = b"redfish/v1/Systems"
 
+OLD_REDFISH_BOOT_ENDPOINT = b"redfish/v1/Systems/%s"
+NEW_REDFISH_BOOT_ENDPOINT = b"redfish/v1/Systems/%s/Settings"
+
 MAX_REQUEST_RETRIES = 5
 
 MAX_STATUS_REQUEST_RETRIES = 7
@@ -341,7 +344,6 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
     @inlineCallbacks
     def set_pxe_boot(self, url, node_id, headers):
         """Set the machine with node_id to PXE boot."""
-        endpoint = join(REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
 
         def _get_bodyProducer():
             return FileBodyProducer(
@@ -362,13 +364,26 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
             result = yield self.get_etag(url, node_id, headers)
             return result
 
-        yield self.redfish_request(
-            b"PATCH",
-            join(url, endpoint),
-            headers,
-            _get_bodyProducer,
-            _get_etag,
-        )
+        try:
+            # 1. Try the NEW boot settings endpoint (for upgraded iDRAC)
+            new_endpoint = NEW_REDFISH_BOOT_ENDPOINT % node_id
+            yield self.redfish_request(
+                b"PATCH",
+                join(url, new_endpoint),
+                headers,
+                _get_bodyProducer,
+                _get_etag,
+            )
+        except Exception:
+            # 2. Fall back to the OLD endpoint if the new one fails
+            old_endpoint = OLD_REDFISH_BOOT_ENDPOINT % node_id
+            yield self.redfish_request(
+                b"PATCH",
+                join(url, old_endpoint),
+                headers,
+                _get_bodyProducer,
+                _get_etag,
+            )
 
     @inlineCallbacks
     def power(self, power_change: PowerChange, url, node_id, headers):

--- a/src/provisioningserver/drivers/power/redfish.py
+++ b/src/provisioningserver/drivers/power/redfish.py
@@ -50,9 +50,6 @@ REDFISH_POWER_CONTROL_ENDPOINT = (
 
 REDFISH_SYSTEMS_ENDPOINT = b"redfish/v1/Systems"
 
-OLD_REDFISH_BOOT_ENDPOINT = b"redfish/v1/Systems/%s"
-NEW_REDFISH_BOOT_ENDPOINT = b"redfish/v1/Systems/%s/Settings"
-
 MAX_REQUEST_RETRIES = 5
 
 MAX_STATUS_REQUEST_RETRIES = 7
@@ -319,7 +316,7 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
 
     @inlineCallbacks
     def get_etag(self, url, node_id, headers, endpoint=None):
-        """Get the Etag suggested for PATCH calls."""
+        """Get the system Etag suggested for PATCH calls."""
         if endpoint is None:
             endpoint = join(REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
         uri = join(url, endpoint)
@@ -344,6 +341,36 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
         return basename(member).encode("utf-8")
 
     @inlineCallbacks
+    def get_boot_endpoint(self, url, node_id, headers):
+        """Discover the boot settings endpoint dynamically from the System object."""
+        system_endpoint = join(REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
+        system_uri = join(url, system_endpoint)
+
+        try:
+            node_data, _ = yield self.redfish_request(
+                b"GET", system_uri, headers
+            )
+        except PowerFatalError:
+            raise
+        except Exception:
+            return system_endpoint
+
+        if not isinstance(node_data, dict):
+            return system_endpoint
+        redfish_settings = node_data.get("@Redfish.Settings") or {}
+        if not isinstance(redfish_settings, dict):
+            return system_endpoint
+        settings_obj = redfish_settings.get("SettingsObject") or {}
+        if not isinstance(settings_obj, dict):
+            return system_endpoint
+        odata_id = settings_obj.get("@odata.id")
+
+        if isinstance(odata_id, str) and odata_id:
+            return odata_id.lstrip("/").encode("utf-8")
+
+        return system_endpoint
+
+    @inlineCallbacks
     def set_pxe_boot(self, url, node_id, headers):
         """Set the machine with node_id to PXE boot."""
 
@@ -361,44 +388,25 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
                 )
             )
 
-        # 1. Try the standard legacy endpoint first (works for majority of vendors/older FW)
-        old_endpoint = OLD_REDFISH_BOOT_ENDPOINT % node_id
-        
+        # 1. Discover the correct endpoint dynamically
+        target_endpoint = yield self.get_boot_endpoint(url, node_id, headers)
+
+        # 2. Retrieve context-aware ETag for our discovered target endpoint
         @inlineCallbacks
-        def _get_old_etag():
-            result = yield self.get_etag(url, node_id, headers, endpoint=old_endpoint)
+        def _get_target_etag():
+            result = yield self.get_etag(
+                url, node_id, headers, endpoint=target_endpoint
+            )
             return result
 
-        try:
-            yield self.redfish_request(
-                b"PATCH",
-                join(url, old_endpoint),
-                headers,
-                _get_bodyProducer,
-                _get_old_etag,
-            )
-        except PowerActionError as e:
-            # Check if it failed due to a Method Not Allowed (405) or Bad Request (400) on the root endpoint.
-            # If so, fall back instantly to the iDRAC10 /Settings endpoint.
-            maaslog.info(
-                "PATCH on root system endpoint failed for node %s. Retrying via modern /Settings endpoint...",
-                node_id.decode("utf-8")
-            )
-            
-            new_endpoint = NEW_REDFISH_BOOT_ENDPOINT % node_id
-            
-            @inlineCallbacks
-            def _get_new_etag():
-                result = yield self.get_etag(url, node_id, headers, endpoint=new_endpoint)
-                return result
-
-            yield self.redfish_request(
-                b"PATCH",
-                join(url, new_endpoint),
-                headers,
-                _get_bodyProducer,
-                _get_new_etag,
-            )
+        # 3. Perform the PATCH operation
+        yield self.redfish_request(
+            b"PATCH",
+            join(url, target_endpoint),
+            headers,
+            _get_bodyProducer,
+            _get_target_etag,
+        )
 
     @inlineCallbacks
     def power(self, power_change: PowerChange, url, node_id, headers):

--- a/src/provisioningserver/drivers/power/redfish.py
+++ b/src/provisioningserver/drivers/power/redfish.py
@@ -318,9 +318,11 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
         return url, node_id, headers
 
     @inlineCallbacks
-    def get_etag(self, url, node_id, headers):
-        """Get the system Etag suggested for PATCH calls"""
-        uri = join(url, REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
+    def get_etag(self, url, node_id, headers, endpoint=None):
+        """Get the Etag suggested for PATCH calls."""
+        if endpoint is None:
+            endpoint = join(REDFISH_SYSTEMS_ENDPOINT, b"%s" % node_id)
+        uri = join(url, endpoint)
         node_data, node_headers = yield self.redfish_request(
             b"GET", uri, headers
         )
@@ -359,30 +361,43 @@ class RedfishPowerDriver(RedfishPowerDriverBase):
                 )
             )
 
+        # 1. Try the standard legacy endpoint first (works for majority of vendors/older FW)
+        old_endpoint = OLD_REDFISH_BOOT_ENDPOINT % node_id
+        
         @inlineCallbacks
-        def _get_etag():
-            result = yield self.get_etag(url, node_id, headers)
+        def _get_old_etag():
+            result = yield self.get_etag(url, node_id, headers, endpoint=old_endpoint)
             return result
 
         try:
-            # 1. Try the NEW boot settings endpoint (for upgraded iDRAC)
-            new_endpoint = NEW_REDFISH_BOOT_ENDPOINT % node_id
-            yield self.redfish_request(
-                b"PATCH",
-                join(url, new_endpoint),
-                headers,
-                _get_bodyProducer,
-                _get_etag,
-            )
-        except Exception:
-            # 2. Fall back to the OLD endpoint if the new one fails
-            old_endpoint = OLD_REDFISH_BOOT_ENDPOINT % node_id
             yield self.redfish_request(
                 b"PATCH",
                 join(url, old_endpoint),
                 headers,
                 _get_bodyProducer,
-                _get_etag,
+                _get_old_etag,
+            )
+        except PowerActionError as e:
+            # Check if it failed due to a Method Not Allowed (405) or Bad Request (400) on the root endpoint.
+            # If so, fall back instantly to the iDRAC10 /Settings endpoint.
+            maaslog.info(
+                "PATCH on root system endpoint failed for node %s. Retrying via modern /Settings endpoint...",
+                node_id.decode("utf-8")
+            )
+            
+            new_endpoint = NEW_REDFISH_BOOT_ENDPOINT % node_id
+            
+            @inlineCallbacks
+            def _get_new_etag():
+                result = yield self.get_etag(url, node_id, headers, endpoint=new_endpoint)
+                return result
+
+            yield self.redfish_request(
+                b"PATCH",
+                join(url, new_endpoint),
+                headers,
+                _get_bodyProducer,
+                _get_new_etag,
             )
 
     @inlineCallbacks

--- a/src/provisioningserver/drivers/power/tests/test_redfish.py
+++ b/src/provisioningserver/drivers/power/tests/test_redfish.py
@@ -34,8 +34,6 @@ from provisioningserver.drivers.power import (
 )
 import provisioningserver.drivers.power.redfish as redfish_module
 from provisioningserver.drivers.power.redfish import (
-    NEW_REDFISH_BOOT_ENDPOINT,
-    OLD_REDFISH_BOOT_ENDPOINT,
     REDFISH_POWER_CONTROL_ENDPOINT,
     RedfishPowerDriver,
     WebClientContextFactory,
@@ -867,6 +865,8 @@ class TestRedfishPowerDriver(MAASTestCase):
             )
         )
         mock_file_body_producer.return_value = payload
+        boot_endpoint = join(b"redfish/v1/Systems", b"%s" % node_id)
+        self.patch(driver, "get_boot_endpoint").return_value = boot_endpoint
         mock_redfish_request = self.patch(driver, "redfish_request")
         mock_get_etag = self.patch(driver, "get_etag")
         mock_get_etag.return_value = None
@@ -884,6 +884,9 @@ class TestRedfishPowerDriver(MAASTestCase):
         # The 5th arg is a function that produces the etag.
         argument_etag = yield mock_redfish_request.mock_calls[0].args[4]()
         self.assertEqual(None, argument_etag)
+        mock_get_etag.assert_called_once_with(
+            url, node_id, headers, endpoint=boot_endpoint
+        )
 
     @inlineCallbacks
     def test_set_pxe_boot_with_etag(self):
@@ -908,6 +911,8 @@ class TestRedfishPowerDriver(MAASTestCase):
             )
         )
         mock_file_body_producer.return_value = payload
+        boot_endpoint = join(b"redfish/v1/Systems", b"%s" % node_id)
+        self.patch(driver, "get_boot_endpoint").return_value = boot_endpoint
         mock_redfish_request = self.patch(driver, "redfish_request")
         mock_get_etag = self.patch(driver, "get_etag")
         mock_get_etag.return_value = b"1631210000"
@@ -926,30 +931,84 @@ class TestRedfishPowerDriver(MAASTestCase):
         # The 5th arg is a function that produces the etag.
         argument_etag = yield mock_redfish_request.mock_calls[0].args[4]()
         self.assertEqual(b"1631210000", argument_etag)
+        mock_get_etag.assert_called_once_with(
+            url, node_id, headers, endpoint=boot_endpoint
+        )
 
     @inlineCallbacks
-    def test_set_pxe_boot_uses_old_endpoint_by_default(self):
+    def test_get_boot_endpoint_discovers_dynamic_settings(self):
         driver = RedfishPowerDriver()
         context = make_context()
         url = driver.get_url(context)
         node_id = b"1"
         headers = driver.make_auth_headers(**context)
-        
-        mock_file_body_producer = self.patch(redfish_module, "FileBodyProducer")
-        mock_file_body_producer.return_value = None
-        
+
+        mock_system_payload = {
+            "@Redfish.Settings": {
+                "SettingsObject": {
+                    "@odata.id": "/redfish/v1/Systems/1/Settings"
+                }
+            }
+        }
         mock_redfish_request = self.patch(driver, "redfish_request")
-        mock_redfish_request.return_value = (b"", {})  # Standard successful response
-        
+        mock_redfish_request.return_value = (mock_system_payload, None)
+
+        endpoint = yield driver.get_boot_endpoint(url, node_id, headers)
+        self.assertEqual(b"redfish/v1/Systems/1/Settings", endpoint)
+
+    @inlineCallbacks
+    def test_get_boot_endpoint_falls_back_to_root_on_missing_property(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+
+        mock_system_payload = {"Id": "System.Embedded.1"}
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.return_value = (mock_system_payload, None)
+
+        endpoint = yield driver.get_boot_endpoint(url, node_id, headers)
+        self.assertEqual(b"redfish/v1/Systems/1", endpoint)
+
+    @inlineCallbacks
+    def test_get_boot_endpoint_falls_back_to_root_on_empty_payload(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.return_value = (None, None)
+        endpoint = yield driver.get_boot_endpoint(url, node_id, headers)
+        self.assertEqual(b"redfish/v1/Systems/1", endpoint)
+
+    @inlineCallbacks
+    def test_set_pxe_boot_executes_patch_on_discovered_endpoint(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+
+        self.patch(redfish_module, "FileBodyProducer").return_value = None
         self.patch(driver, "get_etag").return_value = None
+
+        # Force get_boot_endpoint to return our targeted Settings URL
+        self.patch(
+            driver, "get_boot_endpoint"
+        ).return_value = b"redfish/v1/Systems/1/Settings"
+
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.return_value = (b"", {})
 
         yield driver.set_pxe_boot(url, node_id, headers)
 
-        # Assert it only called redfish_request once on the legacy root endpoint
+        # Assert the PATCH is issued directly to the endpoint returned by get_boot_endpoint
         self.assertEqual(1, len(mock_redfish_request.mock_calls))
         self.assertEqual(b"PATCH", mock_redfish_request.mock_calls[0].args[0])
         self.assertEqual(
-            join(url, OLD_REDFISH_BOOT_ENDPOINT % node_id),
+            join(url, b"redfish/v1/Systems/1/Settings"),
             mock_redfish_request.mock_calls[0].args[1],
         )
 

--- a/src/provisioningserver/drivers/power/tests/test_redfish.py
+++ b/src/provisioningserver/drivers/power/tests/test_redfish.py
@@ -928,48 +928,29 @@ class TestRedfishPowerDriver(MAASTestCase):
         self.assertEqual(b"1631210000", argument_etag)
 
     @inlineCallbacks
-    def test_set_pxe_boot_falls_back_to_old_endpoint(self):
+    def test_set_pxe_boot_uses_old_endpoint_by_default(self):
         driver = RedfishPowerDriver()
         context = make_context()
         url = driver.get_url(context)
         node_id = b"1"
         headers = driver.make_auth_headers(**context)
-        mock_file_body_producer = self.patch(
-            redfish_module, "FileBodyProducer"
-        )
-        payload = FileBodyProducer(
-            BytesIO(
-                json.dumps(
-                    {
-                        "Boot": {
-                            "BootSourceOverrideEnabled": "Once",
-                            "BootSourceOverrideTarget": "Pxe",
-                        }
-                    }
-                ).encode("utf-8")
-            )
-        )
-        mock_file_body_producer.return_value = payload
+        
+        mock_file_body_producer = self.patch(redfish_module, "FileBodyProducer")
+        mock_file_body_producer.return_value = None
+        
         mock_redfish_request = self.patch(driver, "redfish_request")
-        mock_redfish_request.side_effect = [
-            PowerActionError("Settings endpoint not supported"),
-            None,
-        ]
-        mock_get_etag = self.patch(driver, "get_etag")
-        mock_get_etag.return_value = None
+        mock_redfish_request.return_value = (b"", {})  # Standard successful response
+        
+        self.patch(driver, "get_etag").return_value = None
+
         yield driver.set_pxe_boot(url, node_id, headers)
-        self.assertEqual(2, len(mock_redfish_request.mock_calls))
-        # First call tries the new endpoint
+
+        # Assert it only called redfish_request once on the legacy root endpoint
+        self.assertEqual(1, len(mock_redfish_request.mock_calls))
         self.assertEqual(b"PATCH", mock_redfish_request.mock_calls[0].args[0])
         self.assertEqual(
-            join(url, NEW_REDFISH_BOOT_ENDPOINT % node_id),
-            mock_redfish_request.mock_calls[0].args[1],
-        )
-        # Second call falls back to the old endpoint
-        self.assertEqual(b"PATCH", mock_redfish_request.mock_calls[1].args[0])
-        self.assertEqual(
             join(url, OLD_REDFISH_BOOT_ENDPOINT % node_id),
-            mock_redfish_request.mock_calls[1].args[1],
+            mock_redfish_request.mock_calls[0].args[1],
         )
 
     @inlineCallbacks

--- a/src/provisioningserver/drivers/power/tests/test_redfish.py
+++ b/src/provisioningserver/drivers/power/tests/test_redfish.py
@@ -34,6 +34,8 @@ from provisioningserver.drivers.power import (
 )
 import provisioningserver.drivers.power.redfish as redfish_module
 from provisioningserver.drivers.power.redfish import (
+    NEW_REDFISH_BOOT_ENDPOINT,
+    OLD_REDFISH_BOOT_ENDPOINT,
     REDFISH_POWER_CONTROL_ENDPOINT,
     RedfishPowerDriver,
     WebClientContextFactory,
@@ -924,6 +926,51 @@ class TestRedfishPowerDriver(MAASTestCase):
         # The 5th arg is a function that produces the etag.
         argument_etag = yield mock_redfish_request.mock_calls[0].args[4]()
         self.assertEqual(b"1631210000", argument_etag)
+
+    @inlineCallbacks
+    def test_set_pxe_boot_falls_back_to_old_endpoint(self):
+        driver = RedfishPowerDriver()
+        context = make_context()
+        url = driver.get_url(context)
+        node_id = b"1"
+        headers = driver.make_auth_headers(**context)
+        mock_file_body_producer = self.patch(
+            redfish_module, "FileBodyProducer"
+        )
+        payload = FileBodyProducer(
+            BytesIO(
+                json.dumps(
+                    {
+                        "Boot": {
+                            "BootSourceOverrideEnabled": "Once",
+                            "BootSourceOverrideTarget": "Pxe",
+                        }
+                    }
+                ).encode("utf-8")
+            )
+        )
+        mock_file_body_producer.return_value = payload
+        mock_redfish_request = self.patch(driver, "redfish_request")
+        mock_redfish_request.side_effect = [
+            PowerActionError("Settings endpoint not supported"),
+            None,
+        ]
+        mock_get_etag = self.patch(driver, "get_etag")
+        mock_get_etag.return_value = None
+        yield driver.set_pxe_boot(url, node_id, headers)
+        self.assertEqual(2, len(mock_redfish_request.mock_calls))
+        # First call tries the new endpoint
+        self.assertEqual(b"PATCH", mock_redfish_request.mock_calls[0].args[0])
+        self.assertEqual(
+            join(url, NEW_REDFISH_BOOT_ENDPOINT % node_id),
+            mock_redfish_request.mock_calls[0].args[1],
+        )
+        # Second call falls back to the old endpoint
+        self.assertEqual(b"PATCH", mock_redfish_request.mock_calls[1].args[0])
+        self.assertEqual(
+            join(url, OLD_REDFISH_BOOT_ENDPOINT % node_id),
+            mock_redfish_request.mock_calls[1].args[1],
+        )
 
     @inlineCallbacks
     def test_redfish_request_retry_refreshed_etag(self):


### PR DESCRIPTION
**Description**

Modern iDRAC rejects PATCH requests to the `redfish/v1/Systems/{node_id}` endpoint. Instead it expects PATCH requests to `redfish/v1/Systems/{node_id}/Settings`.

This PR implements dynamic endpoint discovery:

- Extracts the boot configuration endpoint dynamically by querying the main `System` object payload and extracting the `@Redfish.Settings` URI (`SettingsObject -> @odata.id`).
- Falls back to the standard legacy path if the property is missing or if the payload fetch fails.
- Refactors `get_etag` to accept a target endpoint path.
- Adds helper method `get_boot_endpoint` for `set_pxe_boot` to use.

Resolves: [LP:2160731](https://bugs.launchpad.net/maas/+bug/2160731)