### PR TITLE
tests: load migration-seeded default records from DB in _setup_test_list

### DIFF
--- a/src/maastesting/factory.py
+++ b/src/maastesting/factory.py
@@ -14,7 +14,6 @@ import os.path
 import random
 import string
 import subprocess
-import time
 from typing import Optional
 import unicodedata
 from unittest import mock
@@ -526,10 +525,14 @@ class Factory:
         return leases
 
     def make_date(self, year=2017):
-        start = time.mktime(datetime.datetime(year, 1, 1).timetuple())
-        end = time.mktime(datetime.datetime(year + 1, 1, 1).timetuple())
+        start = datetime.datetime(
+            year, 1, 1, tzinfo=datetime.timezone.utc
+        ).timestamp()
+        end = datetime.datetime(
+            year + 1, 1, 1, tzinfo=datetime.timezone.utc
+        ).timestamp()
         stamp = random.uniform(start, end)
-        return datetime.datetime.fromtimestamp(stamp)
+        return datetime.datetime.fromtimestamp(stamp, tz=datetime.timezone.utc)
 
     def make_timedelta(self):
         return datetime.timedelta(

--- a/src/tests/maasservicelayer/db/repositories/test_domains.py
+++ b/src/tests/maasservicelayer/db/repositories/test_domains.py
@@ -2,7 +2,6 @@
 #  GNU Affero General Public License version 3 (see the file LICENSE).
 
 from collections.abc import Sequence
-from datetime import datetime, timezone
 import random
 from typing import TypeVar
 
@@ -16,6 +15,7 @@ from maasservicelayer.db.repositories.domains import (
     DomainsClauseFactory,
     DomainsRepository,
 )
+from maasservicelayer.db.tables import DomainTable
 from maasservicelayer.models.base import MaasTimestampedBaseModel
 from maasservicelayer.models.domains import Domain
 from tests.fixtures.factories.domain import create_test_domain_entry
@@ -71,24 +71,10 @@ class TestDomainsRepository(RepositoryCommonTests[Domain]):
         self, fixture: Fixture, num_objects: int
     ) -> Sequence[Domain]:
         # The default domain is created by the migrations
-        # and it has the following timestamp hardcoded in the test sql dump,
-        # see src/maasserver/testing/inital.maas_test.sql:8981
-        ts = datetime(2025, 9, 11, 12, 23, 3, 583496, tzinfo=timezone.utc)
-        created_domains = [
-            Domain(
-                id=0,
-                created=ts,
-                updated=ts,
-                name="maas",
-                authoritative=True,
-                ttl=None,
-            )
-        ]
+        created_domains = await fixture.get_typed(DomainTable.name, Domain)
         created_domains.extend(
             [
-                await create_test_domain_entry(
-                    fixture,
-                )
+                await create_test_domain_entry(fixture)
                 for _ in range(num_objects - 1)
             ]
         )

--- a/src/tests/maasservicelayer/db/repositories/test_package_repositories.py
+++ b/src/tests/maasservicelayer/db/repositories/test_package_repositories.py
@@ -1,15 +1,9 @@
 # Copyright 2025 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from datetime import datetime, timezone
-
 import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
 
-from maascommon.enums.package_repositories import (
-    PACKAGE_REPO_MAIN_ARCHES,
-    PACKAGE_REPO_PORTS_ARCHES,
-)
 from maasservicelayer.builders.package_repositories import (
     PackageRepositoryBuilder,
 )
@@ -17,6 +11,7 @@ from maasservicelayer.context import Context
 from maasservicelayer.db.repositories.package_repositories import (
     PackageRepositoriesRepository,
 )
+from maasservicelayer.db.tables import PackageRepositoryTable
 from maasservicelayer.models.fields import PackageRepoUrl
 from maasservicelayer.models.package_repositories import PackageRepository
 from tests.fixtures.factories.package_repositories import (
@@ -41,44 +36,10 @@ class TestCommonPackageRepositoriesRepository(
     async def _setup_test_list(
         self, fixture: Fixture, num_objects: int
     ) -> list[PackageRepository]:
-        # The default package repositories are created by the migration and it
-        # has the following timestamp hardcoded in the test sql dump,
-        # see src/maasserver/testing/inital.maas_test.sql:9239
-        ts = datetime(2025, 9, 11, 12, 23, 3, 583496, tzinfo=timezone.utc)
-        created_package_repositories = [
-            PackageRepository(
-                id=1,
-                created=ts,
-                updated=ts,
-                name="main_archive",
-                url=PackageRepoUrl("http://archive.ubuntu.com/ubuntu"),
-                components=set(),
-                arches=PACKAGE_REPO_MAIN_ARCHES,
-                key="",
-                default=True,
-                enabled=True,
-                disabled_pockets=set(),
-                distributions=[],
-                disabled_components=set(),
-                disable_sources=True,
-            ),
-            PackageRepository(
-                id=2,
-                created=ts,
-                updated=ts,
-                name="ports_archive",
-                url=PackageRepoUrl("http://ports.ubuntu.com/ubuntu-ports"),
-                components=set(),
-                arches=PACKAGE_REPO_PORTS_ARCHES,
-                key="",
-                default=True,
-                enabled=True,
-                disabled_pockets=set(),
-                distributions=[],
-                disabled_components=set(),
-                disable_sources=True,
-            ),
-        ]
+        # The default package repositories are created by the migrations
+        created_package_repositories = await fixture.get_typed(
+            PackageRepositoryTable.name, PackageRepository
+        )
         created_package_repositories.extend(
             [
                 await create_test_package_repository(

--- a/src/tests/maasservicelayer/db/repositories/test_resource_pools.py
+++ b/src/tests/maasservicelayer/db/repositories/test_resource_pools.py
@@ -1,8 +1,6 @@
 # Copyright 2024-2025 Canonical Ltd.  This software is licensed under the
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
-from datetime import datetime, timezone
-
 import pytest
 from sqlalchemy.ext.asyncio import AsyncConnection
 
@@ -14,6 +12,7 @@ from maasservicelayer.db.repositories.resource_pools import (
     ResourcePoolClauseFactory,
     ResourcePoolRepository,
 )
+from maasservicelayer.db.tables import ResourcePoolTable
 from maasservicelayer.exceptions.catalog import (
     AlreadyExistsException,
     NotFoundException,
@@ -57,18 +56,9 @@ class TestResourcePoolRepository(RepositoryCommonTests[ResourcePool]):
         self, fixture: Fixture, num_objects: int
     ) -> list[ResourcePool]:
         # The default resource pool is created by the migrations
-        # and it has the following timestamp hardcoded in the test sql dump,
-        # see src/maasserver/testing/inital.maas_test.sql:9360
-        ts = datetime(2025, 9, 11, 12, 23, 3, 583496, tzinfo=timezone.utc)
-        created_resource_pools = [
-            ResourcePool(
-                id=0,
-                name="default",
-                description="Default pool",
-                created=ts,
-                updated=ts,
-            )
-        ]
+        created_resource_pools = await fixture.get_typed(
+            ResourcePoolTable.name, ResourcePool
+        )
         created_resource_pools.extend(
             await create_n_test_resource_pools(fixture, size=num_objects - 1)
         )

--- a/src/tests/maasservicelayer/db/repositories/test_zones.py
+++ b/src/tests/maasservicelayer/db/repositories/test_zones.py
@@ -1,8 +1,6 @@
 #  Copyright 2024-2025 Canonical Ltd.  This software is licensed under the
 #  GNU Affero General Public License version 3 (see the file LICENSE).
 
-from datetime import datetime, timezone
-
 import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncConnection
@@ -57,19 +55,8 @@ class TestZonesRepository(RepositoryCommonTests[Zone]):
     async def _setup_test_list(
         self, fixture: Fixture, num_objects: int
     ) -> list[Zone]:
-        # The default zone is created by the migration and it has the following
-        # timestamp hardcoded in the test sql dump,
-        # see src/maasserver/testing/inital.maas_test.sql:9553
-        ts = datetime(2025, 9, 11, 12, 23, 3, 583496, tzinfo=timezone.utc)
-        created_zones = [
-            Zone(
-                id=1,
-                name="default",
-                description="",
-                created=ts,
-                updated=ts,
-            )
-        ]
+        # The default zone is created by the migrations
+        created_zones = await fixture.get_typed(ZoneTable.name, Zone)
         created_zones.extend(
             [
                 (


### PR DESCRIPTION
Instead of constructing hardcoded model objects for the default domain, zone, resource pool, and package repositories, query the existing rows from the database. This removes any coupling between the tests and the timestamps stored in the SQL dump.