### PR TITLE
chore: suppress verbose httpx logs

### DIFF
--- a/src/maasservicelayer/logging/configure.py
+++ b/src/maasservicelayer/logging/configure.py
@@ -62,3 +62,6 @@ def configure_logging(level=logging.INFO, query_level=logging.WARNING):
     # Configure sqlalchemy
     logging.getLogger("sqlalchemy.engine").setLevel(query_level)
     logging.getLogger("sqlalchemy.pool").setLevel(query_level)
+
+    # httpx talks too much
+    logging.getLogger("httpx").setLevel(logging.WARNING)

--- a/src/provisioningserver/logger/_logging.py
+++ b/src/provisioningserver/logger/_logging.py
@@ -120,7 +120,7 @@ def get_logging_config(verbosity: int):
                 "handlers": [] if is_dev else ["syslog"],
                 "propagate": is_dev,
             },
-            # The `requests`, `urllib3` and 'httpx' modules talk too much.
+            # The `requests`, `urllib3` and `httpx` modules talk too much.
             "requests": {"level": get_logging_level(verbosity - 1)},
             "urllib3": {"level": get_logging_level(verbosity - 1)},
             "httpx": {"level": get_logging_level(verbosity - 1)},

--- a/src/provisioningserver/logger/_logging.py
+++ b/src/provisioningserver/logger/_logging.py
@@ -120,9 +120,10 @@ def get_logging_config(verbosity: int):
                 "handlers": [] if is_dev else ["syslog"],
                 "propagate": is_dev,
             },
-            # The `requests` and `urllib3` modules talk too much.
+            # The `requests`, `urllib3` and 'httpx' modules talk too much.
             "requests": {"level": get_logging_level(verbosity - 1)},
             "urllib3": {"level": get_logging_level(verbosity - 1)},
+            "httpx": {"level": get_logging_level(verbosity - 1)},
             # Keep `nose` relatively quiet in tests.
             "nose": {"level": get_logging_level(verbosity - 1)},
         },


### PR DESCRIPTION
`httpx` talks too much, better to suppress such verbose logs in `maasapiserver` and `maasserver`