### PR TITLE
fix(network): fix race conditions in neighbour table updates

### DIFF
--- a/src/maasserver/models/interface.py
+++ b/src/maasserver/models/interface.py
@@ -22,6 +22,7 @@ from django.db.models import (
     CASCADE,
     CharField,
     Count,
+    F,
     ForeignKey,
     JSONField,
     Manager,
@@ -1680,9 +1681,18 @@ class Interface(CleanSave, TimestampedModel):
                     f"{mac}, {ip}"
                 )
         else:
-            neighbour.time = time
-            neighbour.count += 1
-            neighbour.save(update_fields=["time", "count", "updated"])
+            # Use a single-round-trip UPDATE to avoid a REPEATABLE READ
+            # conflict: loading the row and then saving it in the same
+            # transaction races with concurrent deletions or updates.
+            # If the row was deleted by a concurrent transaction after
+            # get_or_create returned it, this UPDATE matches 0 rows and
+            # the observation is silently dropped.  The neighbour table is
+            # eventually consistent; losing one ARP observation is acceptable.
+            Neighbour.objects.filter(pk=neighbour.pk).update(
+                time=time,
+                count=F("count") + 1,
+                updated=timezone.now(),
+            )
         return neighbour
 
     def update_mdns_entry(self, avahi_json: dict):

--- a/src/maasserver/models/neighbour.py
+++ b/src/maasserver/models/neighbour.py
@@ -89,9 +89,11 @@ class NeighbourManager(Manager, NeighbourQueriesMixin):
         Returns True if a binding was (deleted and a log was generated).
         """
         deleted = False
-        previous_bindings = self.filter(
-            interface=interface, ip=ip, vid=vid
-        ).exclude(mac_address=mac)
+        previous_bindings = (
+            self.filter(interface=interface, ip=ip, vid=vid)
+            .exclude(mac_address=mac)
+            .select_for_update()
+        )
         # Technically there should be just one existing mapping for this
         # (interface, ip, vid), but the defensive thing to do is to delete
         # them all.

--- a/src/maasserver/rpc/regionservice.py
+++ b/src/maasserver/rpc/regionservice.py
@@ -11,6 +11,7 @@ import random
 from socket import AF_INET, AF_INET6
 import uuid
 
+from django.db.utils import DatabaseError
 from django.utils import timezone
 from netaddr import AddrConversionError, IPAddress
 from twisted.application import service
@@ -43,7 +44,7 @@ from maasserver.rpc.nodes import (
 from maasserver.rpc.services import update_services
 from maasserver.secrets import SecretManager, SecretNotFound
 from maasserver.security import get_shared_secret
-from maasserver.utils.orm import transactional
+from maasserver.utils.orm import is_retryable_failure, transactional
 from maasserver.utils.threads import deferToDatabase
 from provisioningserver.logger import LegacyLogger
 from provisioningserver.prometheus.metrics import (
@@ -307,10 +308,10 @@ class Region(SecuredRPCProtocol):
 
     @region.ReportMDNSEntries.responder
     def report_mdns_entries(self, system_id, mdns):
-        """report_neighbours()
+        """report_mdns_entries()
 
         Implementation of
-        :py:class:`~provisioningserver.rpc.region.ReportNeighbours`.
+        :py:class:`~provisioningserver.rpc.region.ReportMDNSEntries`.
         """
         d = deferToDatabase(
             rackcontrollers.report_mdns_entries, system_id, mdns
@@ -325,10 +326,29 @@ class Region(SecuredRPCProtocol):
         Implementation of
         :py:class:`~provisioningserver.rpc.region.ReportNeighbours`.
         """
+
+        def _suppress_retryable(failure):
+            # After all retries are exhausted the @transactional decorator
+            # lets the final OperationalError propagate.  ReportNeighbours is
+            # a best-effort observation; losing one update under extreme ARP
+            # contention is acceptable.  Log at warning level so the noise
+            # doesn't fill syslog as [critical].
+            if failure.check(DatabaseError) and is_retryable_failure(
+                failure.value
+            ):
+                log.msg(
+                    "Discarding retryable DB failure in ReportNeighbours "
+                    "after exhausting retries: {err}",
+                    err=failure.value,
+                )
+                return {}
+            return failure
+
         d = deferToDatabase(
             rackcontrollers.report_neighbours, system_id, neighbours
         )
         d.addCallback(lambda args: {})
+        d.addErrback(_suppress_retryable)
         return d
 
     @region.RequestNodeInfoByMACAddress.responder

--- a/src/maasserver/rpc/tests/test_regionservice_calls.py
+++ b/src/maasserver/rpc/tests/test_regionservice_calls.py
@@ -9,8 +9,10 @@ from json import dumps
 import random
 from random import randint
 
+from django.db.utils import IntegrityError
 from django.utils import timezone
 from twisted.internet.defer import inlineCallbacks, succeed
+from twisted.protocols.amp import UnknownRemoteError
 from twisted.python.failure import Failure
 
 from maasserver import eventloop
@@ -33,7 +35,11 @@ from maasserver.testing.testcase import (
     MAASServerTestCase,
     MAASTransactionServerTestCase,
 )
-from maasserver.utils.orm import reload_object, transactional
+from maasserver.utils.orm import (
+    make_serialization_failure,
+    reload_object,
+    transactional,
+)
 from maasserver.utils.threads import deferToDatabase
 from maastesting.crochet import wait_for
 from maastesting.testcase import MAASTestCase
@@ -925,6 +931,38 @@ class TestRegionProtocol_ReportNeighbours(MAASServerTestCase):
         report_neighbours.assert_called_once_with(
             params["system_id"], params["neighbours"]
         )
+
+    @wait_for_reactor
+    @inlineCallbacks
+    def test_retryable_db_failure_is_suppressed(self):
+        report_neighbours = self.patch(
+            regionservice.rackcontrollers, "report_neighbours"
+        )
+        report_neighbours.side_effect = make_serialization_failure()
+
+        params = {
+            "system_id": factory.make_name("system_id"),
+            "neighbours": [{"ip": "127.0.0.1"}],
+        }
+
+        response = yield call_responder(Region(), ReportNeighbours, params)
+        self.assertEqual({}, response)
+
+    @wait_for_reactor
+    @inlineCallbacks
+    def test_non_retryable_db_failure_propagates(self):
+        report_neighbours = self.patch(
+            regionservice.rackcontrollers, "report_neighbours"
+        )
+        report_neighbours.side_effect = IntegrityError("constraint violation")
+
+        params = {
+            "system_id": factory.make_name("system_id"),
+            "neighbours": [{"ip": "127.0.0.1"}],
+        }
+
+        with self.assertRaisesRegex(UnknownRemoteError, ".*"):
+            yield call_responder(Region(), ReportNeighbours, params)
 
 
 class TestRegionProtocol_RequestNodeInforByMACAddress(


### PR DESCRIPTION
Two concurrency bugs caused spurious DB errors under high ARP traffic:

update_neighbour() loaded a Neighbour row and then saved it in the same transaction, triggering REPEATABLE READ conflicts when a concurrent transaction deleted or updated the same row. Replace with a single round-trip UPDATE using F("count")+1. If the row is deleted between get_or_create and the UPDATE the observation is silently dropped, which is acceptable for best-effort ARP data.

delete_and_log_obsolete_neighbours() queried previous bindings without taking a row-level lock, allowing a concurrent writer to modify those rows between the SELECT and the DELETE. Add select_for_update() to serialise that window.

Once the @transactional retry budget is exhausted, retryable DatabaseErrors (serialisation failures, deadlocks) propagated as critical log entries from the ReportNeighbours RPC handler. Since neighbour observations are best-effort, suppress those errors after retries are exhausted and log at warning level instead. Non-retryable DatabaseErrors still propagate so genuine bugs remain visible.

(cherry picked from commit 8d19269e74fe1f6a7b7cba7c84565941ba1a1d38)