### PR TITLE
fix: fix boot resources race condition (#496)

### DIFF
--- a/src/maastemporalworker/workflow/bootresource.py
+++ b/src/maastemporalworker/workflow/bootresource.py
@@ -348,8 +348,37 @@ class BootResourcesActivity(ActivityBase):
     async def delete_bootresourcefile(
         self, param: ResourceDeleteParam
     ) -> bool:
-        """Delete files from disk"""
+        """Delete files from disk, unless they have become referenced again.
+
+        The files to delete are chosen when the workflow is scheduled, but
+        execution (particularly resolving region endpoints) can be
+        delayed. If a newer import recreates a BootResourceFile with the
+        same sha256 in the meantime, deleting it would remove content that
+        is genuinely in use again. So each file is re-checked against the
+        database immediately before it is unlinked.
+        """
+        if not param.files:
+            return True
+
+        async with self.start_transaction() as services:
+            still_referenced_shas = {
+                f.sha256
+                for f in await services.boot_resource_files.get_many(
+                    query=QuerySpec(
+                        where=BootResourceFileClauseFactory.with_sha256_in(
+                            list({file.sha256 for file in param.files})
+                        )
+                    )
+                )
+            }
         for file in param.files:
+            if file.sha256 in still_referenced_shas:
+                logger.info(
+                    f"skipping delete of {file}: a BootResourceFile with "
+                    "this sha256 was recreated since the deletion was "
+                    "scheduled"
+                )
+                continue
             logger.debug(f"attempt to delete {file}")
             lfile = AsyncLocalBootResourceFile(
                 file.sha256, file.filename_on_disk, 0
@@ -906,7 +935,16 @@ class SyncBootResourcesWorkflow:
 
 @workflow.defn(name=DELETE_BOOTRESOURCE_WORKFLOW_NAME, sandboxed=False)
 class DeleteBootResourceWorkflow:
-    """Delete a BootResourceFile from this cluster"""
+    """Delete a BootResourceFile, unless it has become referenced again.
+
+    The files targeted by this workflow are chosen when it is scheduled,
+    but execution (particularly resolving region endpoints) can be
+    delayed. If a newer import recreates a BootResourceFile with the same
+    sha256 in the meantime, deleting it would remove content that is genuinely
+    in use again. So, before deleting, an activity of this workflow
+    re-checks the database immediately and skips any file that is no
+    longer safe to remove.
+    """
 
     @workflow_run_with_context
     async def run(self, input: ResourceDeleteParam) -> None:
@@ -916,8 +954,8 @@ class DeleteBootResourceWorkflow:
             start_to_close_timeout=timedelta(seconds=30),
         )
         regions = frozenset(endpoints.keys())
-        for r in regions:
-            await workflow.execute_activity(
+        tasks = [
+            workflow.execute_activity(
                 DELETE_BOOTRESOURCEFILE_ACTIVITY_NAME,
                 input,
                 task_queue=f"region:{r}",
@@ -925,6 +963,9 @@ class DeleteBootResourceWorkflow:
                 schedule_to_close_timeout=DISK_TIMEOUT,
                 retry_policy=RetryPolicy(maximum_attempts=3),
             )
+            for r in regions
+        ]
+        await asyncio.gather(*tasks)
 
 
 @workflow.defn(

--- a/src/tests/maastemporalworker/workflow/test_bootresource.py
+++ b/src/tests/maastemporalworker/workflow/test_bootresource.py
@@ -672,9 +672,12 @@ class TestDeleteBootresourcefileActivity:
         self,
         mocker,
         boot_activities: BootResourcesActivity,
+        services_mock: ServiceCollectionV3,
         activity_env: ActivityEnvironment,
     ) -> None:
         mocker.patch("asyncio.sleep")
+        services_mock.boot_resource_files = Mock(BootResourceFilesService)
+        services_mock.boot_resource_files.get_many = AsyncMock(return_value=[])
 
         heartbeats = []
         activity_env.on_heartbeat = lambda *args: heartbeats.append(args[0])
@@ -692,10 +695,41 @@ class TestDeleteBootresourcefileActivity:
         self,
         mock_local_file: Mock,
         boot_activities: BootResourcesActivity,
+        services_mock: ServiceCollectionV3,
         activity_env: ActivityEnvironment,
     ) -> None:
+        services_mock.boot_resource_files = Mock(BootResourceFilesService)
+        services_mock.boot_resource_files.get_many = AsyncMock(return_value=[])
+
         param = ResourceDeleteParam(
             files=[ResourceIdentifier("0" * 64, "0" * 7)]
+        )
+        res = await activity_env.run(
+            boot_activities.delete_bootresourcefile, param
+        )
+        assert res is True
+        mock_local_file.unlink.assert_called_once()
+
+    async def test_skips_files_that_were_recreated(
+        self,
+        mock_local_file: Mock,
+        boot_activities: BootResourcesActivity,
+        services_mock: ServiceCollectionV3,
+        activity_env: ActivityEnvironment,
+    ) -> None:
+        # A newer import recreated a BootResourceFile reusing the sha256
+        # of the first identifier below, after the delete was scheduled.
+        recreated_file = Mock(BootResourceFile, sha256="1" * 64)
+        services_mock.boot_resource_files = Mock(BootResourceFilesService)
+        services_mock.boot_resource_files.get_many = AsyncMock(
+            return_value=[recreated_file]
+        )
+
+        param = ResourceDeleteParam(
+            files=[
+                ResourceIdentifier("1" * 64, "1" * 7),
+                ResourceIdentifier("2" * 64, "2" * 7),
+            ]
         )
         res = await activity_env.run(
             boot_activities.delete_bootresourcefile, param


### PR DESCRIPTION
We are having several issues in our testplan runs in SolQA due to race conditions regarding file deletions.

This PR checks, just before deleting, if the files are being referenced. If they are, keep them.

It would perhaps be more ideal to implement some sort of "garbage collection" instead of just avoiding deletion and relying on proper triggers later to delete the files in case they become stale, but this would be a much bigger change and it is unclear if it would bring much more value.

Worth noticing: this race condition was present before 3.8. It is also present in 3.5 (see here for more details:
https://bugs.launchpad.net/maas/+bug/2152843), but apparently we are hitting it much more frequently now, perhaps due to infrastructure issues.

(cherry picked from commit 67f681257d02fa4c0be66899d7f7e4c6fa5b0bb6)