### PR TITLE
fix: add maas-openfga.service to regiond's Requires

### DIFF
--- a/debian/maas-region-api.maas-regiond.service
+++ b/debian/maas-region-api.maas-regiond.service
@@ -2,7 +2,7 @@
 Description=MAAS Region Controller
 Documentation=https://maas.io/docs/
 Requires=network-online.target maas-apiserver.service maas-openfga.service
-After=network-online.target
+After=network-online.target maas-apiserver.service maas-openfga.service
 ConditionPathExists=/etc/maas/regiond.conf
 
 [Service]

--- a/debian/maas-region-api.maas-regiond.service
+++ b/debian/maas-region-api.maas-regiond.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=MAAS Region Controller
 Documentation=https://maas.io/docs/
-Requires=network-online.target maas-apiserver.service
+Requires=network-online.target maas-apiserver.service maas-openfga.service
 After=network-online.target
 ConditionPathExists=/etc/maas/regiond.conf
 


### PR DESCRIPTION
We are having some issues with the test runs related to OpenFGA initialization and inexistence of some unix sockets.

@r00ta noticed that this might be related to [another similar issue](https://bugs.launchpad.net/maas/+bug/2073540) that we faced in the past with startup of the apiserver.

If that is the case, the change here should fix it (by doing the same thing: declaring the openfga service as a dependence to the regiond service).