### PR TITLE
chore: Prepare for 3.8.0 beta3 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+maas (1:3.8.0~beta3-0ubuntu1) resolute; urgency=medium
+
+  * New upstream release, MAAS 3.8.0 beta3.
+
+ -- Aloizio Macedo <aloizio.macedo@canonical.com>  Fri, 24 Jul 2026 01:42:16 +0000
+
 maas (1:3.8.0~beta2-0ubuntu1) resolute; urgency=medium
 
   * New upstream release, MAAS 3.8.0 beta2.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = []
 
 [project]
 name = "maas"
-version = "3.8.0b2"
+version = "3.8.0b3"
 description = "Metal As A Service"
 readme = { file = "README.rst", content-type = "text/x-rst" }
 license = { file = "LICENSE" }


### PR DESCRIPTION
OBS: We are maintaining the betaN increases for N for this release, but going forward we will not increase it unless the release actually happens for the respective channels.