### PR TITLE
feat: add config column to OIDCProviderTable

### DIFF
--- a/src/maasservicelayer/builders/external_auth.py
+++ b/src/maasservicelayer/builders/external_auth.py
@@ -2,6 +2,7 @@
 # GNU Affero General Public License version 3 (see the file LICENSE).
 
 from datetime import datetime
+from typing import Any
 
 from pydantic import Field
 
@@ -22,6 +23,7 @@ class OAuthProviderBuilder(ResourceBuilder):
 
     client_id: str | Unset = Field(default=UNSET)
     client_secret: str | Unset = Field(default=UNSET)
+    config: dict[str, Any] | None | Unset = Field(default=UNSET)
     created: datetime | Unset = Field(default=UNSET)
     enabled: bool | Unset = Field(default=UNSET)
     issuer_url: str | Unset = Field(default=UNSET)

--- a/src/maasservicelayer/db/alembic/versions/0034_add_config_column_for_oidc.py
+++ b/src/maasservicelayer/db/alembic/versions/0034_add_config_column_for_oidc.py
@@ -1,0 +1,33 @@
+"""add config column for oidc
+
+Revision ID: 0034
+Revises: 0030
+Create Date: 2026-07-24 11:32:43.402422+00:00
+
+"""
+
+from typing import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0034"
+down_revision: str | None = "0030"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "maasserver_oidc_provider",
+        sa.Column(
+            "config", postgresql.JSONB(astext_type=sa.Text()), nullable=True
+        ),
+    )
+
+
+def downgrade() -> None:
+    # we don't support migration downgrade
+    pass

--- a/src/maasservicelayer/db/tables.py
+++ b/src/maasservicelayer/db/tables.py
@@ -1709,6 +1709,9 @@ OIDCProviderTable = Table(
     Column("token_type", Integer, nullable=False),
     Column("enabled", Boolean, nullable=False),
     Column("metadata", JSONB, nullable=False),
+    Column(
+        "config", JSONB, nullable=True
+    ),  # For additional config options specific to the provider
 )
 
 OIDCRevokedTokenTable = Table(

--- a/src/maasservicelayer/models/external_auth.py
+++ b/src/maasservicelayer/models/external_auth.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime
 from enum import IntEnum
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -51,3 +52,4 @@ class OAuthProvider(MaasTimestampedBaseModel):
     scopes: str
     enabled: bool
     metadata: ProviderMetadata
+    config: dict[str, Any] | None = None


### PR DESCRIPTION
Copied over from [PR#505](https://github.com/canonical/maas/pull/505)
- This PR adds a `config` column to the `OIDCProviderTable`, which will be used to provide any additional config parameters for setting up the provider. For e.g., since we have requests to support Google as an IdP, we require additional attributes (such as `client_email`, `private_key` etc.) for the provider. These attributes can differ between providers, thus the column is of the type `JSONB`. Some providers that are already supported (e.g. Entra ID) do not require additional config params, and thus, this column is nullable.
- The goal is that these additional config options will be shown to the user in the UI/API, and from there we can parse and store this information in an appropriate way in the table.