### PR TITLE
fix: check for indication of virtual device

### DIFF
--- a/src/host-info/pkg/info/info.go
+++ b/src/host-info/pkg/info/info.go
@@ -157,6 +157,7 @@ func getHostInfo() (*HostInfo, error) {
 			"resources_pci_iommu",
 			"resources_network_usb",
 			"resources_disk_address",
+			"resources_disk_used_by",
 		},
 		// machine-resources leverages LXD API code to output data. If
 		// the LXD import is updated and this changes MAAS may need to

--- a/src/host-info/pkg/info/info.go
+++ b/src/host-info/pkg/info/info.go
@@ -157,7 +157,6 @@ func getHostInfo() (*HostInfo, error) {
 			"resources_pci_iommu",
 			"resources_network_usb",
 			"resources_disk_address",
-			"resources_disk_used_by",
 		},
 		// machine-resources leverages LXD API code to output data. If
 		// the LXD import is updated and this changes MAAS may need to

--- a/src/metadataserver/builtin_scripts/hooks.py
+++ b/src/metadataserver/builtin_scripts/hooks.py
@@ -813,6 +813,7 @@ _DEV_PATH = re.compile(
     r"^(?P<bus>\w+)-(?P<bus_addr>[\da-fA-F:\.]+)-(?P<proto>\w+)-(?P<device>.*)$"
 )
 
+
 # bcache virtual holder devices are always named "bcacheN" by the kernel
 # (e.g. /dev/bcache0); the name is assigned by the bcache driver itself and
 # isn't user-configurable, unlike e.g. mdadm arrays or LVM volumes. LXD
@@ -821,7 +822,7 @@ _DEV_PATH = re.compile(
 # present in this same list, so they must not be imported as
 # `PhysicalBlockDevice`s.
 def _is_virtual_bcache_holder(block_info):
-    return block_info["id"].startswith("bcache")
+    return block_info.get("id", "").startswith("bcache")
 
 
 def _condense_luns(disks):

--- a/src/metadataserver/builtin_scripts/hooks.py
+++ b/src/metadataserver/builtin_scripts/hooks.py
@@ -987,6 +987,12 @@ def _update_node_physical_block_devices(
         # for the user to view but they do not get an entry in the database.
         if block_info["read_only"] or block_info["type"] == "cdrom":
             continue
+        # Skip virtual holder devices (e.g. bcache) reported by LXD's
+        # "used_by" field. These are stacked block devices backed by other
+        # disks already present in this list and are not independent
+        # physical disks.
+        if block_info.get("used_by"):
+            continue
         name = block_info["id"]
         model = block_info.get("model", "")
         serial = block_info.get("serial", "")

--- a/src/metadataserver/builtin_scripts/hooks.py
+++ b/src/metadataserver/builtin_scripts/hooks.py
@@ -813,6 +813,16 @@ _DEV_PATH = re.compile(
     r"^(?P<bus>\w+)-(?P<bus_addr>[\da-fA-F:\.]+)-(?P<proto>\w+)-(?P<device>.*)$"
 )
 
+# bcache virtual holder devices are always named "bcacheN" by the kernel
+# (e.g. /dev/bcache0); the name is assigned by the bcache driver itself and
+# isn't user-configurable, unlike e.g. mdadm arrays or LVM volumes. LXD
+# reports them alongside physical disks in the "storage.disks" list, but
+# they are stacked virtual devices backed by other disks that are already
+# present in this same list, so they must not be imported as
+# `PhysicalBlockDevice`s.
+def _is_virtual_bcache_holder(block_info):
+    return block_info["id"].startswith("bcache")
+
 
 def _condense_luns(disks):
     """Condense disks by LUN.
@@ -987,11 +997,10 @@ def _update_node_physical_block_devices(
         # for the user to view but they do not get an entry in the database.
         if block_info["read_only"] or block_info["type"] == "cdrom":
             continue
-        # Skip virtual holder devices (e.g. bcache) reported by LXD's
-        # "used_by" field. These are stacked block devices backed by other
-        # disks already present in this list and are not independent
-        # physical disks.
-        if block_info.get("used_by"):
+        # Skip virtual holder devices (e.g. bcache). These are stacked block
+        # devices backed by other disks already present in this list and are
+        # not independent physical disks.
+        if _is_virtual_bcache_holder(block_info):
             continue
         name = block_info["id"]
         model = block_info.get("model", "")

--- a/src/metadataserver/builtin_scripts/hooks.py
+++ b/src/metadataserver/builtin_scripts/hooks.py
@@ -815,12 +815,13 @@ _DEV_PATH = re.compile(
 
 
 # bcache virtual holder devices are always named "bcacheN" by the kernel
-# (e.g. /dev/bcache0); the name is assigned by the bcache driver itself and
-# isn't user-configurable, unlike e.g. mdadm arrays or LVM volumes. LXD
-# reports them alongside physical disks in the "storage.disks" list, but
-# they are stacked virtual devices backed by other disks that are already
-# present in this same list, so they must not be imported as
-# `PhysicalBlockDevice`s.
+# (e.g. /dev/bcache0). This name comes from the "id" LXD reports for a
+# disk, which is just the /sys/class/block/<name> directory name assigned
+# by the originating kernel driver at registration time. It cannot be
+# overridden by users. LXD reports bcache holders alongside physical
+# disks in the "storage.disks" list, but they are stacked virtual devices
+# backed by other disks that are already present in this same list, so
+# they must not be imported as `PhysicalBlockDevice`s.
 def _is_virtual_bcache_holder(block_info):
     return block_info.get("id", "").startswith("bcache")
 

--- a/src/metadataserver/builtin_scripts/tests/test_hooks.py
+++ b/src/metadataserver/builtin_scripts/tests/test_hooks.py
@@ -3689,6 +3689,19 @@ class TestUpdateNodePhysicalBlockDevices(MAASServerTestCase):
         ]
         self.assertCountEqual([], created_names)
 
+    def test_skips_devices_used_by_virtual_holders(self):
+        node = factory.make_Node()
+        USED_BY_BCACHE = deepcopy(SAMPLE_LXD_RESOURCES)
+        USED_BY_BCACHE["storage"]["disks"][0]["used_by"] = "bcache"
+        _update_node_physical_block_devices(
+            node, USED_BY_BCACHE, create_numa_nodes(node)
+        )
+        created_names = [
+            device.name for device in node.physicalblockdevice_set.all()
+        ]
+        skipped_name = USED_BY_BCACHE["storage"]["disks"][0]["id"]
+        self.assertNotIn(skipped_name, created_names)
+
     def test_handles_renamed_block_device(self):
         node = factory.make_Node()
         _update_node_physical_block_devices(

--- a/src/metadataserver/builtin_scripts/tests/test_hooks.py
+++ b/src/metadataserver/builtin_scripts/tests/test_hooks.py
@@ -3689,18 +3689,33 @@ class TestUpdateNodePhysicalBlockDevices(MAASServerTestCase):
         ]
         self.assertCountEqual([], created_names)
 
-    def test_skips_devices_used_by_virtual_holders(self):
+    def test_skips_bcache_virtual_holder_devices(self):
         node = factory.make_Node()
-        USED_BY_BCACHE = deepcopy(SAMPLE_LXD_RESOURCES)
-        USED_BY_BCACHE["storage"]["disks"][0]["used_by"] = "bcache"
+        WITH_BCACHE = deepcopy(SAMPLE_LXD_RESOURCES)
+        WITH_BCACHE["storage"]["disks"].append(
+            {
+                "id": "bcache0",
+                "device": "251:0",
+                "type": "block",
+                "read_only": False,
+                "mounted": False,
+                "size": 10737410048,
+                "removable": False,
+                "numa_node": 0,
+                "block_size": 512,
+                "rpm": 0,
+                "device_id": "",
+                "partitions": [],
+                "device_fs_uuid": "",
+            }
+        )
         _update_node_physical_block_devices(
-            node, USED_BY_BCACHE, create_numa_nodes(node)
+            node, WITH_BCACHE, create_numa_nodes(node)
         )
         created_names = [
             device.name for device in node.physicalblockdevice_set.all()
         ]
-        skipped_name = USED_BY_BCACHE["storage"]["disks"][0]["id"]
-        self.assertNotIn(skipped_name, created_names)
+        self.assertNotIn("bcache0", created_names)
 
     def test_handles_renamed_block_device(self):
         node = factory.make_Node()


### PR DESCRIPTION
bcache is being interpreted as a physical device when it should not.

~~LXD has a specific extension that can be used to check for usage by any virtual parent devices. It is documented here: https://canonical.com/lxd/docs/default/api-extensions/#resources-disk-used-by~~

~~Note that the fix works in general by checking the presence of something in that key (as documented above). bcache is only an example, even though it was the one that bit us in the test runs.~~

When testing locally (setting up a VM with bcache), the documented field above never came up. According to this comment, https://github.com/canonical/lxd/blob/ee58e024857aa16e73e4b5e88cdbb55a3fbd5165/lxd/resources/storage.go#L196, it makes sense that it would not be populated for bcache (due to the `pathIsDir` check). But then the use of that key is not clear to me.

The only way I see right now to identify this is to rely on the kernel convention for their names, which start with "bcache". This seems a bit flimsy, but I have no better solution, and this seems to be reliable since the naming is handled directly by the kernel and not something that could be user-specified.