### PR TITLE
fix: check for indication of virtual device (#512)

### DIFF
--- a/src/metadataserver/builtin_scripts/hooks.py
+++ b/src/metadataserver/builtin_scripts/hooks.py
@@ -814,6 +814,18 @@ _DEV_PATH = re.compile(
 )
 
 
+# bcache virtual holder devices are always named "bcacheN" by the kernel
+# (e.g. /dev/bcache0). This name comes from the "id" LXD reports for a
+# disk, which is just the /sys/class/block/<name> directory name assigned
+# by the originating kernel driver at registration time. It cannot be
+# overridden by users. LXD reports bcache holders alongside physical
+# disks in the "storage.disks" list, but they are stacked virtual devices
+# backed by other disks that are already present in this same list, so
+# they must not be imported as `PhysicalBlockDevice`s.
+def _is_virtual_bcache_holder(block_info):
+    return block_info.get("id", "").startswith("bcache")
+
+
 def _condense_luns(disks):
     """Condense disks by LUN.
 
@@ -986,6 +998,11 @@ def _update_node_physical_block_devices(
         # Skip the read-only devices or cdroms. We keep them in the output
         # for the user to view but they do not get an entry in the database.
         if block_info["read_only"] or block_info["type"] == "cdrom":
+            continue
+        # Skip virtual holder devices (e.g. bcache). These are stacked block
+        # devices backed by other disks already present in this list and are
+        # not independent physical disks.
+        if _is_virtual_bcache_holder(block_info):
             continue
         name = block_info["id"]
         model = block_info.get("model", "")

--- a/src/metadataserver/builtin_scripts/tests/test_hooks.py
+++ b/src/metadataserver/builtin_scripts/tests/test_hooks.py
@@ -3689,6 +3689,34 @@ class TestUpdateNodePhysicalBlockDevices(MAASServerTestCase):
         ]
         self.assertCountEqual([], created_names)
 
+    def test_skips_bcache_virtual_holder_devices(self):
+        node = factory.make_Node()
+        WITH_BCACHE = deepcopy(SAMPLE_LXD_RESOURCES)
+        WITH_BCACHE["storage"]["disks"].append(
+            {
+                "id": "bcache0",
+                "device": "251:0",
+                "type": "block",
+                "read_only": False,
+                "mounted": False,
+                "size": 10737410048,
+                "removable": False,
+                "numa_node": 0,
+                "block_size": 512,
+                "rpm": 0,
+                "device_id": "",
+                "partitions": [],
+                "device_fs_uuid": "",
+            }
+        )
+        _update_node_physical_block_devices(
+            node, WITH_BCACHE, create_numa_nodes(node)
+        )
+        created_names = [
+            device.name for device in node.physicalblockdevice_set.all()
+        ]
+        self.assertNotIn("bcache0", created_names)
+
     def test_handles_renamed_block_device(self):
         node = factory.make_Node()
         _update_node_physical_block_devices(


### PR DESCRIPTION
bcache is being interpreted as a physical device when it should not.

~~LXD has a specific extension that can be used to check for usage by any virtual parent devices. It is documented here: https://canonical.com/lxd/docs/default/api-extensions/#resources-disk-used-by~~

~~Note that the fix works in general by checking the presence of something in that key (as documented above). bcache is only an example, even though it was the one that bit us in the test runs.~~

When testing locally (setting up a VM with bcache), the documented field above never came up. According to this comment,
https://github.com/canonical/lxd/blob/ee58e024857aa16e73e4b5e88cdbb55a3fbd5165/lxd/resources/storage.go#L196, it makes sense that it would not be populated for bcache (due to the `pathIsDir` check). But then the use of that key is not clear to me.

The only way I see right now to identify this is to rely on the kernel convention for their names, which start with "bcache". This seems a bit flimsy, but I have no better solution, and this seems to be reliable since the naming is handled directly by the kernel and not something that could be user-specified.

(cherry picked from commit 9d021c24297f26b36701144e04e466ee2874ae41)