### PR TITLE
fix: N+1 node queries in dhcp, api and websocket handlers (#439)

### DIFF
--- a/src/maasserver/api/ip_addresses.py
+++ b/src/maasserver/api/ip_addresses.py
@@ -3,7 +3,7 @@
 
 """API handler: `StaticIPAddress`."""
 
-
+from django.db.models import Prefetch
 from django.http import Http404
 from django.http.response import HttpResponseBadRequest, HttpResponseForbidden
 from formencode.validators import StringBool
@@ -403,4 +403,12 @@ class IPAddressesHandler(OperationsHandler):
         if ip is not None:
             query = query.filter(ip=ip)
         query = query.order_by("id")
-        return query
+        # Serializing the interface_set field reads each interface's node
+        # (system_id/resource_uri call get_node()); preload the nodes so
+        # that does not run a query per IP.
+        return query.prefetch_related(
+            Prefetch(
+                "interface_set",
+                queryset=Interface.objects.select_related("node_config__node"),
+            )
+        )

--- a/src/maasserver/api/tests/test_ipaddresses.py
+++ b/src/maasserver/api/tests/test_ipaddresses.py
@@ -7,15 +7,18 @@
 import http.client
 
 from django.conf import settings
+from django.test import RequestFactory
 from django.urls import reverse
 from netaddr import IPAddress
 
+from maasserver.api.ip_addresses import IPAddressesHandler
 from maasserver.enum import INTERFACE_LINK_TYPE, INTERFACE_TYPE, IPADDRESS_TYPE
 from maasserver.models import DNSResource, StaticIPAddress
 from maasserver.testing.api import APITestCase, APITransactionTestCase
 from maasserver.testing.factory import factory
 from maasserver.utils.converters import json_load_bytes
 from maasserver.utils.orm import reload_object, transactional
+from maastesting.djangotestcase import count_queries
 
 
 class TestIPAddressesAPI(APITestCase.ForUserAndAdmin):
@@ -219,6 +222,49 @@ class TestIPAddressesAPI(APITestCase.ForUserAndAdmin):
         ]
         observed = [result["ip"] for result in parsed_result]
         self.assertEqual(expected, observed)
+
+
+class TestIPAddressesReadPrefetch(APITestCase.ForAdmin):
+    def test_read_all_does_not_query_node_per_ip(self):
+        # read() serializes interface_set, whose system_id/resource_uri call
+        # get_node(); without prefetch that runs a query per IP. The node
+        # query count must stay flat as machines are added.
+        subnet = factory.make_Subnet()
+        request = RequestFactory().get("/", {"all": "true"})
+        request.user = self.user
+        handler = IPAddressesHandler()
+
+        def access_nodes():
+            query = handler.read(request)
+            return [
+                iface.get_node()
+                for ip in query
+                for iface in ip.interface_set.all()
+            ]
+
+        def add_machines(count):
+            for _ in range(count):
+                node = factory.make_Node(interface=False)
+                iface = factory.make_Interface(
+                    INTERFACE_TYPE.PHYSICAL, node=node, vlan=subnet.vlan
+                )
+                factory.make_StaticIPAddress(
+                    alloc_type=IPADDRESS_TYPE.AUTO,
+                    subnet=subnet,
+                    interface=iface,
+                )
+
+        add_machines(2)
+        # Warm the permission cache; the first read() call runs one extra
+        # authorization query that later calls serve from the cache.
+        access_nodes()
+        count_2, nodes_2 = count_queries(access_nodes)
+        add_machines(3)
+        count_5, nodes_5 = count_queries(access_nodes)
+        self.assertEqual(2, len(nodes_2))
+        self.assertEqual(5, len(nodes_5))
+        self.assertEqual(2, count_2)
+        self.assertEqual(count_2, count_5)
 
 
 class TestIPAddressesReleaseAPI(APITransactionTestCase.ForUserAndAdmin):

--- a/src/maasserver/dhcp.py
+++ b/src/maasserver/dhcp.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 from typing import Iterable, Optional, Union
 
 from django.conf import settings
-from django.db.models import Q
+from django.db.models import Prefetch, Q
 from netaddr import IPAddress, IPNetwork
 from twisted.internet.defer import inlineCallbacks
 
@@ -30,6 +30,7 @@ from maasserver.models import (
     Config,
     DHCPSnippet,
     Domain,
+    Interface,
     RackController,
     ReservedIP,
     Service,
@@ -340,16 +341,39 @@ def make_hosts_for_subnets(
                 dhcp_snippets.append(make_dhcp_snippet(dhcp_snippet))
         return dhcp_snippets
 
-    sips = StaticIPAddress.objects.filter(
-        alloc_type__in=[
-            IPADDRESS_TYPE.AUTO,
-            IPADDRESS_TYPE.STICKY,
-            IPADDRESS_TYPE.USER_RESERVED,
-        ],
-        subnet__in=subnets,
-        ip__isnull=False,
-        temp_expires_on__isnull=True,
-    ).order_by("id")
+    sips = (
+        StaticIPAddress.objects.filter(
+            alloc_type__in=[
+                IPADDRESS_TYPE.AUTO,
+                IPADDRESS_TYPE.STICKY,
+                IPADDRESS_TYPE.USER_RESERVED,
+            ],
+            subnet__in=subnets,
+            ip__isnull=False,
+            temp_expires_on__isnull=True,
+        )
+        .order_by("id")
+        .prefetch_related(
+            # Prefetch interfaces (+ node and parents used below) to avoid a query
+            # per IP; ordering stays here so the .all() below hits the cache.
+            Prefetch(
+                "interface_set",
+                queryset=Interface.objects.order_by("id")
+                .select_related("node_config__node")
+                .prefetch_related(
+                    # Bond parents become host entries too, and
+                    # make_interface_hostname(parent) reads parent.node_config.node,
+                    # so pull each parent's node in the same query.
+                    Prefetch(
+                        "parents",
+                        queryset=Interface.objects.select_related(
+                            "node_config__node"
+                        ),
+                    )
+                ),
+            ),
+        )
+    )
     hosts = []
     interface_ids = set()
     for sip in sips:
@@ -361,7 +385,7 @@ def make_hosts_for_subnets(
             continue
 
         # Add all interfaces attached to this IP address.
-        for interface in sip.interface_set.order_by("id"):
+        for interface in sip.interface_set.all():
             # Only allow an interface to be in hosts once.
             if interface.id in interface_ids:
                 continue

--- a/src/maasserver/models/fabric.py
+++ b/src/maasserver/models/fabric.py
@@ -8,7 +8,15 @@ from operator import attrgetter
 import re
 
 from django.core.exceptions import PermissionDenied, ValidationError
-from django.db.models import AutoField, CharField, Manager, TextField
+from django.db.models import (
+    AutoField,
+    CharField,
+    Manager,
+    OuterRef,
+    Subquery,
+    TextField,
+)
+from django.db.models.functions import Coalesce
 from django.db.models.query import QuerySet
 
 from maasserver.fields import MODEL_NAME_VALIDATOR
@@ -179,10 +187,28 @@ class Fabric(CleanSave, TimestampedModel):
                 "still present: %s" % (", ".join(descriptions))
             )
         if Interface.objects.filter(vlan__fabric=self).exists():
-            interfaces = Interface.objects.filter(vlan__fabric=self).order_by(
-                "node_config__node", "name"
+            # Avoid duplicating orphan interfaces with multiple parents while
+            # preserving get_node_config()'s first-parent fallback.
+            parent_hostname = (
+                Interface.objects.filter(children=OuterRef("pk"))
+                .order_by("created")
+                .values("node_config__node__hostname")[:1]
             )
-            descriptions = [iface.get_log_string() for iface in interfaces]
+            interface_rows = (
+                Interface.objects.filter(vlan__fabric=self)
+                .annotate(
+                    resolved_hostname=Coalesce(
+                        "node_config__node__hostname",
+                        Subquery(parent_hostname),
+                    )
+                )
+                .order_by("node_config__node", "name")
+                .values_list("name", "type", "resolved_hostname")
+            )
+            descriptions = [
+                f"{name} ({interface_type}) on {hostname or '<unknown-node>'}"
+                for name, interface_type, hostname in interface_rows
+            ]
             raise ValidationError(
                 "Can't delete fabric; the following interfaces are "
                 "still connected: %s" % (", ".join(descriptions))

--- a/src/maasserver/models/tests/test_bmc.py
+++ b/src/maasserver/models/tests/test_bmc.py
@@ -12,6 +12,7 @@ from django.core.exceptions import (
     ValidationError,
 )
 from django.db import IntegrityError
+from django.db.models import Prefetch
 from django.db.models.deletion import ProtectedError
 from django.http import Http404
 import petname
@@ -57,6 +58,7 @@ from maasserver.testing.testcase import (
 from maasserver.utils.orm import reload_object
 from maasserver.utils.threads import deferToDatabase
 from maastesting.crochet import wait_for
+from maastesting.djangotestcase import count_queries
 from provisioningserver.drivers.pod import (
     DiscoveredMachine,
     DiscoveredMachineBlockDevice,
@@ -895,6 +897,30 @@ class PodTestMixin:
 
 
 class TestPod(MAASServerTestCase, PodTestMixin):
+    def test_host_returns_lowest_pk_node(self):
+        # Node has no Meta.ordering; Pod.host must still pick the pk-first node,
+        # matching hints.nodes.first().
+        pod = factory.make_Pod()
+        pod.hints.nodes.add(*[factory.make_Node() for _ in range(3)])
+        self.assertEqual(pod.hints.nodes.order_by("id").first(), pod.host)
+
+    def test_host_reuses_prefetched_nodes(self):
+        # With hints.nodes prefetched, Pod.host must serve from the cache
+        # without querying and still return the pk-first node.
+        pod = factory.make_Pod()
+        pod.hints.nodes.add(*[factory.make_Node() for _ in range(3)])
+        expected = pod.hints.nodes.order_by("id").first()
+        loaded = (
+            Pod.objects.select_related("hints")
+            .prefetch_related(
+                Prefetch("hints__nodes", queryset=Node.objects.order_by("id"))
+            )
+            .get(id=pod.id)
+        )
+        count, host = count_queries(lambda: loaded.host)
+        self.assertEqual(expected, host)
+        self.assertEqual(0, count)
+
     def test_name_project_cluster_uniqueness(self):
         user = factory.make_User()
         cluster = factory.make_VMCluster(pods=0)

--- a/src/maasserver/models/tests/test_fabric.py
+++ b/src/maasserver/models/tests/test_fabric.py
@@ -6,10 +6,12 @@ from django.core.exceptions import PermissionDenied, ValidationError
 
 from maasserver.enum import INTERFACE_TYPE
 from maasserver.models.fabric import Fabric
+from maasserver.models.interface import Interface
 from maasserver.models.vlan import DEFAULT_VID, DEFAULT_VLAN_NAME, VLAN
 from maasserver.permissions import NodePermission
 from maasserver.testing.factory import factory
 from maasserver.testing.testcase import MAASServerTestCase
+from maastesting.djangotestcase import count_queries
 
 
 class TestFabricManagerGetFabricOr404(MAASServerTestCase):
@@ -223,6 +225,135 @@ class TestFabric(MAASServerTestCase):
 
         with self.assertRaisesRegex(ValidationError, msg):
             fabric.delete()
+
+    def _assert_delete_interface_query_count_constant(self, make_interfaces):
+        def attempt_delete(interface_count):
+            fabric = factory.make_Fabric()
+            make_interfaces(fabric, interface_count)
+
+            def do_delete():
+                self.assertRaises(ValidationError, fabric.delete)
+
+            count, _ = count_queries(do_delete)
+            return count
+
+        count_2 = attempt_delete(2)
+        count_4 = attempt_delete(4)
+        self.assertEqual(3, count_2)
+        self.assertEqual(count_2, count_4)
+
+    def _make_orphan_interfaces(self, fabric, interface_count):
+        parent = factory.make_Interface(
+            INTERFACE_TYPE.PHYSICAL, vlan=fabric.get_default_vlan()
+        )
+        interfaces = [
+            factory.make_Interface(
+                INTERFACE_TYPE.VLAN,
+                parents=[parent],
+                vlan=factory.make_VLAN(fabric=fabric),
+            )
+            for _ in range(interface_count)
+        ]
+        # Bypass post-save handling to reproduce orphan interfaces.
+        Interface.objects.filter(
+            id__in=[interface.id for interface in interfaces]
+        ).update(node_config=None)
+        return parent, interfaces
+
+    def test_delete_interface_listing_query_count_is_constant(self):
+        def make_interfaces(fabric, interface_count):
+            for _ in range(interface_count):
+                factory.make_Interface(
+                    INTERFACE_TYPE.PHYSICAL, vlan=fabric.get_default_vlan()
+                )
+
+        self._assert_delete_interface_query_count_constant(make_interfaces)
+
+    def test_delete_interface_listing_query_count_is_constant_for_orphans(
+        self,
+    ):
+        self._assert_delete_interface_query_count_constant(
+            self._make_orphan_interfaces
+        )
+
+    def test_delete_interface_listing_uses_parent_hostname_for_orphan(self):
+        fabric = factory.make_Fabric()
+        parent, interfaces = self._make_orphan_interfaces(fabric, 1)
+
+        error = self.assertRaises(ValidationError, fabric.delete)
+
+        self.assertIn(
+            f"{interfaces[0].name} (vlan) on {parent.get_node().hostname}",
+            error.message,
+        )
+
+    def test_delete_interface_listing_matches_get_node_for_orphan(self):
+        fabric = factory.make_Fabric()
+        oldest_node = factory.make_Node(
+            hostname="oldest-parent", interface=False
+        )
+        newer_node = factory.make_Node(
+            hostname="newer-parent", interface=False
+        )
+        parents = [
+            factory.make_Interface(
+                INTERFACE_TYPE.PHYSICAL,
+                name=name,
+                node=oldest_node,
+                vlan=fabric.get_default_vlan(),
+            )
+            for name in ("eth0", "eth1")
+        ]
+        interface = factory.make_Interface(
+            INTERFACE_TYPE.BOND,
+            name="bond0",
+            parents=list(reversed(parents)),
+            vlan=fabric.get_default_vlan(),
+        )
+        Interface.objects.filter(id=parents[1].id).update(
+            node_config=newer_node.current_config
+        )
+        Interface.objects.filter(id=interface.id).update(node_config=None)
+        orphan = Interface.objects.get(id=interface.id)
+
+        error = self.assertRaises(ValidationError, fabric.delete)
+
+        self.assertEqual("oldest-parent", orphan.get_node().hostname)
+        self.assertEqual(1, error.message.count("bond0 (bond) on "))
+        self.assertIn("bond0 (bond) on oldest-parent", error.message)
+        self.assertNotIn("bond0 (bond) on newer-parent", error.message)
+
+    def test_delete_interface_listing_deduplicates_multi_parent_interface(
+        self,
+    ):
+        fabric = factory.make_Fabric()
+        node = factory.make_Node(interface=False)
+        parents = [
+            factory.make_Interface(
+                INTERFACE_TYPE.PHYSICAL,
+                name=name,
+                node=node,
+                vlan=fabric.get_default_vlan(),
+            )
+            for name in ("eth0", "eth1")
+        ]
+        factory.make_Interface(
+            INTERFACE_TYPE.BOND,
+            name="bond0",
+            node=node,
+            parents=parents,
+            vlan=fabric.get_default_vlan(),
+        )
+
+        error = self.assertRaises(ValidationError, fabric.delete)
+
+        self.assertEqual(
+            "Can't delete fabric; the following interfaces are still "
+            f"connected: bond0 (bond) on {node.hostname}, "
+            f"eth0 (physical) on {node.hostname}, "
+            f"eth1 (physical) on {node.hostname}",
+            error.message,
+        )
 
     def test_cant_delete_fabric_if_connected_to_subnet(self):
         fabric = factory.make_Fabric()

--- a/src/maasserver/models/tests/test_vmcluster.py
+++ b/src/maasserver/models/tests/test_vmcluster.py
@@ -18,6 +18,7 @@ from maasserver.testing.testcase import (
 from maasserver.utils.orm import reload_object
 from maasserver.utils.threads import deferToDatabase
 from maastesting.crochet import wait_for
+from maastesting.djangotestcase import count_queries
 from provisioningserver.testing.certificates import get_sample_cert
 
 wait_for_reactor = wait_for()
@@ -139,6 +140,34 @@ class TestVMClusterManager(MAASServerTestCase):
 
 
 class TestVMCluster(MAASServerTestCase):
+    def test_tracked_virtual_machines_query_count_is_constant(self):
+        # Reading vm.machine while iterating tracked VMs must not query the
+        # machine per VM; the count stays constant as VMs are added.
+        project = factory.make_name("project")
+        cluster = VMCluster.objects.create(
+            name=factory.make_name("name"), project=project
+        )
+        pod = factory.make_Pod(pod_type="lxd", host=None, cluster=cluster)
+
+        def add_vms(count):
+            for _ in range(count):
+                node = factory.make_Node(bmc=pod)
+                factory.make_VirtualMachine(
+                    machine=node, bmc=pod, project=project
+                )
+
+        def read_machines():
+            return [vm.machine for vm in cluster.tracked_virtual_machines()]
+
+        add_vms(2)
+        count_2, machines_2 = count_queries(read_machines)
+        add_vms(3)
+        count_5, machines_5 = count_queries(read_machines)
+        self.assertEqual(2, len(machines_2))
+        self.assertEqual(5, len(machines_5))
+        self.assertEqual(1, count_2)
+        self.assertEqual(count_2, count_5)
+
     def test_hosts(self):
         cluster_name = factory.make_name("name")
         project = factory.make_name("project")

--- a/src/maasserver/models/vmcluster.py
+++ b/src/maasserver/models/vmcluster.py
@@ -202,7 +202,13 @@ class VMCluster(CleanSave, TimestampedModel):
 
     def tracked_virtual_machines(self):
         """VirtualMachines that are part of this project."""
-        return self.virtual_machines().filter(project=self.project)
+        # select_related("machine") so the handler reading vm.machine
+        # (system_id/hostname) does not query the node per VM.
+        return (
+            self.virtual_machines()
+            .filter(project=self.project)
+            .select_related("machine")
+        )
 
     def storage_pools(self):
         from maasserver.models.virtualmachine import get_vm_host_storage_pools

--- a/src/maasserver/tests/test_dhcp.py
+++ b/src/maasserver/tests/test_dhcp.py
@@ -1832,6 +1832,72 @@ class TestMakeSubnetConfig(MAASServerTestCase):
 
 
 class TestMakeHostsForSubnet(MAASServerTestCase):
+    def test_query_count_independent_of_host_count(self):
+        # Host generation must not run a query per allocated IP; the query
+        # count stays constant as more machines are added.
+        subnet = factory.make_Subnet()
+
+        def add_machines(count):
+            for _ in range(count):
+                node = factory.make_Node(interface=False)
+                iface = factory.make_Interface(
+                    INTERFACE_TYPE.PHYSICAL, node=node, vlan=subnet.vlan
+                )
+                factory.make_StaticIPAddress(
+                    alloc_type=IPADDRESS_TYPE.AUTO,
+                    subnet=subnet,
+                    interface=iface,
+                )
+
+        add_machines(2)
+        count_2, hosts_2 = count_queries(dhcp.make_hosts_for_subnets, [subnet])
+        add_machines(3)
+        count_5, hosts_5 = count_queries(dhcp.make_hosts_for_subnets, [subnet])
+        self.assertEqual(2, len(hosts_2))
+        self.assertEqual(5, len(hosts_5))
+        self.assertEqual(4, count_2)
+        self.assertEqual(count_2, count_5)
+
+    def test_query_count_independent_of_bond_parent_count(self):
+        # Bond parents get their own host entries and
+        # make_interface_hostname(parent) reads parent.node_config.node; the
+        # query count must not grow with the number of parents.
+        subnet = factory.make_Subnet()
+
+        def add_bond(parent_count):
+            node = factory.make_Node(interface=False)
+            parents = [
+                factory.make_Interface(
+                    INTERFACE_TYPE.PHYSICAL, node=node, vlan=subnet.vlan
+                )
+                for _ in range(parent_count)
+            ]
+            bond = factory.make_Interface(
+                INTERFACE_TYPE.BOND,
+                node=node,
+                vlan=subnet.vlan,
+                parents=parents,
+            )
+            factory.make_StaticIPAddress(
+                alloc_type=IPADDRESS_TYPE.AUTO,
+                subnet=subnet,
+                interface=bond,
+            )
+
+        add_bond(2)
+        count_small, hosts_small = count_queries(
+            dhcp.make_hosts_for_subnets, [subnet]
+        )
+        add_bond(4)
+        count_large, hosts_large = count_queries(
+            dhcp.make_hosts_for_subnets, [subnet]
+        )
+        # Each bond and its parents get a host entry (factory MACs differ).
+        self.assertEqual(3, len(hosts_small))
+        self.assertEqual(8, len(hosts_large))
+        self.assertEqual(4, count_small)
+        self.assertEqual(count_small, count_large)
+
     def tests__returns_defined_hosts(self):
         rack_controller = factory.make_RackController(interface=False)
         vlan = factory.make_VLAN()

--- a/src/maasserver/websockets/handlers/pod.py
+++ b/src/maasserver/websockets/handlers/pod.py
@@ -7,6 +7,7 @@
 import dataclasses
 
 import attr
+from django.db.models import Prefetch
 from django.http import HttpRequest
 
 from maasserver.clusterrpc.pods import (
@@ -16,6 +17,7 @@ from maasserver.clusterrpc.pods import (
 from maasserver.exceptions import PodProblem
 from maasserver.forms.pods import ComposeMachineForm, PodForm
 from maasserver.models.bmc import Pod
+from maasserver.models.node import Node
 from maasserver.models.resourcepool import ResourcePool
 from maasserver.models.virtualmachine import get_vm_host_resources
 from maasserver.models.zone import Zone
@@ -76,9 +78,15 @@ class PodHandler(TimestampedModelHandler):
 
     def get_queryset(self, for_list=False):
         """Return `QuerySet` for devices only viewable by `user`."""
-        return Pod.objects.get_pods(
-            self.user, PodPermission.view
-        ).select_related("hints")
+        return (
+            Pod.objects.get_pods(self.user, PodPermission.view)
+            .select_related("hints")
+            .prefetch_related(
+                # Order the prefetch so Pod.host picks the same node .first()
+                # would (Node has no ordering) while reusing this cache.
+                Prefetch("hints__nodes", queryset=Node.objects.order_by("id"))
+            )
+        )
 
     def preprocess_form(self, action, params):
         """Process the `params` before passing the data to the form."""

--- a/src/maasserver/websockets/handlers/tests/test_pod.py
+++ b/src/maasserver/websockets/handlers/tests/test_pod.py
@@ -26,6 +26,7 @@ from maasserver.websockets.base import DATETIME_FORMAT
 from maasserver.websockets.handlers import pod as pod_module
 from maasserver.websockets.handlers.pod import ComposeMachineForm, PodHandler
 from maastesting.crochet import wait_for
+from maastesting.djangotestcase import count_queries
 from provisioningserver.drivers.pod import (
     Capabilities,
     DiscoveredPod,
@@ -638,6 +639,28 @@ class TestPodHandler(MAASTransactionServerTestCase):
         expected_data = [handler.full_dehydrate(pod, for_list=True)]
         result = handler.list({"id": pod.id})
         self.assertEqual(expected_data, result)
+
+    def test_list_queryset_prefetches_host_node(self):
+        # dehydrate reads pod.host.system_id per pod in the list; get_queryset
+        # must prefetch hints__nodes so that access is served from the cache
+        # rather than querying the node per pod.
+        admin = factory.make_admin()
+        handler = PodHandler(admin, {}, None)
+        hosts = []
+        for _ in range(3):
+            node = factory.make_Node()
+            self.make_pod_with_hints(host=node)
+            hosts.append(node)
+
+        pods = list(handler.get_queryset(for_list=True))
+        self.assertEqual(len(hosts), len(pods))
+
+        def read_hosts():
+            return [pod.host.system_id if pod.host else None for pod in pods]
+
+        count, system_ids = count_queries(read_hosts)
+        self.assertEqual(0, count)
+        self.assertCountEqual([node.system_id for node in hosts], system_ids)
 
     def test_full_dehydrate_for_list_no_details(self):
         admin = factory.make_admin()


### PR DESCRIPTION
Backport #439 to MAAS 3.6.

Resolves LP:2161952

(cherry picked from commit 0d716782d579342ad4faaad401894d3f5ff782e9)