### PR TITLE
fix: normalize overflow in systemd_interval_to_calendar

### DIFF
--- a/src/maasserver/utils/converters.py
+++ b/src/maasserver/utils/converters.py
@@ -131,10 +131,24 @@ def systemd_interval_to_calendar(interval):
     if not duration.group():
         raise ValueError("value is not a valid interval")
     duration = duration.groupdict()
-    hours = duration.get("hours")
-    minutes = duration.get("minutes")
-    seconds = duration.get("seconds")
-    hour_interval = f"00/{hours}" if hours and hours != "1" else "*"
+    hours = int(duration.get("hours") or 0)
+    minutes = int(duration.get("minutes") or 0)
+    seconds = int(duration.get("seconds") or 0)
+
+    # Normalise overflowing values, otherwise the generated calendar
+    # specification is invalid (systemd minutes/seconds only go up to 59,
+    # hours up to 23). For example, "120 minutes" must become "00/2"
+    # hours. See LP:2077276.
+    minutes, seconds = divmod(minutes * 60 + seconds, 60)
+    hours, minutes = divmod(hours * 60 + minutes, 60)
+    days, hours = divmod(hours, 24)
+    if days > 31:
+        raise ValueError("interval is too large to be expressed as a calendar event")
+
+    day_interval = f"01/{days}" if days and days != 1 else "*"
+    hour_interval = (
+        f"00/{hours}" if hours and hours != 1 else "00" if days else "*"
+    )
     second_interval = f"00/{seconds}" if seconds else "00"
     minute_interval = (
         f"00/{minutes}"
@@ -144,4 +158,4 @@ def systemd_interval_to_calendar(interval):
         else "*"
     )
 
-    return f"*-*-* {hour_interval}:{minute_interval}:{second_interval}"
+    return f"*-*-{day_interval} {hour_interval}:{minute_interval}:{second_interval}"

--- a/src/maasserver/utils/tests/test_converters.py
+++ b/src/maasserver/utils/tests/test_converters.py
@@ -128,8 +128,7 @@ class TestSystemdIntervalToCalendar(MAASTestCase):
         )
 
     def test_minutes_overflow_is_converted_to_hours(self):
-        # Regression test for LP:2077276 - intervals above 59 minutes must
-        # not generate invalid systemd calendar specifications.
+        # LP:2077276 - intervals above 59 minutes must not generate invalid systemd calendar specifications.
         self.assertEqual(
             "*-*-* 00/2:00:00", systemd_interval_to_calendar("120m")
         )

--- a/src/maasserver/utils/tests/test_converters.py
+++ b/src/maasserver/utils/tests/test_converters.py
@@ -127,6 +127,41 @@ class TestSystemdIntervalToCalendar(MAASTestCase):
             "*-*-* *:00/30:00/5", systemd_interval_to_calendar(interval)
         )
 
+    def test_minutes_overflow_is_converted_to_hours(self):
+        # Regression test for LP:2077276 - intervals above 59 minutes must
+        # not generate invalid systemd calendar specifications.
+        self.assertEqual(
+            "*-*-* 00/2:00:00", systemd_interval_to_calendar("120m")
+        )
+        self.assertEqual(
+            "*-*-* *:00:00", systemd_interval_to_calendar("60m")
+        )
+        self.assertEqual(
+            "*-*-* *:00/10:00", systemd_interval_to_calendar("70m")
+        )
+
+    def test_hours_overflow_is_converted_to_days(self):
+        # 6000 minutes = 100 hours = 4 days + 4 hours.
+        self.assertEqual(
+            "*-*-01/4 00/4:00:00", systemd_interval_to_calendar("6000m")
+        )
+        self.assertEqual(
+            "*-*-01/2 00:00:00", systemd_interval_to_calendar("48h")
+        )
+        self.assertEqual(
+            "*-*-* 00:00:00", systemd_interval_to_calendar("24h")
+        )
+
+    def test_too_large_interval_raises_error(self):
+        self.assertRaises(
+            ValueError, systemd_interval_to_calendar, "768h"  # 32 days
+        )
+
+    def test_seconds_overflow_is_converted_to_minutes(self):
+        self.assertEqual(
+            "*-*-* *:00/1:00/30", systemd_interval_to_calendar("90s")
+        )
+
     def test_every_15_seconds(self):
         interval = "15s"
         self.assertEqual(


### PR DESCRIPTION
Intervals above 59 minutes invalid systemd calendar specifications. For example, `120m` generates `*-*-* *:00/120:00` which is invalid. This commit normalizes the input to a valid systemd format.

Fixes LP:2077276